### PR TITLE
chore: reduce lint warnings in middleware and tailwind config

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -16,7 +16,7 @@ export async function middleware(req: NextRequest) {
           return req.cookies.getAll()
         },
         setAll(cookiesToSet) {
-          cookiesToSet.forEach(({ name, value, options }) => req.cookies.set(name, value))
+          cookiesToSet.forEach(({ name, value }) => req.cookies.set(name, value))
           supabaseResponse = NextResponse.next({
             request: req
           })

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -55,7 +55,7 @@ const radiusScale = {
 }
 
 /** @type {import('tailwindcss').Config} */
-export default {
+const config = {
   darkMode: 'class',
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
@@ -207,3 +207,5 @@ export default {
   },
   plugins: [plugin]
 }
+
+export default config


### PR DESCRIPTION
### Motivation
- Reduce a couple of easy-to-fix lint/quality warnings: avoid an unused destructured value in middleware cookie propagation and remove an anonymous default export in the Tailwind config.

### Description
- Update `middleware.ts` to stop destructuring the unused `options` property when calling `req.cookies.set`, keeping the later `supabaseResponse.cookies.set` call that uses `options` intact.
- Update `tailwind.config.mjs` to declare a named `const config = { ... }` and export it with `export default config` instead of an anonymous default export.

### Testing
- Ran `bunx eslint middleware.ts tailwind.config.mjs` which completed without introducing new lint errors.
- Ran `bun run lint` and confirmed the repository baseline warnings remain but no new errors were added by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e67aefb3a48330a4daedcf0a3a0c57)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ashish921998/vinesight/pull/132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal code structure to improve maintainability and configuration organization while maintaining all existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce lint warnings by removing the unused destructured `options` in `middleware.ts` and switching `tailwind.config.mjs` to a named `const config` with `export default config`. No runtime behavior changes.

<sup>Written for commit fcea3dbb2047929b9992b8eb3a51e2b0bf917439. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

