### PR TITLE
Add delete functionality for logs

### DIFF
--- a/src/components/farm-details/ActivityFeed.tsx
+++ b/src/components/farm-details/ActivityFeed.tsx
@@ -14,6 +14,7 @@ import {
   Clock,
   CheckCircle,
   Edit,
+  Trash2,
   ArrowRight
 } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -24,6 +25,7 @@ interface ActivityFeedProps {
   loading: boolean;
   onCompleteTask: (taskId: number) => Promise<void>;
   onEditRecord: (record: any, recordType: string) => void;
+  onDeleteRecord: (record: any, recordType: string) => void;
   farmId?: string;
 }
 
@@ -33,6 +35,7 @@ export function ActivityFeed({
   loading,
   onCompleteTask,
   onEditRecord,
+  onDeleteRecord,
   farmId
 }: ActivityFeedProps) {
   const router = useRouter();
@@ -195,16 +198,26 @@ export function ActivityFeed({
                       </div>
                     </div>
                     
-                    <div className="flex items-center h-full">
+                    <div className="flex items-center gap-1 h-full">
                       {(activity.type === 'irrigation' || activity.type === 'spray' || activity.type === 'harvest' || activity.type === 'fertigation' || activity.type === 'expense' || activity.type === 'soil_test') && (
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => onEditRecord(activity, activity.type)}
-                          className="h-6 w-6 p-0 text-green-600 hover:text-green-800 hover:bg-green-100 flex-shrink-0"
-                        >
-                          <Edit className="h-3 w-3" />
-                        </Button>
+                        <>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => onEditRecord(activity, activity.type)}
+                            className="h-6 w-6 p-0 text-green-600 hover:text-green-800 hover:bg-green-100 flex-shrink-0"
+                          >
+                            <Edit className="h-3 w-3" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => onDeleteRecord(activity, activity.type)}
+                            className="h-6 w-6 p-0 text-red-600 hover:text-red-800 hover:bg-red-100 flex-shrink-0"
+                          >
+                            <Trash2 className="h-3 w-3" />
+                          </Button>
+                        </>
                       )}
                     </div>
                   </div>

--- a/src/lib/supabase-service.ts
+++ b/src/lib/supabase-service.ts
@@ -266,6 +266,16 @@ export class SupabaseService {
     return toApplicationFertigationRecord(data);
   }
 
+  static async deleteFertigationRecord(id: number): Promise<void> {
+    const supabase = getTypedSupabaseClient();
+    const { error } = await supabase
+      .from('fertigation_records')
+      .delete()
+      .eq('id', id);
+
+    if (error) throw error;
+  }
+
   // Harvest operations
   static async getHarvestRecords(farmId: number): Promise<HarvestRecord[]> {
     const supabase = getTypedSupabaseClient();
@@ -358,6 +368,16 @@ export class SupabaseService {
 
     if (error) throw error;
     return toApplicationExpenseRecord(data);
+  }
+
+  static async deleteExpenseRecord(id: number): Promise<void> {
+    const supabase = getTypedSupabaseClient();
+    const { error } = await supabase
+      .from('expense_records')
+      .delete()
+      .eq('id', id);
+
+    if (error) throw error;
   }
 
   // Calculation history operations
@@ -485,6 +505,16 @@ export class SupabaseService {
 
     if (error) throw error;
     return toApplicationSoilTestRecord(data);
+  }
+
+  static async deleteSoilTestRecord(id: number): Promise<void> {
+    const supabase = getTypedSupabaseClient();
+    const { error } = await supabase
+      .from('soil_test_records')
+      .delete()
+      .eq('id', id);
+
+    if (error) throw error;
   }
 
   // Export data functions


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Delete activity logs directly from the Activity Feed and Logs pages for irrigation, spray, harvest, fertigation, expense, and soil tests.
  * Added a Delete (trash) action next to Edit for eligible records.
  * Introduced a confirmation dialog showing the log type and date, with clear destructive styling.
  * Deletion shows progress, disables actions, and refreshes the list automatically after completion.
  * Minor layout adjustments for cleaner action spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->