### PR TITLE
fix: resolve Next.js build failure and deprecation warnings

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -159,12 +159,12 @@ export default withSentryConfig(nextConfig, {
   // side errors will fail.
   tunnelRoute: '/monitoring',
 
-  // Automatically tree-shake Sentry logger statements to reduce bundle size
-  disableLogger: true,
-
-  // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
-  // See the following for more information:
-  // https://docs.sentry.io/product/crons/
-  // https://vercel.com/docs/cron-jobs
-  automaticVercelMonitors: true
+  webpack: {
+    // Automatically tree-shake Sentry logger statements to reduce bundle size
+    treeshake: {
+      removeDebugLogging: true
+    },
+    // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
+    automaticVercelMonitors: true
+  }
 })

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -21,8 +21,18 @@ export function getTypedSupabaseClient() {
   )
 }
 
-// For backward compatibility
-export const supabase = getSupabaseClient()
+// For backward compatibility - lazy proxy to avoid build-time env var evaluation.
+// Top-level instantiation caused `next build` page-data collection to fail when
+// NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY are not set in the build env.
+export const supabase = new Proxy({} as ReturnType<typeof getSupabaseClient>, {
+  get(_target, prop) {
+    const client = getSupabaseClient() as unknown as Record<string | symbol, unknown>
+    const value = client[prop as string]
+    return typeof value === 'function'
+      ? (value as (...args: unknown[]) => unknown).bind(client)
+      : value
+  }
+})
 
 // Database types based on your existing schema
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -24,9 +24,11 @@ export function getTypedSupabaseClient() {
 // For backward compatibility - lazy proxy to avoid build-time env var evaluation.
 // Top-level instantiation caused `next build` page-data collection to fail when
 // NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY are not set in the build env.
+let _supabaseSingleton: ReturnType<typeof getSupabaseClient> | null = null
 export const supabase = new Proxy({} as ReturnType<typeof getSupabaseClient>, {
   get(_target, prop) {
-    const client = getSupabaseClient() as unknown as Record<string | symbol, unknown>
+    if (!_supabaseSingleton) _supabaseSingleton = getSupabaseClient()
+    const client = _supabaseSingleton as unknown as Record<string | symbol, unknown>
     const value = client[prop as string]
     return typeof value === 'function'
       ? (value as (...args: unknown[]) => unknown).bind(client)


### PR DESCRIPTION
## Summary

Fixes two Next.js-related issues discovered while running `next build`:

1. **Build failure during page-data collection.** `src/lib/supabase.ts` eagerly executed `getSupabaseClient()` at module evaluation time via `export const supabase = getSupabaseClient()`. When `next build` collected page data for `/api/farms` (which transitively imports this module), `createBrowserClient` was invoked without `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` available, throwing `@supabase/ssr: Your project's URL and API key are required` and aborting the build. Replaced the eager export with a lazy `Proxy` that instantiates the client on first property access — no import surface change for consumers, but imports no longer require env vars.

2. **Sentry plugin deprecation warnings.** `@sentry/nextjs` now warns that the top-level `disableLogger` and `automaticVercelMonitors` options are deprecated and should live under `webpack.*`. Moved them to `webpack.treeshake.removeDebugLogging` and `webpack.automaticVercelMonitors` in `next.config.mjs`.

## Test plan

- [x] `bun run build` completes successfully (previously failed at "Collecting page data /api/farms")
- [x] No `[@sentry/nextjs] DEPRECATION WARNING` lines in build output
- [ ] Deploy preview: confirm Sentry source map upload + tunnel route still function (requires SENTRY_AUTH_TOKEN env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ashish921998/vinesight/pull/130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Next.js build failures by lazily initializing and caching the Supabase client, and removes `@sentry/nextjs` deprecation warnings by moving options under `webpack`.

- **Bug Fixes**
  - Make `supabase` a lazy `Proxy` that creates and caches a single client on first use, avoiding env var access at import time; no import changes for consumers.
  - Update `next.config.mjs`: move `disableLogger` to `webpack.treeshake.removeDebugLogging` and `automaticVercelMonitors` to `webpack.automaticVercelMonitors` to silence deprecation warnings.

<sup>Written for commit f471c3971b95539455e99881fef1196d8920b5b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Sentry logging/webpack configuration to improve bundle efficiency and debug logging removal
* **Refactor**
  * Changed Supabase client initialization to a lazy, on-demand instantiation for improved startup performance and resource usage
<!-- end of auto-generated comment: release notes by coderabbit.ai -->