### PR TITLE
Fix soil test reminder reappearing after close

### DIFF
--- a/src/app/farms/[id]/page.tsx
+++ b/src/app/farms/[id]/page.tsx
@@ -1399,24 +1399,36 @@ export default function FarmDetailsPage() {
           onAddFarm={handleAddFarm}
         />
 
-        <main className="relative z-10 mx-auto max-w-6xl px-4 pb-16 pt-6 sm:px-6 lg:px-8">
-          <div className="space-y-6">
+        <main className="relative z-10 mx-auto max-w-7xl px-4 pb-16 pt-6 sm:px-6 lg:px-8">
+          {/* Quick Actions Section */}
+          <div className="mb-6">
             <QuickActions />
-            <TestReminderNotification farmId={Number.parseInt(farmId, 10)} />
-            <TasksOverviewCard
-              farmId={Number.parseInt(farmId, 10)}
-              tasks={dashboardData?.pendingTasks || []}
-              farmName={farm?.name ? capitalize(farm.name) : undefined}
-              loading={loading}
-              onTasksUpdated={loadDashboardData}
-            />
-            <ActivityFeed
-              recentActivities={dashboardData?.recentActivities || []}
-              loading={loading}
-              onEditDateGroup={handleEditDateGroup}
-              onDeleteDateGroup={handleDeleteDateGroup}
-              farmId={farmId}
-            />
+          </div>
+
+          {/* Main Content Grid */}
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+            {/* Left Column - Tasks & Reminders (1/3 width on desktop) */}
+            <div className="space-y-6 lg:col-span-1">
+              <TestReminderNotification farmId={Number.parseInt(farmId, 10)} compact />
+              <TasksOverviewCard
+                farmId={Number.parseInt(farmId, 10)}
+                tasks={dashboardData?.pendingTasks || []}
+                farmName={farm?.name ? capitalize(farm.name) : undefined}
+                loading={loading}
+                onTasksUpdated={loadDashboardData}
+              />
+            </div>
+
+            {/* Right Column - Activity Feed (2/3 width on desktop) */}
+            <div className="lg:col-span-2">
+              <ActivityFeed
+                recentActivities={dashboardData?.recentActivities || []}
+                loading={loading}
+                onEditDateGroup={handleEditDateGroup}
+                onDeleteDateGroup={handleDeleteDateGroup}
+                farmId={farmId}
+              />
+            </div>
           </div>
         </main>
 

--- a/src/components/lab-tests/TestReminderNotification.tsx
+++ b/src/components/lab-tests/TestReminderNotification.tsx
@@ -83,7 +83,7 @@ export function TestReminderNotification({
       const description =
         testType === 'soil'
           ? 'It has been over 2 years since the last soil test. Schedule a new soil test to check pH, EC, and nutrient levels for optimal fertilizer planning.'
-          : 'It has been over 3 months since the last petiole test. Conduct a petiole test during active growth to monitor plant nutrient uptake and adjust fertigation.'
+          : 'It has been over 30 days since the last petiole test. Conduct a petiole test during active growth to monitor plant nutrient uptake and adjust fertigation.'
 
       await SupabaseService.addTaskReminder({
         farmId,
@@ -154,7 +154,7 @@ export function TestReminderNotification({
                     <strong className="text-foreground">Petiole test:</strong> Last test was{' '}
                     {reminders.petioleTestAge
                       ? `${reminders.petioleTestAge} days ago`
-                      : 'over 3 months ago'}
+                      : 'over 30 days ago'}
                     .
                   </>
                 )}
@@ -272,7 +272,7 @@ export function TestReminderNotification({
                       {reminders.petioleTestAge} days ago
                     </span>
                   ) : (
-                    <span className="font-semibold text-primary">3+ months ago</span>
+                    <span className="font-semibold text-primary">30+ days ago</span>
                   )}
                 </p>
               </div>

--- a/src/lib/lab-test-integration.ts
+++ b/src/lib/lab-test-integration.ts
@@ -83,7 +83,7 @@ export async function checkTestReminders(farmId: number): Promise<{
   petioleTestAge?: number
 }> {
   const SOIL_TEST_INTERVAL_DAYS = 730 // 2 years
-  const PETIOLE_TEST_INTERVAL_DAYS = 90 // 3 months
+  const PETIOLE_TEST_INTERVAL_DAYS = 30 // 30 days
 
   const [latestSoil, latestPetiole] = await Promise.all([
     getLatestSoilTest(farmId),


### PR DESCRIPTION
- Store dismissed state in localStorage per farm and test type
- Separate tracking for soil and petiole test dismissals
- Reminders no longer reappear after being closed
- Dismissal persists across page refreshes and navigation





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist dismissal of soil and petiole test reminders per farm so they don’t reappear after closing. Updated the farm details page with a responsive two-column grid, a compact reminder card, and a 30-day petiole test interval.

- **Bug Fixes**
  - Store dismissed state in localStorage per farm and test type.
  - Respect dismissed state and existing tasks when deciding to show reminders.

- **New Features**
  - Auto-map nitrate and ammonium nitrogen variants (NO3-N, NH4-N, ammonium) to the correct fields.
  - Set petiole test reminder interval to 30 days and update UI text.

<sup>Written for commit 485248109e14bfae22117494763109baa370e47a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reorganized the farm details page from a single-column to a three-column grid for clearer content grouping and improved spacing.

* **Bug Fixes / Behavior**
  * Reminders for petiole tests now use a 30‑day threshold (previously longer), and on-screen copy updated to reflect "30+ days ago" to match the new cadence.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->