### PR TITLE
Add consultant organization client foundation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -48,7 +48,7 @@
         "jspdf": "^3.0.4",
         "jspdf-autotable": "^5.0.2",
         "lucide-react": "^0.562.0",
-        "next": "15.5.7",
+        "next": "15.5.9",
         "next-themes": "^0.4.6",
         "openai": "^6.15.0",
         "openmeteo": "^1.2.3",
@@ -337,7 +337,7 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
-    "@next/env": ["@next/env@15.5.7", "", {}, "sha512-4h6Y2NyEkIEN7Z8YxkA27pq6zTkS09bUSYC0xjd0NpwFxjnIKeZEeH591o5WECSmjpUhLn3H2QLJcDye3Uzcvg=="],
+    "@next/env": ["@next/env@15.5.9", "", {}, "sha512-4GlTZ+EJM7WaW2HEZcyU317tIQDjkQIyENDLxYJfSWlfqguN+dHkZgyQTV/7ykvobU7yEH5gKvreNrH4B6QgIg=="],
 
     "@next/eslint-plugin-next": ["@next/eslint-plugin-next@15.5.7", "", { "dependencies": { "fast-glob": "3.3.1" } }, "sha512-DtRU2N7BkGr8r+pExfuWHwMEPX5SD57FeA6pxdgCHODo+b/UgIgjE+rgWKtJAbEbGhVZ2jtHn4g3wNhWFoNBQQ=="],
 
@@ -2031,7 +2031,7 @@
 
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
-    "next": ["next@15.5.7", "", { "dependencies": { "@next/env": "15.5.7", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.5.7", "@next/swc-darwin-x64": "15.5.7", "@next/swc-linux-arm64-gnu": "15.5.7", "@next/swc-linux-arm64-musl": "15.5.7", "@next/swc-linux-x64-gnu": "15.5.7", "@next/swc-linux-x64-musl": "15.5.7", "@next/swc-win32-arm64-msvc": "15.5.7", "@next/swc-win32-x64-msvc": "15.5.7", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": "dist/bin/next" }, "sha512-+t2/0jIJ48kUpGKkdlhgkv+zPTEOoXyr60qXe68eB/pl3CMJaLeIGjzp5D6Oqt25hCBiBTt8wEeeAzfJvUKnPQ=="],
+    "next": ["next@15.5.9", "", { "dependencies": { "@next/env": "15.5.9", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.5.7", "@next/swc-darwin-x64": "15.5.7", "@next/swc-linux-arm64-gnu": "15.5.7", "@next/swc-linux-arm64-musl": "15.5.7", "@next/swc-linux-x64-gnu": "15.5.7", "@next/swc-linux-x64-musl": "15.5.7", "@next/swc-win32-arm64-msvc": "15.5.7", "@next/swc-win32-x64-msvc": "15.5.7", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg=="],
 
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 

--- a/src/app/api/invite/route.ts
+++ b/src/app/api/invite/route.ts
@@ -133,7 +133,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Verify user has admin/owner role to send invitations
-    if (membership.role !== 'admin' && !membership.is_owner) {
+    if (!membership.is_owner && membership.role !== 'owner' && membership.role !== 'admin') {
       return NextResponse.json(
         { error: 'Insufficient permissions: Only admins and owners can send invitations' },
         { status: 403 }

--- a/src/app/api/organizations/add-client/route.ts
+++ b/src/app/api/organizations/add-client/route.ts
@@ -124,6 +124,27 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    if (assignedTo) {
+      const { data: assigneeMembership, error: assigneeMembershipError } = await getSupabaseAdmin()
+        .from('organization_members')
+        .select('id')
+        .eq('organization_id', organizationId)
+        .eq('user_id', assignedTo)
+        .maybeSingle()
+
+      if (assigneeMembershipError) {
+        console.error('Error checking assigned agronomist membership:', assigneeMembershipError)
+        return NextResponse.json({ error: 'Failed to verify assigned agronomist' }, { status: 500 })
+      }
+
+      if (!assigneeMembership) {
+        return NextResponse.json(
+          { error: 'Assigned agronomist must belong to the organization' },
+          { status: 400 }
+        )
+      }
+    }
+
     const { error: clientError } = await getSupabaseAdmin()
       .from('organization_clients')
       .upsert(
@@ -149,8 +170,11 @@ export async function POST(request: NextRequest) {
       .eq('id', userId)
 
     if (updateError) {
-      console.error('Error updating profile:', updateError)
-      return NextResponse.json({ error: 'Failed to add as client' }, { status: 500 })
+      console.error('Error updating legacy profile organization mirror:', {
+        updateError,
+        userId,
+        organizationId
+      })
     }
 
     return NextResponse.json({

--- a/src/app/api/organizations/add-client/route.ts
+++ b/src/app/api/organizations/add-client/route.ts
@@ -12,6 +12,11 @@ const AddClientSchema = z.object({
   assignedTo: z.string().uuid().nullable().optional()
 })
 
+function isUniqueConstraintError(error: { code?: string; message?: string; details?: string }) {
+  const text = `${error.message ?? ''} ${error.details ?? ''}`.toLowerCase()
+  return error.code === '23505' || text.includes('duplicate') || text.includes('unique')
+}
+
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
@@ -61,6 +66,13 @@ export async function POST(request: NextRequest) {
     const isSelfAdd = authUser.id === userId
 
     if (isSelfAdd) {
+      if (assignedTo) {
+        return NextResponse.json(
+          { error: 'Self-service clients cannot assign themselves to an agronomist' },
+          { status: 400 }
+        )
+      }
+
       // Self-add flow: User is connecting themselves to an organization
       // This is allowed - users can choose their consultant organization
       // The organization must exist and be active
@@ -181,6 +193,13 @@ export async function POST(request: NextRequest) {
       )
 
     if (clientError) {
+      if (isUniqueConstraintError(clientError)) {
+        return NextResponse.json(
+          { error: 'Client is already active in another organization' },
+          { status: 409 }
+        )
+      }
+
       console.error('Error adding organization client:', clientError)
       return NextResponse.json({ error: 'Failed to add as client' }, { status: 500 })
     }

--- a/src/app/api/organizations/add-client/route.ts
+++ b/src/app/api/organizations/add-client/route.ts
@@ -30,6 +30,7 @@ export async function POST(request: NextRequest) {
       )
     }
     const { userId, organizationId, assignedTo } = parseResult.data
+    const hasAssignedToField = Object.prototype.hasOwnProperty.call(body, 'assignedTo')
 
     // Validate environment variables
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -66,7 +67,7 @@ export async function POST(request: NextRequest) {
     const isSelfAdd = authUser.id === userId
 
     if (isSelfAdd) {
-      if (assignedTo) {
+      if (hasAssignedToField) {
         return NextResponse.json(
           { error: 'Self-service clients cannot assign themselves to an agronomist' },
           { status: 400 }
@@ -180,7 +181,7 @@ export async function POST(request: NextRequest) {
     }
 
     const shouldWriteClientLink = !(
-      isSelfAdd && activeClientLink?.organization_id === organizationId
+      activeClientLink?.organization_id === organizationId && !hasAssignedToField
     )
 
     if (shouldWriteClientLink) {

--- a/src/app/api/organizations/add-client/route.ts
+++ b/src/app/api/organizations/add-client/route.ts
@@ -179,29 +179,35 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const { error: clientError } = await getSupabaseAdmin()
-      .from('organization_clients')
-      .upsert(
-        {
-          organization_id: organizationId,
-          client_user_id: userId,
-          assigned_to: assignedTo ?? null,
-          assigned_by: authUser.id,
-          status: 'active'
-        },
-        { onConflict: 'organization_id,client_user_id' }
-      )
+    const shouldWriteClientLink = !(
+      isSelfAdd && activeClientLink?.organization_id === organizationId
+    )
 
-    if (clientError) {
-      if (isUniqueConstraintError(clientError)) {
-        return NextResponse.json(
-          { error: 'Client is already active in another organization' },
-          { status: 409 }
+    if (shouldWriteClientLink) {
+      const { error: clientError } = await getSupabaseAdmin()
+        .from('organization_clients')
+        .upsert(
+          {
+            organization_id: organizationId,
+            client_user_id: userId,
+            assigned_to: assignedTo ?? null,
+            assigned_by: authUser.id,
+            status: 'active'
+          },
+          { onConflict: 'organization_id,client_user_id' }
         )
-      }
 
-      console.error('Error adding organization client:', clientError)
-      return NextResponse.json({ error: 'Failed to add as client' }, { status: 500 })
+      if (clientError) {
+        if (isUniqueConstraintError(clientError)) {
+          return NextResponse.json(
+            { error: 'Client is already active in another organization' },
+            { status: 409 }
+          )
+        }
+
+        console.error('Error adding organization client:', clientError)
+        return NextResponse.json({ error: 'Failed to add as client' }, { status: 500 })
+      }
     }
 
     // Keep this as a backward-compatible mirror while older screens migrate.
@@ -216,6 +222,7 @@ export async function POST(request: NextRequest) {
         userId,
         organizationId
       })
+      return NextResponse.json({ error: 'Failed to add as client' }, { status: 500 })
     }
 
     return NextResponse.json({

--- a/src/app/api/organizations/add-client/route.ts
+++ b/src/app/api/organizations/add-client/route.ts
@@ -224,7 +224,6 @@ export async function POST(request: NextRequest) {
         userId,
         organizationId
       })
-      return NextResponse.json({ error: 'Failed to add as client' }, { status: 500 })
     }
 
     return NextResponse.json({

--- a/src/app/api/organizations/add-client/route.ts
+++ b/src/app/api/organizations/add-client/route.ts
@@ -145,6 +145,28 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    const { data: activeClientLink, error: activeClientLinkError } = await getSupabaseAdmin()
+      .from('organization_clients')
+      .select('organization_id')
+      .eq('client_user_id', userId)
+      .eq('status', 'active')
+      .maybeSingle()
+
+    if (activeClientLinkError) {
+      console.error('Error checking active organization client link:', activeClientLinkError)
+      return NextResponse.json(
+        { error: 'Failed to verify current client organization' },
+        { status: 500 }
+      )
+    }
+
+    if (activeClientLink && activeClientLink.organization_id !== organizationId) {
+      return NextResponse.json(
+        { error: 'Client is already active in another organization' },
+        { status: 409 }
+      )
+    }
+
     const { error: clientError } = await getSupabaseAdmin()
       .from('organization_clients')
       .upsert(

--- a/src/app/api/organizations/add-client/route.ts
+++ b/src/app/api/organizations/add-client/route.ts
@@ -8,7 +8,8 @@ import { getSupabaseAdmin } from '@/lib/supabase-admin'
 // P0: Validate input schema
 const AddClientSchema = z.object({
   userId: z.string().uuid(),
-  organizationId: z.string().uuid()
+  organizationId: z.string().uuid(),
+  assignedTo: z.string().uuid().nullable().optional()
 })
 
 export async function POST(request: NextRequest) {
@@ -23,7 +24,7 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       )
     }
-    const { userId, organizationId } = parseResult.data
+    const { userId, organizationId, assignedTo } = parseResult.data
 
     // Validate environment variables
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -91,7 +92,10 @@ export async function POST(request: NextRequest) {
         return NextResponse.json({ error: 'Failed to verify permissions' }, { status: 500 })
       }
 
-      if (!membership || (membership.role !== 'admin' && !membership.is_owner)) {
+      if (
+        !membership ||
+        (!membership.is_owner && membership.role !== 'owner' && membership.role !== 'admin')
+      ) {
         return NextResponse.json(
           { error: 'Unauthorized - must be organization admin or owner' },
           { status: 403 }
@@ -120,7 +124,25 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // Update user profile with consultant organization
+    const { error: clientError } = await getSupabaseAdmin()
+      .from('organization_clients')
+      .upsert(
+        {
+          organization_id: organizationId,
+          client_user_id: userId,
+          assigned_to: assignedTo ?? null,
+          assigned_by: authUser.id,
+          status: 'active'
+        },
+        { onConflict: 'organization_id,client_user_id' }
+      )
+
+    if (clientError) {
+      console.error('Error adding organization client:', clientError)
+      return NextResponse.json({ error: 'Failed to add as client' }, { status: 500 })
+    }
+
+    // Keep this as a backward-compatible mirror while older screens migrate.
     const { error: updateError } = await getSupabaseAdmin()
       .from('profiles')
       .update({ consultant_organization_id: organizationId })

--- a/src/app/api/organizations/add-client/route.ts
+++ b/src/app/api/organizations/add-client/route.ts
@@ -67,7 +67,7 @@ export async function POST(request: NextRequest) {
     const isSelfAdd = authUser.id === userId
 
     if (isSelfAdd) {
-      if (hasAssignedToField) {
+      if (assignedTo) {
         return NextResponse.json(
           { error: 'Self-service clients cannot assign themselves to an agronomist' },
           { status: 400 }
@@ -181,7 +181,8 @@ export async function POST(request: NextRequest) {
     }
 
     const shouldWriteClientLink = !(
-      activeClientLink?.organization_id === organizationId && !hasAssignedToField
+      activeClientLink?.organization_id === organizationId &&
+      (!hasAssignedToField || isSelfAdd)
     )
 
     if (shouldWriteClientLink) {

--- a/src/app/api/organizations/route.ts
+++ b/src/app/api/organizations/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
-import type { Database } from '@/types/database'
 import { getSupabaseAdmin } from '@/lib/supabase-admin'
 
 // P0/P2: Validate input with proper schema
@@ -77,7 +76,7 @@ export async function POST(request: NextRequest) {
     const { error: memberError } = await getSupabaseAdmin().from('organization_members').insert({
       organization_id: org.id,
       user_id: userId,
-      role: 'admin',
+      role: 'owner',
       is_owner: true
     })
 

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -118,7 +118,7 @@ export async function PATCH(request: NextRequest, context: { params: Promise<{ i
     if (data.task_type !== undefined) updates.type = data.task_type
     if (data.status !== undefined) updates.status = data.status
     if (data.priority !== undefined) updates.priority = data.priority
-    if (data.due_date !== undefined) updates.dueDate = data.due_date ?? null
+    if (data.due_date !== undefined && data.due_date !== null) updates.dueDate = data.due_date
     if (data.estimated_duration_minutes !== undefined)
       updates.estimatedDurationMinutes = data.estimated_duration_minutes ?? null
     if (data.location !== undefined) updates.location = data.location ?? null

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -118,7 +118,7 @@ export async function PATCH(request: NextRequest, context: { params: Promise<{ i
     if (data.task_type !== undefined) updates.type = data.task_type
     if (data.status !== undefined) updates.status = data.status
     if (data.priority !== undefined) updates.priority = data.priority
-    if (data.due_date !== undefined && data.due_date !== null) updates.dueDate = data.due_date
+    if (data.due_date !== undefined) updates.dueDate = data.due_date ?? null
     if (data.estimated_duration_minutes !== undefined)
       updates.estimatedDurationMinutes = data.estimated_duration_minutes ?? null
     if (data.location !== undefined) updates.location = data.location ?? null

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -44,7 +44,7 @@ export default function DashboardPage() {
           <Button
             onClick={() => {
               posthog.capture('dashboard_connection_retry_clicked', {
-                error_message: error || 'Unknown authentication error'
+                error_message: String(error ?? 'Unknown authentication error')
               })
               window.location.reload()
             }}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -44,7 +44,7 @@ export default function DashboardPage() {
           <Button
             onClick={() => {
               posthog.capture('dashboard_connection_retry_clicked', {
-                error_message: error instanceof Error ? error.message : String(error)
+                error_message: error || 'Unknown authentication error'
               })
               window.location.reload()
             }}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,6 +7,9 @@ import { FarmerDashboard } from '@/components/dashboard/FarmerDashboard'
 import { useSupabaseAuth } from '@/hooks/useSupabaseAuth'
 import posthog from 'posthog-js'
 
+const getErrorMessage = (value: unknown) =>
+  value instanceof Error ? value.message : String(value ?? 'Unknown authentication error')
+
 export default function DashboardPage() {
   const { user, loading, error } = useSupabaseAuth()
   const router = useRouter()
@@ -44,7 +47,7 @@ export default function DashboardPage() {
           <Button
             onClick={() => {
               posthog.capture('dashboard_connection_retry_clicked', {
-                error_message: String(error ?? 'Unknown authentication error')
+                error_message: getErrorMessage(error)
               })
               window.location.reload()
             }}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -69,25 +69,26 @@ export default function SettingsPage() {
       setOrgLoading(true)
       const supabase = getTypedSupabaseClient()
 
-      // Check if user has a consultant organization in their profile
-      const { data: profile, error: profileError } = await supabase
-        .from('profiles')
-        .select('consultant_organization_id')
-        .eq('id', user.id)
-        .maybeSingle()
+      const { data: clientLinks, error: clientError } = await supabase
+        .from('organization_clients')
+        .select('organization_id')
+        .eq('client_user_id', user.id)
+        .eq('status', 'active')
+        .limit(1)
 
-      if (profileError) {
-        console.error('Error fetching profile:', profileError)
+      if (clientError) {
+        console.error('Error fetching organization client link:', clientError)
         toast.error('Failed to fetch organization status')
         return
       }
 
-      if (profile?.consultant_organization_id) {
+      const organizationId = clientLinks?.[0]?.organization_id
+      if (organizationId) {
         // Fetch the organization details
         const { data: org, error: orgError } = await supabase
           .from('organizations')
           .select('id, name, slug')
-          .eq('id', profile.consultant_organization_id)
+          .eq('id', organizationId)
           .maybeSingle()
 
         if (orgError) {

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -70,12 +70,12 @@ export default function SettingsPage() {
       setCurrentOrg(null)
       const supabase = getTypedSupabaseClient()
 
-      const { data: clientLinks, error: clientError } = await supabase
+      const { data: clientLink, error: clientError } = await supabase
         .from('organization_clients')
         .select('organization_id')
         .eq('client_user_id', user.id)
         .eq('status', 'active')
-        .limit(1)
+        .maybeSingle()
 
       if (clientError) {
         console.error('Error fetching organization client link:', clientError)
@@ -83,7 +83,7 @@ export default function SettingsPage() {
         return
       }
 
-      const organizationId = clientLinks?.[0]?.organization_id
+      const organizationId = clientLink?.organization_id
       if (organizationId) {
         // Fetch the organization details
         const { data: org, error: orgError } = await supabase

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -67,6 +67,7 @@ export default function SettingsPage() {
     if (!user) return
     try {
       setOrgLoading(true)
+      setCurrentOrg(null)
       const supabase = getTypedSupabaseClient()
 
       const { data: clientLinks, error: clientError } = await supabase

--- a/src/components/lab-tests/FertilizerPlanGenerator.tsx
+++ b/src/components/lab-tests/FertilizerPlanGenerator.tsx
@@ -78,15 +78,15 @@ export function FertilizerPlanGenerator({
     try {
       const tasks = plan.flatMap((item) =>
         item.applications.map((app) => ({
-          farm_id: farmId,
+          farmId,
           title: `${app.method === 'soil' ? 'Apply' : app.method === 'foliar' ? 'Spray' : 'Add to fertigation'}: ${app.product}`,
           description: `${app.purpose}\n\nDosage: ${app.dosage}\nMethod: ${app.method}\n\nGrowth Stage: ${item.growthStage}\n\nBased on ${testType} test from ${format(new Date(test.date), 'MMM dd, yyyy')}\n\n${item.notes}`,
-          due_date: format(item.date, 'yyyy-MM-dd'),
+          dueDate: format(item.date, 'yyyy-MM-dd'),
+          type: 'fertigation',
           priority:
             app.recommendationSource.includes('pH') || app.recommendationSource.includes('EC')
               ? ('high' as const)
               : ('medium' as const),
-          category: 'fertilization' as const,
           status: 'pending' as const
         }))
       )

--- a/src/components/lab-tests/LabTestTrendCharts.tsx
+++ b/src/components/lab-tests/LabTestTrendCharts.tsx
@@ -70,7 +70,7 @@ export function LabTestTrendCharts({ soilTests, petioleTests }: LabTestTrendChar
   const soilTrendData: TrendData[] = [...soilTests]
     .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
     .map((record) => ({
-      date: record.date,
+      date: new Date(record.date).toISOString(),
       displayDate: format(new Date(record.date), 'MMM dd, yyyy'),
       // Primary parameters
       ph: record.parameters?.ph ?? null,
@@ -98,7 +98,7 @@ export function LabTestTrendCharts({ soilTests, petioleTests }: LabTestTrendChar
   const petioleTrendData: TrendData[] = [...petioleTests]
     .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
     .map((record) => ({
-      date: record.date,
+      date: new Date(record.date).toISOString(),
       displayDate: format(new Date(record.date), 'MMM dd, yyyy'),
       // Major nutrients
       total_nitrogen: record.parameters?.total_nitrogen ?? null,

--- a/src/lib/ai-insights-service.ts
+++ b/src/lib/ai-insights-service.ts
@@ -560,7 +560,7 @@ export class AIInsightsService {
             id: record.id,
             activity_type: 'fertigation',
             date: record.date,
-            notes: record.notes || `${record.fertilizer} application`,
+            notes: record.notes || 'Fertigation application',
             created_at: record.created_at
           })
         })

--- a/src/lib/organization-service.ts
+++ b/src/lib/organization-service.ts
@@ -302,22 +302,28 @@ export class OrganizationService {
       throw new Error('Client is already active in another organization')
     }
 
-    const { error } = await supabase.from('organization_clients').upsert(
-      {
-        organization_id: organizationId,
-        client_user_id: clientUserId,
-        assigned_to: assignedTo ?? null,
-        assigned_by: user.id,
-        status: 'active'
-      },
-      { onConflict: 'organization_id,client_user_id' }
+    const shouldWriteClientLink = !(
+      activeClientLink?.organization_id === organizationId && assignedTo === undefined
     )
 
-    if (error) {
-      if (isUniqueConstraintError(error)) {
-        throw new Error('Client is already active in another organization')
+    if (shouldWriteClientLink) {
+      const { error } = await supabase.from('organization_clients').upsert(
+        {
+          organization_id: organizationId,
+          client_user_id: clientUserId,
+          assigned_to: assignedTo ?? null,
+          assigned_by: user.id,
+          status: 'active'
+        },
+        { onConflict: 'organization_id,client_user_id' }
+      )
+
+      if (error) {
+        if (isUniqueConstraintError(error)) {
+          throw new Error('Client is already active in another organization')
+        }
+        throw error
       }
-      throw error
     }
 
     // Backward-compatible mirror for existing screens that still read profile state.

--- a/src/lib/organization-service.ts
+++ b/src/lib/organization-service.ts
@@ -282,6 +282,21 @@ export class OrganizationService {
       }
     }
 
+    const { data: activeClientLink, error: activeClientLinkError } = await supabase
+      .from('organization_clients')
+      .select('organization_id')
+      .eq('client_user_id', clientUserId)
+      .eq('status', 'active')
+      .maybeSingle()
+
+    if (activeClientLinkError) {
+      throw activeClientLinkError
+    }
+
+    if (activeClientLink && activeClientLink.organization_id !== organizationId) {
+      throw new Error('Client is already active in another organization')
+    }
+
     const { error } = await supabase.from('organization_clients').upsert(
       {
         organization_id: organizationId,

--- a/src/lib/organization-service.ts
+++ b/src/lib/organization-service.ts
@@ -16,7 +16,7 @@ export interface OrganizationMember {
   id: string
   organization_id: string
   user_id: string
-  role: 'admin' | 'agronomist'
+  role: 'owner' | 'admin' | 'agronomist'
   is_owner: boolean | null
   joined_at: string | null
 }
@@ -25,11 +25,21 @@ export interface OrganizationClient {
   id: string
   organization_id: string
   client_user_id: string
+  assigned_to: string | null
   assigned_by: string | null
+  status: 'active' | 'inactive' | 'pending'
   assigned_at: string | null
   notes: string | null
+  created_at: string | null
+  updated_at: string | null
   full_name?: string | null
   email?: string | null
+}
+
+function canAdminOrganization(
+  member: Pick<OrganizationMember, 'role' | 'is_owner'> | null
+): boolean {
+  return Boolean(member && (member.is_owner || member.role === 'owner' || member.role === 'admin'))
 }
 
 export class OrganizationService {
@@ -94,7 +104,7 @@ export class OrganizationService {
   static async addOrganizationMember(
     organizationId: string,
     userId: string,
-    role: 'admin' | 'agronomist',
+    role: 'owner' | 'admin' | 'agronomist',
     isOwner = false
   ): Promise<OrganizationMember> {
     const supabase = await getTypedSupabaseClient()
@@ -129,7 +139,7 @@ export class OrganizationService {
     }
 
     // Require admin or owner role to add members
-    if (membership.role !== 'admin' && !membership.is_owner) {
+    if (!canAdminOrganization(membership as OrganizationMember | null)) {
       throw new Error('Permission denied: You are not authorized to modify this organization')
     }
 
@@ -178,29 +188,47 @@ export class OrganizationService {
 
   static async getOrganizationClients(organizationId: string): Promise<OrganizationClient[]> {
     const supabase = await getTypedSupabaseClient()
-    // Fetch limited profile fields (id, full_name, email, updated_at) to minimize PII exposure.
-    // Sensitive fields like phone, address, etc. are intentionally excluded.
-    const { data, error } = await supabase
-      .from('profiles')
-      .select('id, full_name, email, updated_at')
-      .eq('consultant_organization_id', organizationId)
+    const { data: clients, error } = await supabase
+      .from('organization_clients')
+      .select('*')
+      .eq('organization_id', organizationId)
+      .eq('status', 'active')
+      .order('assigned_at', { ascending: false })
 
     if (error) throw error
 
-    // Map profiles to OrganizationClient structure
-    return (data ?? []).map((profile) => ({
-      id: profile.id,
-      client_user_id: profile.id,
-      organization_id: organizationId,
-      full_name: profile.full_name,
-      email: profile.email,
-      assigned_at: profile.updated_at,
-      assigned_by: null,
-      notes: null
-    }))
+    const clientRows = (clients ?? []) as OrganizationClient[]
+    const clientUserIds = clientRows.map((client) => client.client_user_id)
+
+    if (clientUserIds.length === 0) {
+      return []
+    }
+
+    // Fetch limited profile fields to minimize PII exposure.
+    const { data: profiles, error: profilesError } = await supabase
+      .from('profiles')
+      .select('id, full_name, email')
+      .in('id', clientUserIds)
+
+    if (profilesError) throw profilesError
+
+    const profilesById = new Map((profiles ?? []).map((profile) => [profile.id, profile]))
+
+    return clientRows.map((client) => {
+      const profile = profilesById.get(client.client_user_id)
+      return {
+        ...client,
+        full_name: profile?.full_name ?? null,
+        email: profile?.email ?? null
+      }
+    })
   }
 
-  static async addOrganizationClient(organizationId: string, clientUserId: string): Promise<void> {
+  static async addOrganizationClient(
+    organizationId: string,
+    clientUserId: string,
+    assignedTo?: string | null
+  ): Promise<void> {
     const supabase = await getTypedSupabaseClient()
 
     // Verify user is authenticated with distinct error handling
@@ -233,16 +261,30 @@ export class OrganizationService {
     }
 
     // Require admin or owner role to add clients
-    if (membership.role !== 'admin' && !membership.is_owner) {
+    if (!canAdminOrganization(membership as OrganizationMember | null)) {
       throw new Error('Permission denied: You are not authorized to modify this organization')
     }
 
-    const { error } = await supabase
+    const { error } = await supabase.from('organization_clients').upsert(
+      {
+        organization_id: organizationId,
+        client_user_id: clientUserId,
+        assigned_to: assignedTo ?? null,
+        assigned_by: user.id,
+        status: 'active'
+      },
+      { onConflict: 'organization_id,client_user_id' }
+    )
+
+    if (error) throw error
+
+    // Backward-compatible mirror for existing screens that still read profile state.
+    const { error: profileError } = await supabase
       .from('profiles')
       .update({ consultant_organization_id: organizationId })
       .eq('id', clientUserId)
 
-    if (error) throw error
+    if (profileError) throw profileError
   }
 
   static async isUserOrgClient(
@@ -250,21 +292,19 @@ export class OrganizationService {
   ): Promise<{ isClient: boolean; organizationId?: string }> {
     const supabase = await getTypedSupabaseClient()
     const { data, error } = await supabase
-      .from('profiles')
-      .select('consultant_organization_id')
-      .eq('id', userId)
-      .single()
+      .from('organization_clients')
+      .select('organization_id')
+      .eq('client_user_id', userId)
+      .eq('status', 'active')
+      .limit(1)
 
     if (error) {
-      // Handle profile not found gracefully - treat as not a client
-      if (error.code === 'PGRST116') {
-        return { isClient: false }
-      }
       throw error
     }
 
-    if (data && data.consultant_organization_id) {
-      return { isClient: true, organizationId: data.consultant_organization_id }
+    const client = data?.[0]
+    if (client?.organization_id) {
+      return { isClient: true, organizationId: client.organization_id }
     }
     return { isClient: false }
   }

--- a/src/lib/organization-service.ts
+++ b/src/lib/organization-service.ts
@@ -265,6 +265,23 @@ export class OrganizationService {
       throw new Error('Permission denied: You are not authorized to modify this organization')
     }
 
+    if (assignedTo) {
+      const { data: assigneeMembership, error: assigneeMembershipError } = await supabase
+        .from('organization_members')
+        .select('id')
+        .eq('organization_id', organizationId)
+        .eq('user_id', assignedTo)
+        .maybeSingle()
+
+      if (assigneeMembershipError) {
+        throw assigneeMembershipError
+      }
+
+      if (!assigneeMembership) {
+        throw new Error('Assigned agronomist must belong to the organization')
+      }
+    }
+
     const { error } = await supabase.from('organization_clients').upsert(
       {
         organization_id: organizationId,
@@ -284,7 +301,13 @@ export class OrganizationService {
       .update({ consultant_organization_id: organizationId })
       .eq('id', clientUserId)
 
-    if (profileError) throw profileError
+    if (profileError) {
+      console.error('Error updating legacy profile organization mirror:', {
+        profileError,
+        clientUserId,
+        organizationId
+      })
+    }
   }
 
   static async isUserOrgClient(
@@ -296,15 +319,14 @@ export class OrganizationService {
       .select('organization_id')
       .eq('client_user_id', userId)
       .eq('status', 'active')
-      .limit(1)
+      .maybeSingle()
 
     if (error) {
       throw error
     }
 
-    const client = data?.[0]
-    if (client?.organization_id) {
-      return { isClient: true, organizationId: client.organization_id }
+    if (data?.organization_id) {
+      return { isClient: true, organizationId: data.organization_id }
     }
     return { isClient: false }
   }

--- a/src/lib/organization-service.ts
+++ b/src/lib/organization-service.ts
@@ -198,7 +198,7 @@ export class OrganizationService {
       .select('*')
       .eq('organization_id', organizationId)
       .eq('status', 'active')
-      .order('assigned_at', { ascending: false })
+      .order('updated_at', { ascending: false })
 
     if (error) throw error
 

--- a/src/lib/organization-service.ts
+++ b/src/lib/organization-service.ts
@@ -42,6 +42,11 @@ function canAdminOrganization(
   return Boolean(member && (member.is_owner || member.role === 'owner' || member.role === 'admin'))
 }
 
+function isUniqueConstraintError(error: { code?: string; message?: string; details?: string }) {
+  const text = `${error.message ?? ''} ${error.details ?? ''}`.toLowerCase()
+  return error.code === '23505' || text.includes('duplicate') || text.includes('unique')
+}
+
 export class OrganizationService {
   static async getOrganization(id: string): Promise<Organization | null> {
     const supabase = await getTypedSupabaseClient()
@@ -308,7 +313,12 @@ export class OrganizationService {
       { onConflict: 'organization_id,client_user_id' }
     )
 
-    if (error) throw error
+    if (error) {
+      if (isUniqueConstraintError(error)) {
+        throw new Error('Client is already active in another organization')
+      }
+      throw error
+    }
 
     // Backward-compatible mirror for existing screens that still read profile state.
     const { error: profileError } = await supabase

--- a/src/lib/supabase-types.ts
+++ b/src/lib/supabase-types.ts
@@ -97,7 +97,8 @@ export interface TaskReminderCreateInput {
   completedAt?: string | null
 }
 
-export interface TaskReminderUpdateInput extends Partial<TaskReminderCreateInput> {
+export type TaskReminderUpdateInput = Omit<Partial<TaskReminderCreateInput>, 'dueDate'> & {
+  dueDate?: string | null
   status?: TaskReminder['status']
   completed?: boolean
   completedAt?: string | null

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1982,6 +1982,48 @@ export type Database = {
         }
         Relationships: []
       }
+      warehouse_items: {
+        Row: {
+          id: number
+          user_id: string
+          name: string
+          type: 'fertilizer' | 'spray'
+          quantity: number
+          unit: 'kg' | 'liter' | 'gram' | 'ml'
+          unit_price: number
+          reorder_quantity: number | null
+          notes: string | null
+          created_at: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          id?: number
+          user_id: string
+          name: string
+          type: 'fertilizer' | 'spray'
+          quantity: number
+          unit: 'kg' | 'liter' | 'gram' | 'ml'
+          unit_price: number
+          reorder_quantity?: number | null
+          notes?: string | null
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          id?: number
+          user_id?: string
+          name?: string
+          type?: 'fertilizer' | 'spray'
+          quantity?: number
+          unit?: 'kg' | 'liter' | 'gram' | 'ml'
+          unit_price?: number
+          reorder_quantity?: number | null
+          notes?: string | null
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
       organizations: {
         Row: {
           id: string
@@ -2020,7 +2062,7 @@ export type Database = {
           id: string
           organization_id: string
           user_id: string
-          role: string
+          role: 'owner' | 'admin' | 'agronomist'
           is_owner: boolean | null
           joined_at: string | null
         }
@@ -2028,7 +2070,7 @@ export type Database = {
           id?: string
           organization_id: string
           user_id: string
-          role?: string
+          role?: 'owner' | 'admin' | 'agronomist'
           is_owner?: boolean | null
           joined_at?: string | null
         }
@@ -2036,7 +2078,7 @@ export type Database = {
           id?: string
           organization_id?: string
           user_id?: string
-          role?: string
+          role?: 'owner' | 'admin' | 'agronomist'
           is_owner?: boolean | null
           joined_at?: string | null
         }
@@ -2055,25 +2097,37 @@ export type Database = {
           id: string
           organization_id: string
           client_user_id: string
+          assigned_to: string | null
           assigned_by: string | null
+          status: 'active' | 'inactive' | 'pending'
           assigned_at: string | null
           notes: string | null
+          created_at: string | null
+          updated_at: string | null
         }
         Insert: {
           id?: string
           organization_id: string
           client_user_id: string
+          assigned_to?: string | null
           assigned_by?: string | null
+          status?: 'active' | 'inactive' | 'pending'
           assigned_at?: string | null
           notes?: string | null
+          created_at?: string | null
+          updated_at?: string | null
         }
         Update: {
           id?: string
           organization_id?: string
           client_user_id?: string
+          assigned_to?: string | null
           assigned_by?: string | null
+          status?: 'active' | 'inactive' | 'pending'
           assigned_at?: string | null
           notes?: string | null
+          created_at?: string | null
+          updated_at?: string | null
         }
         Relationships: [
           {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1750,7 +1750,7 @@ export type Database = {
           created_at: string | null
           created_by: string | null
           description: string | null
-          due_date: string
+          due_date: string | null
           estimated_duration_minutes: number | null
           farm_id: number | null
           id: number
@@ -1770,7 +1770,7 @@ export type Database = {
           created_at?: string | null
           created_by?: string | null
           description?: string | null
-          due_date: string
+          due_date?: string | null
           estimated_duration_minutes?: number | null
           farm_id?: number | null
           id?: number
@@ -1790,7 +1790,7 @@ export type Database = {
           created_at?: string | null
           created_by?: string | null
           description?: string | null
-          due_date?: string
+          due_date?: string | null
           estimated_duration_minutes?: number | null
           farm_id?: number | null
           id?: number

--- a/supabase/supabase-schema.sql
+++ b/supabase/supabase-schema.sql
@@ -1076,7 +1076,10 @@ CREATE POLICY "Admins can delete organization members" ON organization_members F
 -- RLS Policies for organization_clients
 CREATE POLICY "Members can view organization clients" ON organization_clients FOR SELECT USING (
   client_user_id = auth.uid()
-  OR EXISTS (SELECT 1 FROM organization_members om WHERE om.organization_id = organization_clients.organization_id AND om.user_id = auth.uid())
+  OR (
+    status = 'active'
+    AND EXISTS (SELECT 1 FROM organization_members om WHERE om.organization_id = organization_clients.organization_id AND om.user_id = auth.uid())
+  )
 );
 CREATE POLICY "Admins can insert organization clients" ON organization_clients FOR INSERT WITH CHECK (
   EXISTS (SELECT 1 FROM organization_members om WHERE om.organization_id = organization_clients.organization_id AND om.user_id = auth.uid() AND (om.role IN ('owner', 'admin') OR om.is_owner = TRUE))

--- a/supabase/supabase-schema.sql
+++ b/supabase/supabase-schema.sql
@@ -321,8 +321,27 @@ CREATE TRIGGER validate_task_linked_record_trigger
   FOR EACH ROW
   EXECUTE FUNCTION validate_task_linked_record();
 
+-- Create warehouse_items table
+CREATE TABLE warehouse_items (
+  id BIGSERIAL PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  name VARCHAR(255) NOT NULL,
+  type VARCHAR(50) NOT NULL CHECK (type IN ('fertilizer', 'spray')),
+  quantity DECIMAL(12,2) NOT NULL DEFAULT 0 CHECK (quantity >= 0),
+  unit VARCHAR(50) NOT NULL CHECK (unit IN ('kg', 'liter', 'gram', 'ml')),
+  unit_price DECIMAL(12,2) NOT NULL DEFAULT 0 CHECK (unit_price >= 0),
+  reorder_quantity DECIMAL(12,2) CHECK (reorder_quantity IS NULL OR reorder_quantity >= 0),
+  notes TEXT,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_warehouse_items_user_id ON warehouse_items(user_id);
+CREATE INDEX idx_warehouse_items_user_type ON warehouse_items(user_id, type);
+
 -- Enable Row Level Security
 ALTER TABLE task_reminders ENABLE ROW LEVEL SECURITY;
+ALTER TABLE warehouse_items ENABLE ROW LEVEL SECURITY;
 
 -- Create soil_test_records table
 CREATE TABLE soil_test_records (
@@ -535,6 +554,12 @@ CREATE POLICY "Users can delete farm tasks" ON task_reminders FOR DELETE USING (
     AND farms.user_id = auth.uid()
   )
 );
+
+-- Warehouse items
+CREATE POLICY "Users can view their warehouse items" ON warehouse_items FOR SELECT USING (user_id = auth.uid());
+CREATE POLICY "Users can insert their warehouse items" ON warehouse_items FOR INSERT WITH CHECK (user_id = auth.uid());
+CREATE POLICY "Users can update their warehouse items" ON warehouse_items FOR UPDATE USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+CREATE POLICY "Users can delete their warehouse items" ON warehouse_items FOR DELETE USING (user_id = auth.uid());
 
 -- Soil test records
 CREATE POLICY "Users can view their farm soil test records" ON soil_test_records FOR SELECT USING (
@@ -786,6 +811,9 @@ FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 CREATE TRIGGER update_temporary_worker_entries_updated_at BEFORE UPDATE ON temporary_worker_entries
 FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
+CREATE TRIGGER update_warehouse_items_updated_at BEFORE UPDATE ON warehouse_items
+FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
 -- ============================================================================
 -- END WORKER / LABOR MANAGEMENT TABLES
 -- ============================================================================
@@ -924,7 +952,7 @@ CREATE TABLE organization_members (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
   organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
   user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
-  role VARCHAR(50) DEFAULT 'agronomist' CHECK (role IN ('owner', 'admin', 'agronomist')),
+  role VARCHAR(50) DEFAULT 'agronomist' NOT NULL CHECK (role IN ('owner', 'admin', 'agronomist')),
   is_owner BOOLEAN DEFAULT FALSE,
   joined_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
   UNIQUE(organization_id, user_id)
@@ -938,7 +966,7 @@ CREATE TABLE organization_clients (
   client_user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
   assigned_to UUID REFERENCES auth.users(id) ON DELETE SET NULL,
   assigned_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
-  status VARCHAR(50) DEFAULT 'active' CHECK (status IN ('active', 'inactive', 'pending')),
+  status VARCHAR(50) DEFAULT 'active' NOT NULL CHECK (status IN ('active', 'inactive', 'pending')),
   notes TEXT,
   assigned_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
@@ -995,6 +1023,7 @@ CREATE INDEX idx_organization_members_user_id ON organization_members(user_id);
 CREATE INDEX idx_organization_clients_organization_id ON organization_clients(organization_id);
 CREATE INDEX idx_organization_clients_client_user_id ON organization_clients(client_user_id);
 CREATE INDEX idx_organization_clients_assigned_to ON organization_clients(assigned_to);
+CREATE UNIQUE INDEX idx_organization_clients_one_active_per_client ON organization_clients(client_user_id) WHERE status = 'active';
 CREATE INDEX idx_farmer_invitations_organization_id ON farmer_invitations(organization_id);
 CREATE INDEX idx_farmer_invitations_token ON farmer_invitations(token);
 CREATE INDEX idx_farmer_invitations_status ON farmer_invitations(status);
@@ -1053,6 +1082,8 @@ CREATE POLICY "Admins can insert organization clients" ON organization_clients F
   EXISTS (SELECT 1 FROM organization_members om WHERE om.organization_id = organization_clients.organization_id AND om.user_id = auth.uid() AND (om.role IN ('owner', 'admin') OR om.is_owner = TRUE))
 );
 CREATE POLICY "Admins can update organization clients" ON organization_clients FOR UPDATE USING (
+  EXISTS (SELECT 1 FROM organization_members om WHERE om.organization_id = organization_clients.organization_id AND om.user_id = auth.uid() AND (om.role IN ('owner', 'admin') OR om.is_owner = TRUE))
+) WITH CHECK (
   EXISTS (SELECT 1 FROM organization_members om WHERE om.organization_id = organization_clients.organization_id AND om.user_id = auth.uid() AND (om.role IN ('owner', 'admin') OR om.is_owner = TRUE))
 );
 CREATE POLICY "Admins can delete organization clients" ON organization_clients FOR DELETE USING (

--- a/supabase/supabase-schema.sql
+++ b/supabase/supabase-schema.sql
@@ -220,7 +220,7 @@ CREATE TABLE task_reminders (
   type VARCHAR(50) CHECK (type IN ('irrigation', 'spray', 'fertigation', 'harvest', 'soil_test', 'petiole_test', 'expense', 'note')) NOT NULL,
   status VARCHAR(20) CHECK (status IN ('pending', 'in_progress', 'completed', 'cancelled')) DEFAULT 'pending' NOT NULL,
   priority VARCHAR(10) CHECK (priority IN ('low', 'medium', 'high')) DEFAULT 'medium',
-  due_date TIMESTAMP WITH TIME ZONE NOT NULL,
+  due_date TIMESTAMP WITH TIME ZONE,
   estimated_duration_minutes INTEGER CHECK (estimated_duration_minutes IS NULL OR estimated_duration_minutes >= 0),
   location TEXT,
   linked_record_type VARCHAR(50),
@@ -1050,12 +1050,10 @@ CREATE POLICY "Members can view organization clients" ON organization_clients FO
   OR EXISTS (SELECT 1 FROM organization_members om WHERE om.organization_id = organization_clients.organization_id AND om.user_id = auth.uid())
 );
 CREATE POLICY "Admins can insert organization clients" ON organization_clients FOR INSERT WITH CHECK (
-  client_user_id = auth.uid()
-  OR EXISTS (SELECT 1 FROM organization_members om WHERE om.organization_id = organization_clients.organization_id AND om.user_id = auth.uid() AND (om.role IN ('owner', 'admin') OR om.is_owner = TRUE))
+  EXISTS (SELECT 1 FROM organization_members om WHERE om.organization_id = organization_clients.organization_id AND om.user_id = auth.uid() AND (om.role IN ('owner', 'admin') OR om.is_owner = TRUE))
 );
 CREATE POLICY "Admins can update organization clients" ON organization_clients FOR UPDATE USING (
-  client_user_id = auth.uid()
-  OR EXISTS (SELECT 1 FROM organization_members om WHERE om.organization_id = organization_clients.organization_id AND om.user_id = auth.uid() AND (om.role IN ('owner', 'admin') OR om.is_owner = TRUE))
+  EXISTS (SELECT 1 FROM organization_members om WHERE om.organization_id = organization_clients.organization_id AND om.user_id = auth.uid() AND (om.role IN ('owner', 'admin') OR om.is_owner = TRUE))
 );
 CREATE POLICY "Admins can delete organization clients" ON organization_clients FOR DELETE USING (
   EXISTS (SELECT 1 FROM organization_members om WHERE om.organization_id = organization_clients.organization_id AND om.user_id = auth.uid() AND (om.role IN ('owner', 'admin') OR om.is_owner = TRUE))

--- a/supabase/supabase-schema.sql
+++ b/supabase/supabase-schema.sql
@@ -924,10 +924,26 @@ CREATE TABLE organization_members (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
   organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
   user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
-  role VARCHAR(50) DEFAULT 'member' CHECK (role IN ('owner', 'admin', 'member')),
+  role VARCHAR(50) DEFAULT 'agronomist' CHECK (role IN ('owner', 'admin', 'agronomist')),
   is_owner BOOLEAN DEFAULT FALSE,
   joined_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
   UNIQUE(organization_id, user_id)
+);
+
+-- Organization clients table
+-- Canonical mapping between consultant organizations and farmer users.
+CREATE TABLE organization_clients (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  client_user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  assigned_to UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  assigned_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  status VARCHAR(50) DEFAULT 'active' CHECK (status IN ('active', 'inactive', 'pending')),
+  notes TEXT,
+  assigned_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE(organization_id, client_user_id)
 );
 
 -- Farmer invitations table
@@ -976,6 +992,9 @@ CREATE INDEX idx_organizations_created_by ON organizations(created_by);
 CREATE INDEX idx_organizations_slug ON organizations(slug);
 CREATE INDEX idx_organization_members_organization_id ON organization_members(organization_id);
 CREATE INDEX idx_organization_members_user_id ON organization_members(user_id);
+CREATE INDEX idx_organization_clients_organization_id ON organization_clients(organization_id);
+CREATE INDEX idx_organization_clients_client_user_id ON organization_clients(client_user_id);
+CREATE INDEX idx_organization_clients_assigned_to ON organization_clients(assigned_to);
 CREATE INDEX idx_farmer_invitations_organization_id ON farmer_invitations(organization_id);
 CREATE INDEX idx_farmer_invitations_token ON farmer_invitations(token);
 CREATE INDEX idx_farmer_invitations_status ON farmer_invitations(status);
@@ -985,6 +1004,7 @@ CREATE INDEX idx_fertilizer_plan_items_plan_id ON fertilizer_plan_items(plan_id)
 
 -- Composite indexes for AI and analytics queries
 CREATE INDEX idx_organization_members_org_user ON organization_members(organization_id, user_id);
+CREATE INDEX idx_organization_clients_org_client ON organization_clients(organization_id, client_user_id);
 CREATE INDEX idx_fertilizer_plans_org_farm ON fertilizer_plans(organization_id, farm_id);
 CREATE INDEX idx_fertilizer_plan_items_plan_date ON fertilizer_plan_items(plan_id, application_date);
 
@@ -992,6 +1012,7 @@ CREATE INDEX idx_fertilizer_plan_items_plan_date ON fertilizer_plan_items(plan_i
 -- Enable Row Level Security for organization tables
 ALTER TABLE organizations ENABLE ROW LEVEL SECURITY;
 ALTER TABLE organization_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE organization_clients ENABLE ROW LEVEL SECURITY;
 ALTER TABLE farmer_invitations ENABLE ROW LEVEL SECURITY;
 ALTER TABLE fertilizer_plans ENABLE ROW LEVEL SECURITY;
 ALTER TABLE fertilizer_plan_items ENABLE ROW LEVEL SECURITY;
@@ -1023,12 +1044,34 @@ CREATE POLICY "Admins can delete organization members" ON organization_members F
   EXISTS (SELECT 1 FROM organization_members om WHERE om.organization_id = organization_members.organization_id AND om.user_id = auth.uid() AND (om.role IN ('owner', 'admin') OR om.is_owner = TRUE))
 );
 
+-- RLS Policies for organization_clients
+CREATE POLICY "Members can view organization clients" ON organization_clients FOR SELECT USING (
+  client_user_id = auth.uid()
+  OR EXISTS (SELECT 1 FROM organization_members om WHERE om.organization_id = organization_clients.organization_id AND om.user_id = auth.uid())
+);
+CREATE POLICY "Admins can insert organization clients" ON organization_clients FOR INSERT WITH CHECK (
+  client_user_id = auth.uid()
+  OR EXISTS (SELECT 1 FROM organization_members om WHERE om.organization_id = organization_clients.organization_id AND om.user_id = auth.uid() AND (om.role IN ('owner', 'admin') OR om.is_owner = TRUE))
+);
+CREATE POLICY "Admins can update organization clients" ON organization_clients FOR UPDATE USING (
+  client_user_id = auth.uid()
+  OR EXISTS (SELECT 1 FROM organization_members om WHERE om.organization_id = organization_clients.organization_id AND om.user_id = auth.uid() AND (om.role IN ('owner', 'admin') OR om.is_owner = TRUE))
+);
+CREATE POLICY "Admins can delete organization clients" ON organization_clients FOR DELETE USING (
+  EXISTS (SELECT 1 FROM organization_members om WHERE om.organization_id = organization_clients.organization_id AND om.user_id = auth.uid() AND (om.role IN ('owner', 'admin') OR om.is_owner = TRUE))
+);
+
 -- Additional profiles RLS policy for org-based access (added here after organization_members exists)
 CREATE POLICY "Users can view org member profiles" ON profiles FOR SELECT TO authenticated USING (
   EXISTS (
     SELECT 1 FROM organization_members om1
     JOIN organization_members om2 ON om1.organization_id = om2.organization_id
     WHERE om1.user_id = auth.uid() AND om2.user_id = profiles.id
+  )
+  OR EXISTS (
+    SELECT 1 FROM organization_members om
+    JOIN organization_clients oc ON oc.organization_id = om.organization_id
+    WHERE om.user_id = auth.uid() AND oc.client_user_id = profiles.id
   )
 );
 
@@ -1097,6 +1140,11 @@ CREATE POLICY "Org members can delete fertilizer plan items" ON fertilizer_plan_
 -- Trigger to update fertilizer_plans updated_at timestamp
 CREATE TRIGGER update_fertilizer_plans_updated_at
   BEFORE UPDATE ON fertilizer_plans
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_organization_clients_updated_at
+  BEFORE UPDATE ON organization_clients
   FOR EACH ROW
   EXECUTE FUNCTION update_updated_at_column();
 

--- a/supabase/supabase-schema.sql
+++ b/supabase/supabase-schema.sql
@@ -1100,7 +1100,7 @@ CREATE POLICY "Users can view org member profiles" ON profiles FOR SELECT TO aut
   OR EXISTS (
     SELECT 1 FROM organization_members om
     JOIN organization_clients oc ON oc.organization_id = om.organization_id
-    WHERE om.user_id = auth.uid() AND oc.client_user_id = profiles.id
+    WHERE om.user_id = auth.uid() AND oc.client_user_id = profiles.id AND oc.status = 'active'
   )
 );
 


### PR DESCRIPTION
## Summary
- normalize organization member roles to owner/admin/agronomist
- add organization_clients as the canonical consultant-to-farmer mapping with assignment/status fields
- update org creation, client linking, settings status, and organization service reads/writes to use organization_clients
- include small compile fixes needed for a green foundation branch without pulling in the full consultant dashboard UI

## Testing
- bun run typecheck
- bun run lint (passes with existing warnings)
- set -a; source /Users/ashishhuddar/vinesight-web/.env.local; set +a; bun run build
- Computer Use smoke: /settings renders auth gate on localhost; /signup/org and /users returned 200 from dev server but showed blank protected/loading surface in Chrome, so those need authenticated follow-up testing before merging UI work

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce `organization_clients` as the canonical consultant-to-farmer link and update APIs, `OrganizationService`, and Settings to use it. Enforces one active org per client, strict owner/admin controls, validated assignments, preserves assignments on self-join/re-add, restricts RLS visibility to active links, orders client lists by recent updates, and keeps a temporary profile mirror.

- **New Features**
  - Added `organization_clients` with `assigned_to`, `status`, timestamps, `updated_at` trigger, RLS, and indexes (including one-active-per-client); updated types and reads.
  - Updated APIs and `OrganizationService` to upsert `organization_clients`, validate `assignedTo` is an org member, disallow assignment on self-join (null allowed), preserve assignments on self-join/re-add, require owner/admin (explicit `owner` role), and return 409 if a client is active in another org; org creators are set to `owner`; clients list returns only active links with limited profile fields ordered by `updated_at` desc; Settings resolves org via active `organization_clients`; invite permission check includes `owner`; legacy profile mirror updated best-effort.
  - Minor: `task_reminders.due_date` is nullable; task creation uses `farmId`, `dueDate`, and `type='fertigation'`; lab trend charts use ISO dates; default fertigation activity note; small dashboard error capture tweak.

- **Migration**
  - Apply `supabase/supabase-schema.sql` to create `organization_clients` and `warehouse_items`, add RLS (including org-member access limited to active clients and their profiles), indexes (plus unique partial index for one active org per client), and `updated_at` triggers; set `organization_members.role` default to `agronomist`; make `task_reminders.due_date` nullable.
  - Optional: backfill from `profiles.consultant_organization_id` into `organization_clients`; no UI changes required due to the profile mirror.

<sup>Written for commit 9221912d278427cc7a5c6cf61a855d81d9351a07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ashish921998/Vinesight/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Warehouse items management for fertilizers/sprays.
  * Assign organization clients to team members with assignment/status tracking.
  * Organization creators recorded as owners.

* **Bug Fixes**
  * Normalized lab test chart dates for consistent display.

* **Improvements**
  * Stricter admin/owner permission checks for invites and client actions.
  * Updated fertilizer task payloads and nullable task-reminder due dates.
  * Settings now detect current organization via active client links.
  * Improved fallback note for fertigation activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->