### PR TITLE
Add soil type classification

### DIFF
--- a/src/components/farm-details/forms/FarmModal.tsx
+++ b/src/components/farm-details/forms/FarmModal.tsx
@@ -694,16 +694,17 @@ export function FarmModal({
                 <div>
                   <Label htmlFor="soilTextureClass" className="text-sm font-medium text-gray-700">
                     Soil Texture Class{' '}
-                    {calculatedSoilTexture ? '(auto-calculated)' : '(from sand/silt/clay %)'}
+                    {calculatedSoilTexture
+                      ? '(auto-calculated)'
+                      : formData.soilTextureClass
+                        ? '(saved)'
+                        : ''}
                   </Label>
                   <Input
                     id="soilTextureClass"
                     type="text"
-                    value={
-                      calculatedSoilTexture ||
-                      formData.soilTextureClass ||
-                      'Enter sand/silt/clay percentages'
-                    }
+                    value={calculatedSoilTexture || formData.soilTextureClass || ''}
+                    placeholder="Enter sand/silt/clay percentages"
                     readOnly
                     className="mt-1 h-11 w-full bg-muted"
                   />

--- a/src/components/farm-details/forms/FarmModal.tsx
+++ b/src/components/farm-details/forms/FarmModal.tsx
@@ -254,6 +254,15 @@ export function FarmModal({
     )
   }, [formData.sandPercentage, formData.siltPercentage, formData.clayPercentage])
 
+  // Determine if the original farm had percentage data (to handle edit scenario correctly)
+  const hadOriginalPercentages =
+    editingFarm?.sandPercentage !== undefined &&
+    editingFarm?.sandPercentage !== null &&
+    editingFarm?.siltPercentage !== undefined &&
+    editingFarm?.siltPercentage !== null &&
+    editingFarm?.clayPercentage !== undefined &&
+    editingFarm?.clayPercentage !== null
+
   useEffect(() => {
     if (soilCompositionSum === null) {
       setSoilCompositionWarning(null)
@@ -343,7 +352,10 @@ export function FarmModal({
       bulkDensity: safeParseNumber(formData.bulkDensity),
       cationExchangeCapacity: safeParseNumber(formData.cationExchangeCapacity),
       soilWaterRetention: safeParseNumber(formData.soilWaterRetention),
-      soilTextureClass: calculatedSoilTexture || formData.soilTextureClass.trim() || undefined,
+      soilTextureClass:
+        calculatedSoilTexture ||
+        // Preserve existing manual classification only if farm never had percentage data
+        (!hadOriginalPercentages ? formData.soilTextureClass.trim() || undefined : undefined),
       sandPercentage: safeParseNumber(formData.sandPercentage),
       siltPercentage: safeParseNumber(formData.siltPercentage),
       clayPercentage: safeParseNumber(formData.clayPercentage),

--- a/src/components/farm-details/forms/FarmModal.tsx
+++ b/src/components/farm-details/forms/FarmModal.tsx
@@ -21,6 +21,7 @@ import {
   SelectValue
 } from '@/components/ui/select'
 import { getAllCrops, getVarietiesForCrop, getDefaultVariety } from '@/lib/crop-data'
+import { getSoilTextureClass } from '@/lib/soil-texture'
 import type { LocationResult } from '@/lib/open-meteo-geocoding'
 import type { Farm } from '@/types/types'
 
@@ -243,6 +244,14 @@ export function FarmModal({
       return null
     }
     return sand + silt + clay
+  }, [formData.sandPercentage, formData.siltPercentage, formData.clayPercentage])
+
+  const calculatedSoilTexture = useMemo(() => {
+    return getSoilTextureClass(
+      formData.sandPercentage,
+      formData.siltPercentage,
+      formData.clayPercentage
+    )
   }, [formData.sandPercentage, formData.siltPercentage, formData.clayPercentage])
 
   useEffect(() => {
@@ -726,17 +735,27 @@ export function FarmModal({
                   <Label htmlFor="clayPercentage" className="text-sm font-medium text-gray-700">
                     Clay (%)
                   </Label>
-                  <Input
-                    id="clayPercentage"
-                    type="number"
-                    step="0.01"
-                    min="0"
-                    max="100"
-                    value={formData.clayPercentage}
-                    onChange={(e) => handleInputChange('clayPercentage', e.target.value)}
-                    placeholder="45.5"
-                    className="mt-1 h-11"
-                  />
+                  <div className="flex items-center gap-2 mt-1">
+                    <Input
+                      id="clayPercentage"
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      max="100"
+                      value={formData.clayPercentage}
+                      onChange={(e) => handleInputChange('clayPercentage', e.target.value)}
+                      placeholder="45.5"
+                      className="h-11 flex-1"
+                    />
+                    {calculatedSoilTexture && (
+                      <div className="px-3 py-2 bg-accent/10 border border-accent/30 rounded-md min-w-[140px]">
+                        <span className="text-xs text-gray-500 block">Soil Type</span>
+                        <span className="text-sm font-medium text-accent-foreground">
+                          {calculatedSoilTexture}
+                        </span>
+                      </div>
+                    )}
+                  </div>
                   {soilCompositionWarning && (
                     <p className="text-xs text-amber-600 mt-1">{soilCompositionWarning}</p>
                   )}

--- a/src/components/farm-details/forms/FarmModal.tsx
+++ b/src/components/farm-details/forms/FarmModal.tsx
@@ -343,7 +343,7 @@ export function FarmModal({
       bulkDensity: safeParseNumber(formData.bulkDensity),
       cationExchangeCapacity: safeParseNumber(formData.cationExchangeCapacity),
       soilWaterRetention: safeParseNumber(formData.soilWaterRetention),
-      soilTextureClass: formData.soilTextureClass.trim() || undefined,
+      soilTextureClass: calculatedSoilTexture || formData.soilTextureClass.trim() || undefined,
       sandPercentage: safeParseNumber(formData.sandPercentage),
       siltPercentage: safeParseNumber(formData.siltPercentage),
       clayPercentage: safeParseNumber(formData.clayPercentage),
@@ -681,23 +681,15 @@ export function FarmModal({
                 </div>
                 <div>
                   <Label htmlFor="soilTextureClass" className="text-sm font-medium text-gray-700">
-                    Soil Texture Class
+                    Soil Texture Class (auto-calculated)
                   </Label>
-                  <Select
-                    value={formData.soilTextureClass}
-                    onValueChange={(value) => handleInputChange('soilTextureClass', value)}
-                  >
-                    <SelectTrigger id="soilTextureClass" className="mt-1 !h-11 w-full">
-                      <SelectValue placeholder="Select texture class" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {SOIL_TEXTURE_OPTIONS.map((texture) => (
-                        <SelectItem key={texture} value={texture}>
-                          {texture}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <Input
+                    id="soilTextureClass"
+                    type="text"
+                    value={calculatedSoilTexture || 'Enter sand/silt/clay percentages'}
+                    readOnly
+                    className="mt-1 h-11 w-full bg-muted"
+                  />
                 </div>
                 <div>
                   <Label htmlFor="sandPercentage" className="text-sm font-medium text-gray-700">
@@ -735,27 +727,17 @@ export function FarmModal({
                   <Label htmlFor="clayPercentage" className="text-sm font-medium text-gray-700">
                     Clay (%)
                   </Label>
-                  <div className="flex items-center gap-2 mt-1">
-                    <Input
-                      id="clayPercentage"
-                      type="number"
-                      step="0.01"
-                      min="0"
-                      max="100"
-                      value={formData.clayPercentage}
-                      onChange={(e) => handleInputChange('clayPercentage', e.target.value)}
-                      placeholder="45.5"
-                      className="h-11 flex-1"
-                    />
-                    {calculatedSoilTexture && (
-                      <div className="px-3 py-2 bg-accent/10 border border-accent/30 rounded-md min-w-[140px]">
-                        <span className="text-xs text-gray-500 block">Soil Type</span>
-                        <span className="text-sm font-medium text-accent-foreground">
-                          {calculatedSoilTexture}
-                        </span>
-                      </div>
-                    )}
-                  </div>
+                  <Input
+                    id="clayPercentage"
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    max="100"
+                    value={formData.clayPercentage}
+                    onChange={(e) => handleInputChange('clayPercentage', e.target.value)}
+                    placeholder="45.5"
+                    className="mt-1 h-11"
+                  />
                   {soilCompositionWarning && (
                     <p className="text-xs text-amber-600 mt-1">{soilCompositionWarning}</p>
                   )}

--- a/src/components/farm-details/forms/FarmModal.tsx
+++ b/src/components/farm-details/forms/FarmModal.tsx
@@ -681,12 +681,17 @@ export function FarmModal({
                 </div>
                 <div>
                   <Label htmlFor="soilTextureClass" className="text-sm font-medium text-gray-700">
-                    Soil Texture Class (auto-calculated)
+                    Soil Texture Class{' '}
+                    {calculatedSoilTexture ? '(auto-calculated)' : '(from sand/silt/clay %)'}
                   </Label>
                   <Input
                     id="soilTextureClass"
                     type="text"
-                    value={calculatedSoilTexture || 'Enter sand/silt/clay percentages'}
+                    value={
+                      calculatedSoilTexture ||
+                      formData.soilTextureClass ||
+                      'Enter sand/silt/clay percentages'
+                    }
                     readOnly
                     className="mt-1 h-11 w-full bg-muted"
                   />

--- a/src/lib/soil-texture.ts
+++ b/src/lib/soil-texture.ts
@@ -91,17 +91,17 @@ export function getSoilTextureClass(
   }
 
   // 3. Sandy loam
-  if (s >= 43 && s < 85 && c < 20) {
+  if (s >= 43 && s < 85 && c <= 20) {
     return 'Sandy loam'
   }
 
   // 4. Loam
-  if (s >= 25 && s <= 50 && si >= 28 && si <= 50 && c >= 7 && c <= 27) {
+  if (s >= 25 && s < 52 && si >= 28 && si <= 50 && c >= 7 && c <= 27) {
     return 'Loam'
   }
 
   // 5. Silt loam
-  if (si >= 50 && c >= 12 && c < 27 && s < 50) {
+  if (si >= 50 && c >= 12 && c <= 27 && s < 50) {
     return 'Silt loam'
   }
 

--- a/src/lib/soil-texture.ts
+++ b/src/lib/soil-texture.ts
@@ -8,7 +8,7 @@
  * 2. Loamy sand: sand 70-85%, clay <= 15%, silt + 2*clay <= 30%
  * 3. Sandy loam: sand 43-85%, clay <= 20%
  * 4. Loam: clay 7-27%, sand 25-52%, silt 28-50%
- * 5. Silt loam: silt >= 50%, clay 12-27%, sand < 50%
+ * 5. Silt loam: silt >= 50%, clay 0-27%, sand < 50%
  * 6. Silt: silt >= 80%
  * 7. Sandy clay loam: clay 20-35%, sand >= 45%
  * 8. Clay loam: clay 27-40%, sand 20-45%
@@ -101,7 +101,7 @@ export function getSoilTextureClass(
   }
 
   // 5. Silt loam
-  if (si >= 50 && c >= 12 && c <= 27 && s < 50) {
+  if (si >= 50 && c <= 27 && s < 50) {
     return 'Silt loam'
   }
 
@@ -325,5 +325,5 @@ export function getSoilTextureDescription(texture: SoilTextureClass): SoilTextur
     }
   }
 
-  return descriptions[texture] || descriptions.Loam
+  return descriptions[texture]
 }

--- a/src/lib/soil-texture.ts
+++ b/src/lib/soil-texture.ts
@@ -91,17 +91,17 @@ export function getSoilTextureClass(
   }
 
   // 3. Sandy loam
-  if (s >= 43 && s < 85 && c <= 20) {
+  if (s >= 43 && s < 85 && c < 20) {
     return 'Sandy loam'
   }
 
   // 4. Loam
-  if (s >= 25 && s < 52 && si >= 28 && si <= 50 && c >= 7 && c <= 27) {
+  if (s >= 25 && s <= 50 && si >= 28 && si <= 50 && c >= 7 && c <= 27) {
     return 'Loam'
   }
 
   // 5. Silt loam
-  if (si >= 50 && c >= 12 && c <= 27 && s < 50) {
+  if (si >= 50 && c >= 12 && c < 27 && s < 50) {
     return 'Silt loam'
   }
 

--- a/src/lib/soil-texture.ts
+++ b/src/lib/soil-texture.ts
@@ -158,7 +158,7 @@ function findClosestSoilTexture(sand: number, silt: number, clay: number): SoilT
     { name: 'Loam', sand: 40, silt: 40, clay: 20 },
     { name: 'Silt loam', sand: 20, silt: 60, clay: 20 },
     { name: 'Silt', sand: 10, silt: 80, clay: 10 },
-    { name: 'Sandy clay loam', sand: 60, silt: 15, clay: 25 },
+    { name: 'Sandy clay loam', sand: 55, silt: 18, clay: 27 },
     { name: 'Clay loam', sand: 32, silt: 38, clay: 30 },
     { name: 'Silty clay loam', sand: 10, silt: 55, clay: 35 },
     { name: 'Sandy clay', sand: 50, silt: 10, clay: 40 },
@@ -166,16 +166,13 @@ function findClosestSoilTexture(sand: number, silt: number, clay: number): SoilT
     { name: 'Clay', sand: 20, silt: 20, clay: 60 }
   ]
 
-  // Find the closest match using Euclidean distance
+  // Find the closest match using 2D Euclidean distance in sand-clay space
+  // Since silt = 100 - sand - clay, using 2 dimensions is geometrically correct
   let closestTexture: SoilTextureClass | null = null
   let minDistance = Infinity
 
   for (const texture of textureClasses) {
-    const distance = Math.sqrt(
-      Math.pow(sand - texture.sand, 2) +
-        Math.pow(silt - texture.silt, 2) +
-        Math.pow(clay - texture.clay, 2)
-    )
+    const distance = Math.sqrt(Math.pow(sand - texture.sand, 2) + Math.pow(clay - texture.clay, 2))
     if (distance < minDistance) {
       minDistance = distance
       closestTexture = texture.name

--- a/src/lib/soil-texture.ts
+++ b/src/lib/soil-texture.ts
@@ -85,7 +85,8 @@ export function getSoilTextureClass(
   }
 
   // 2. Loamy sand
-  if (s >= 70 && s < 85 && c <= 15) {
+  // USDA boundary: silt + 2*clay <= 30 (diagonal boundary with Sandy loam)
+  if (s >= 70 && s < 85 && c <= 15 && si + 2 * c <= 30) {
     return 'Loamy sand'
   }
 

--- a/src/lib/soil-texture.ts
+++ b/src/lib/soil-texture.ts
@@ -5,7 +5,7 @@
  * Classification rules based on USDA textural triangle:
  *
  * 1. Sand: sand >= 85%
- * 2. Loamy sand: sand 70-85%
+ * 2. Loamy sand: sand 70-85%, clay <= 15%, silt + 2*clay <= 30%
  * 3. Sandy loam: sand 43-85%, clay <= 20%
  * 4. Loam: clay 7-27%, sand 25-52%, silt 28-50%
  * 5. Silt loam: silt >= 50%, clay 12-27%, sand < 50%
@@ -182,15 +182,17 @@ function findClosestSoilTexture(sand: number, silt: number, clay: number): SoilT
   return closestTexture
 }
 
-/**
- * Get a description of the soil texture class properties
- */
-export function getSoilTextureDescription(texture: SoilTextureClass): {
+interface SoilTextureInfo {
   description: string
   characteristics: string[]
   suitability: string
-} {
-  const descriptions: Record<SoilTextureClass, any> = {
+}
+
+/**
+ * Get a description of the soil texture class properties
+ */
+export function getSoilTextureDescription(texture: SoilTextureClass): SoilTextureInfo {
+  const descriptions: Record<SoilTextureClass, SoilTextureInfo> = {
     Sand: {
       description: 'Coarse-textured soil with large particles',
       characteristics: [

--- a/src/lib/soil-texture.ts
+++ b/src/lib/soil-texture.ts
@@ -1,0 +1,329 @@
+/**
+ * Determine soil texture class based on USDA soil texture triangle
+ * using the percentages of sand, silt, and clay.
+ *
+ * Classification rules based on USDA textural triangle:
+ *
+ * 1. Sand: sand >= 85%
+ * 2. Loamy sand: sand 70-85%
+ * 3. Sandy loam: sand 43-85%, clay <= 20%
+ * 4. Loam: clay 7-27%, sand 25-52%, silt 28-50%
+ * 5. Silt loam: silt >= 50%, clay 12-27%, sand < 50%
+ * 6. Silt: silt >= 80%
+ * 7. Sandy clay loam: clay 20-35%, sand >= 45%
+ * 8. Clay loam: clay 27-40%, sand 20-45%
+ * 9. Silty clay loam: clay 27-40%, sand < 20%
+ * 10. Sandy clay: clay >= 35%, sand >= 45%
+ * 11. Silty clay: clay >= 40%, silt >= 40%
+ * 12. Clay: clay >= 40%, sand < 45%, silt < 40%
+ *
+ * @param sand - Percentage of sand (0-100)
+ * @param silt - Percentage of silt (0-100)
+ * @param clay - Percentage of clay (0-100)
+ * @returns The soil texture class name or null if inputs are invalid
+ */
+
+export type SoilTextureClass =
+  | 'Sand'
+  | 'Loamy sand'
+  | 'Sandy loam'
+  | 'Loam'
+  | 'Silt loam'
+  | 'Silt'
+  | 'Sandy clay loam'
+  | 'Clay loam'
+  | 'Silty clay loam'
+  | 'Sandy clay'
+  | 'Silty clay'
+  | 'Clay'
+
+export function getSoilTextureClass(
+  sand: number | string | undefined,
+  silt: number | string | undefined,
+  clay: number | string | undefined
+): SoilTextureClass | null {
+  // Parse input values
+  const sandNum = typeof sand === 'string' ? parseFloat(sand) : sand
+  const siltNum = typeof silt === 'string' ? parseFloat(silt) : silt
+  const clayNum = typeof clay === 'string' ? parseFloat(clay) : clay
+
+  // Validate inputs
+  if (
+    sandNum === undefined ||
+    siltNum === undefined ||
+    clayNum === undefined ||
+    isNaN(sandNum) ||
+    isNaN(siltNum) ||
+    isNaN(clayNum) ||
+    sandNum < 0 ||
+    siltNum < 0 ||
+    clayNum < 0
+  ) {
+    return null
+  }
+
+  // Check if values sum to approximately 100%
+  const sum = sandNum + siltNum + clayNum
+  if (sum < 95 || sum > 105) {
+    return null
+  }
+
+  // Normalize to exactly 100% if close
+  const normalizedSand = sum !== 100 ? (sandNum / sum) * 100 : sandNum
+  const normalizedSilt = sum !== 100 ? (siltNum / sum) * 100 : siltNum
+  const normalizedClay = sum !== 100 ? (clayNum / sum) * 100 : clayNum
+
+  const s = normalizedSand
+  const si = normalizedSilt
+  const c = normalizedClay
+
+  // Classification according to USDA soil texture triangle
+
+  // 1. Sand
+  if (s >= 85 && c <= 10) {
+    return 'Sand'
+  }
+
+  // 2. Loamy sand
+  if (s >= 70 && s < 85 && c <= 15) {
+    return 'Loamy sand'
+  }
+
+  // 3. Sandy loam
+  if (s >= 43 && s < 85 && c <= 20) {
+    return 'Sandy loam'
+  }
+
+  // 4. Loam
+  if (s >= 25 && s < 52 && si >= 28 && si <= 50 && c >= 7 && c <= 27) {
+    return 'Loam'
+  }
+
+  // 5. Silt loam
+  if (si >= 50 && c >= 12 && c <= 27 && s < 50) {
+    return 'Silt loam'
+  }
+
+  // 6. Silt
+  if (si >= 80 && c <= 15) {
+    return 'Silt'
+  }
+
+  // 7. Sandy clay loam
+  if (c >= 20 && c <= 35 && s >= 45) {
+    return 'Sandy clay loam'
+  }
+
+  // 8. Clay loam
+  if (c >= 27 && c <= 40 && s >= 20 && s < 45) {
+    return 'Clay loam'
+  }
+
+  // 9. Silty clay loam
+  if (c >= 27 && c <= 40 && s < 20) {
+    return 'Silty clay loam'
+  }
+
+  // 10. Sandy clay
+  if (c >= 35 && s >= 45) {
+    return 'Sandy clay'
+  }
+
+  // 11. Silty clay
+  if (c >= 40 && si >= 40) {
+    return 'Silty clay'
+  }
+
+  // 12. Clay
+  if (c >= 40 && s < 45 && si < 40) {
+    return 'Clay'
+  }
+
+  // If no exact match, try to find the closest match
+  return findClosestSoilTexture(s, si, c)
+}
+
+function findClosestSoilTexture(sand: number, silt: number, clay: number): SoilTextureClass | null {
+  // Define representative points for each soil texture class
+  const textureClasses: Array<{
+    name: SoilTextureClass
+    sand: number
+    silt: number
+    clay: number
+  }> = [
+    { name: 'Sand', sand: 90, silt: 5, clay: 5 },
+    { name: 'Loamy sand', sand: 80, silt: 15, clay: 5 },
+    { name: 'Sandy loam', sand: 65, silt: 25, clay: 10 },
+    { name: 'Loam', sand: 40, silt: 40, clay: 20 },
+    { name: 'Silt loam', sand: 20, silt: 60, clay: 20 },
+    { name: 'Silt', sand: 10, silt: 80, clay: 10 },
+    { name: 'Sandy clay loam', sand: 60, silt: 15, clay: 25 },
+    { name: 'Clay loam', sand: 32, silt: 38, clay: 30 },
+    { name: 'Silty clay loam', sand: 10, silt: 55, clay: 35 },
+    { name: 'Sandy clay', sand: 50, silt: 10, clay: 40 },
+    { name: 'Silty clay', sand: 10, silt: 45, clay: 45 },
+    { name: 'Clay', sand: 20, silt: 20, clay: 60 }
+  ]
+
+  // Find the closest match using Euclidean distance
+  let closestTexture: SoilTextureClass | null = null
+  let minDistance = Infinity
+
+  for (const texture of textureClasses) {
+    const distance = Math.sqrt(
+      Math.pow(sand - texture.sand, 2) +
+        Math.pow(silt - texture.silt, 2) +
+        Math.pow(clay - texture.clay, 2)
+    )
+    if (distance < minDistance) {
+      minDistance = distance
+      closestTexture = texture.name
+    }
+  }
+
+  return closestTexture
+}
+
+/**
+ * Get a description of the soil texture class properties
+ */
+export function getSoilTextureDescription(texture: SoilTextureClass): {
+  description: string
+  characteristics: string[]
+  suitability: string
+} {
+  const descriptions: Record<SoilTextureClass, any> = {
+    Sand: {
+      description: 'Coarse-textured soil with large particles',
+      characteristics: [
+        'Very fast drainage',
+        'Low water retention',
+        'High aeration',
+        'Low fertility',
+        'Warms up quickly in spring'
+      ],
+      suitability: 'Fair for grapes - requires organic matter and frequent irrigation'
+    },
+    'Loamy sand': {
+      description: 'Coarse-textured soil with some fine particles',
+      characteristics: [
+        'Fast drainage',
+        'Low to moderate water retention',
+        'Good aeration',
+        'Easy to work with'
+      ],
+      suitability: 'Good for grapes - well-draining, requires irrigation management'
+    },
+    'Sandy loam': {
+      description: 'Medium-coarse textured soil',
+      characteristics: [
+        'Good drainage',
+        'Moderate water retention',
+        'Good aeration',
+        'Easy to work with',
+        'Moderate fertility'
+      ],
+      suitability: 'Excellent for grapes - ideal drainage and water balance'
+    },
+    Loam: {
+      description: 'Balanced medium-textured soil',
+      characteristics: [
+        'Balanced drainage',
+        'Good water retention',
+        'Good nutrient holding',
+        'Easy to work with',
+        'High fertility'
+      ],
+      suitability: 'Excellent for grapes - near-ideal growing conditions'
+    },
+    'Silt loam': {
+      description: 'Medium-textured soil with dominant silt',
+      characteristics: [
+        'Moderate drainage',
+        'Good water retention',
+        'Moderate fertility',
+        'Can crust when dry',
+        'Easy to work with when moist'
+      ],
+      suitability: 'Good for grapes - needs careful irrigation to prevent crusting'
+    },
+    Silt: {
+      description: 'Fine-textured soil with dominant silt particles',
+      characteristics: [
+        'Slow drainage',
+        'High water retention',
+        'Easy to work with',
+        'Can become compacted',
+        'Prone to crusting'
+      ],
+      suitability: 'Fair for grapes - requires drainage management'
+    },
+    'Sandy clay loam': {
+      description: 'Medium-fine textured soil',
+      characteristics: [
+        'Moderate drainage',
+        'Good water retention',
+        'Good nutrient holding',
+        'Can become sticky when wet'
+      ],
+      suitability: 'Good for grapes - good water and nutrient retention'
+    },
+    'Clay loam': {
+      description: 'Medium-fine textured soil with significant clay',
+      characteristics: [
+        'Slow to moderate drainage',
+        'High water retention',
+        'High nutrient holding',
+        'Can be sticky when wet',
+        'Hard when dry'
+      ],
+      suitability: 'Good for grapes - excellent for drought resistance'
+    },
+    'Silty clay loam': {
+      description: 'Fine-textured soil',
+      characteristics: [
+        'Slow drainage',
+        'High water retention',
+        'High nutrient holding',
+        'Can be difficult to work with',
+        'Prone to waterlogging'
+      ],
+      suitability: 'Fair for grapes - requires excellent drainage'
+    },
+    'Sandy clay': {
+      description: 'Fine-textured soil with high clay content',
+      characteristics: [
+        'Slow drainage',
+        'High water retention',
+        'High nutrient holding',
+        'Sticky when wet',
+        'Hard when dry'
+      ],
+      suitability: 'Fair to good - requires careful water management'
+    },
+    'Silty clay': {
+      description: 'Very fine-textured soil',
+      characteristics: [
+        'Very slow drainage',
+        'Very high water retention',
+        'High nutrient holding',
+        'Very sticky when wet',
+        'Very hard when dry'
+      ],
+      suitability: 'Challenging - requires raised beds or mounding'
+    },
+    Clay: {
+      description: 'Very fine-textured soil with dominant clay',
+      characteristics: [
+        'Very slow drainage',
+        'Very high water retention',
+        'High nutrient holding',
+        'Cracks when dry',
+        'Very sticky when wet'
+      ],
+      suitability: 'Challenging - requires raised beds and careful irrigation'
+    }
+  }
+
+  return descriptions[texture] || descriptions.Loam
+}


### PR DESCRIPTION
Implements USDA soil texture triangle classification with real-time display in farm form. Farmers can now see soil type instantly as they enter sand, silt, and clay percentages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added USDA soil texture classification with real-time soil type display in the farm form. The soil type is auto-calculated and saved as users enter sand, silt, and clay.

- **New Features**
  - Added src/lib/soil-texture.ts with getSoilTextureClass and getSoilTextureDescription.
  - Validates inputs and classifies only when sand+silt+clay ≈ 100% (95–105), normalizing when close.
  - Applies USDA boundaries (incl. loamy sand silt + 2*clay ≤ 30) with overlap fixes, and uses 2D sand–clay fallback when no exact match.
  - Replaced the manual dropdown and badge with a read-only “Soil Texture” field that shows the calculated value (or a saved value if no inputs); on save, use the calculated value and only preserve a manual value for farms that never had percentage data.

<sup>Written for commit 4a122198736e76e9f57690a04f467e68323fc126. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

---
## EntelligenceAI PR Summary 
 This PR adds USDA soil texture classification with real-time display in the farm modal form.
- Created `src/lib/soil-texture.ts` module with `SoilTextureClass` union type for 12 USDA categories
- Implemented `getSoilTextureClass()` with USDA triangle rules, input validation, normalization (95-105% tolerance), and Euclidean distance fallback
- Added `getSoilTextureDescription()` providing soil characteristics and grape-growing suitability
- Enhanced farm modal with memoized `calculatedSoilTexture` computed from soil composition inputs
- Modified Clay input field to display inline badge with calculated soil texture class using flex layout 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time soil texture classification in the soil properties form: sand/silt/clay inputs auto-calculate and display a read-only "Soil Texture Class" field that indicates "(auto-calculated)" or "(saved)" and shows a descriptive placeholder when incomplete.
  * Added descriptive metadata for each texture class (description, characteristics, suitability).

* **Bug Fixes / Behavior**
  * Saving now uses the auto-calculated texture when available; preserves existing manual values only if they were originally provided.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->