### PR TITLE
Update homepage CTA buttons to navigate to Google Calendar

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -227,14 +227,14 @@ export default function LandingPage() {
             >
               Log In
             </Link>
-            <button
+            <a
               className="hidden sm:block bg-accent hover:bg-accent/90 active:scale-95 transition-all text-accent-foreground text-sm font-semibold px-4 py-2 rounded-lg shadow-sm"
-              onClick={() =>
-                document.getElementById('daily-work')?.scrollIntoView({ behavior: 'smooth' })
-              }
+              href="https://calendar.app.google/vq1JzfjiT59v9dAS7"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               See how it fits your vineyard
-            </button>
+            </a>
           </div>
         </div>
       </header>
@@ -250,15 +250,15 @@ export default function LandingPage() {
             vineyard operations, not spreadsheets.
           </p>
           <div className="flex flex-col sm:flex-row w-full gap-3 max-w-[400px]">
-            <button
+            <a
               className="bg-accent hover:bg-accent/90 active:scale-[0.98] transition-all text-accent-foreground text-base font-semibold px-6 py-3.5 rounded-xl shadow-md w-full text-center flex items-center justify-center gap-2"
-              onClick={() =>
-                document.getElementById('daily-work')?.scrollIntoView({ behavior: 'smooth' })
-              }
+              href="https://calendar.app.google/vq1JzfjiT59v9dAS7"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               See how it fits your vineyard
-              <span aria-hidden="true">↓</span>
-            </button>
+              <span aria-hidden="true">→</span>
+            </a>
           </div>
         </section>
 


### PR DESCRIPTION
## Summary
- Update homepage CTA buttons to navigate to Google Calendar booking link
- Replace scroll-to-section behavior with external calendar link
- Both CTA buttons now link to https://calendar.app.google/vq1JzfjiT59v9dAS7
- Update hero button arrow from ↓ to → for external link indication
- Add target="_blank" and rel="noopener noreferrer" for security

## Test plan
- [ ] Verify both CTA buttons open the calendar link in a new tab
- [ ] Confirm the link is correct and accessible
- [ ] Test responsive behavior on mobile and desktop
- [ ] Check that navigation works for users with and without authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ashish921998/vinesight/pull/128">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated both homepage CTA buttons to open the Google Calendar booking link in a new tab, replacing the scroll-to-section behavior and switching the arrow to → to signal an external link.

Adds target="_blank" and rel="noopener noreferrer" for security on both links.

<sup>Written for commit 26ee9af600335491ccde0d31f5bbf407614bb55e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Call-to-action buttons now link to Google Calendar and open in a new tab, replacing previous scroll-to-section behavior.
  * Updated arrow icons to right-arrow in two locations: the top-right action area and the hero section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
## EntelligenceAI PR Summary 
 Refactored CTA buttons from scroll navigation to external Google Calendar links with proper security attributes.
- Replaced `<button>` elements with `<a>` tags for two call-to-action buttons
- Changed navigation from `onClick` scroll behavior to `href` with Google Calendar URL
- Added `target="_blank"` and `rel="noopener noreferrer"` for secure external link handling
- Updated hero section arrow icon from ↓ to → to indicate external navigation 

