### PR TITLE
feat: add consultant farmer directory

### DIFF
--- a/src/app/consultant/farmers/[farmerId]/farms/[farmId]/page.tsx
+++ b/src/app/consultant/farmers/[farmerId]/farms/[farmId]/page.tsx
@@ -1,0 +1,485 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import {
+  ArrowLeft,
+  Loader2,
+  MapPin,
+  Grape,
+  Calendar,
+  TestTube,
+  Leaf,
+  FileImage,
+  ExternalLink
+} from 'lucide-react'
+import Image from 'next/image'
+import { toast } from 'sonner'
+import type { LabTestRecord } from '@/types/lab-tests'
+import { getConsultantAccess, type ConsultantAccess } from '@/lib/consultant-access'
+import {
+  validateFarmerClient,
+  getFarmDetail,
+  type FarmDetail
+} from '@/lib/consultant-query-service'
+import { SupabaseService } from '@/lib/supabase-service'
+
+export default function ConsultantFarmPage() {
+  const params = useParams()
+  const router = useRouter()
+  const farmerId = params.farmerId as string
+  const farmId = parseInt(params.farmId as string, 10)
+
+  const [loading, setLoading] = useState(true)
+  const [farm, setFarm] = useState<FarmDetail | null>(null)
+  const [soilTests, setSoilTests] = useState<LabTestRecord[]>([])
+  const [petioleTests, setPetioleTests] = useState<LabTestRecord[]>([])
+  const [farmerName, setFarmerName] = useState<string>('')
+
+  const loadData = useCallback(async () => {
+    try {
+      setLoading(true)
+
+      const access = await getConsultantAccess()
+      if (!access) {
+        toast.error('Not authenticated')
+        return
+      }
+
+      // Validate farmer belongs to org through organization_clients
+      const validation = await validateFarmerClient(access, farmerId)
+      if (!validation.isValid) {
+        toast.error('Farmer not found or not authorized')
+        router.push('/consultant/farmers')
+        return
+      }
+
+      // Validate farm belongs to farmer through farms.user_id
+      const farmData = await getFarmDetail(farmId)
+      if (!farmData || farmData.user_id !== farmerId) {
+        toast.error('Farm not found or does not belong to this farmer')
+        router.push(`/consultant/farmers/${farmerId}`)
+        return
+      }
+
+      setFarm(farmData)
+
+      // Fetch lab test records that are already safe to display
+      const [soilTestsData, petioleTestsData, profile] = await Promise.all([
+        SupabaseService.getSoilTestRecords(farmId),
+        SupabaseService.getPetioleTestRecords(farmId),
+        supabaseGetFarmerProfile(farmerId)
+      ])
+
+      setSoilTests((soilTestsData || []) as LabTestRecord[])
+      setPetioleTests((petioleTestsData || []) as LabTestRecord[])
+      setFarmerName(profile?.full_name || 'Farmer')
+    } catch (error) {
+      console.error('Error loading farm data:', error)
+      toast.error(error instanceof Error ? error.message : 'Failed to load farm data')
+    } finally {
+      setLoading(false)
+    }
+  }, [farmerId, farmId, router])
+
+  useEffect(() => {
+    loadData()
+  }, [loadData])
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <div className="text-center space-y-3">
+          <Loader2 className="h-8 w-8 animate-spin text-primary mx-auto" />
+          <p className="text-sm text-muted-foreground">Loading farm data...</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (!farm) {
+    return (
+      <div className="space-y-6">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => router.push(`/consultant/farmers/${farmerId}`)}
+          className="flex items-center gap-2 -ml-2"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Farmer
+        </Button>
+        <Card>
+          <CardContent className="flex flex-col items-center justify-center py-12">
+            <MapPin className="h-12 w-12 text-muted-foreground mb-4" />
+            <h2 className="text-xl font-semibold mb-2">Farm Not Found</h2>
+            <p className="text-muted-foreground">
+              This farm could not be found or does not belong to this farmer.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="space-y-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => router.push(`/consultant/farmers/${farmerId}`)}
+          className="flex items-center gap-2 -ml-2"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to {farmerName}
+        </Button>
+        <div className="flex items-center gap-3">
+          <Grape className="h-8 w-8 text-purple-600" />
+          <div>
+            <h1 className="text-2xl sm:text-3xl font-bold">{farm.name}</h1>
+            <p className="text-muted-foreground flex items-center gap-1">
+              <MapPin className="h-4 w-4" />
+              {farm.region}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Farm Info Card */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Farm Details</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+            <div>
+              <p className="text-sm text-muted-foreground">Variety</p>
+              <p className="font-medium">{farm.crop_variety || 'N/A'}</p>
+            </div>
+            <div>
+              <p className="text-sm text-muted-foreground">Area</p>
+              <p className="font-medium">{farm.area ? `${farm.area} acres` : 'N/A'}</p>
+            </div>
+            <div>
+              <p className="text-sm text-muted-foreground">Last Pruning</p>
+              <p className="font-medium flex items-center gap-1">
+                <Calendar className="h-3.5 w-3.5" />
+                {farm.date_of_pruning ? new Date(farm.date_of_pruning).toLocaleDateString() : 'N/A'}
+              </p>
+            </div>
+            <div>
+              <p className="text-sm text-muted-foreground">Owner</p>
+              <p className="font-medium">{farmerName}</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Soil Properties Card */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <TestTube className="h-5 w-5 text-amber-600" />
+            Soil Properties
+          </CardTitle>
+          <CardDescription>Physical and chemical soil characteristics</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+            <div>
+              <p className="text-sm text-muted-foreground">Texture Class</p>
+              <p className="font-medium">{farm.soil_texture_class || 'N/A'}</p>
+            </div>
+            <div>
+              <p className="text-sm text-muted-foreground">Bulk Density</p>
+              <p className="font-medium">
+                {farm.bulk_density ? `${farm.bulk_density} g/ml` : 'N/A'}
+              </p>
+            </div>
+            <div>
+              <p className="text-sm text-muted-foreground">CEC</p>
+              <p className="font-medium">
+                {farm.cation_exchange_capacity
+                  ? `${farm.cation_exchange_capacity} meq/100g`
+                  : 'N/A'}
+              </p>
+            </div>
+            <div>
+              <p className="text-sm text-muted-foreground">Water Retention</p>
+              <p className="font-medium">
+                {farm.soil_water_retention ? `${farm.soil_water_retention} mm/m` : 'N/A'}
+              </p>
+            </div>
+          </div>
+
+          {/* Soil Composition */}
+          {(farm.sand_percentage || farm.silt_percentage || farm.clay_percentage) && (
+            <div className="mt-6">
+              <p className="text-sm font-medium text-muted-foreground mb-3">Soil Composition</p>
+              <div className="grid grid-cols-3 gap-4">
+                <div className="bg-amber-50 rounded-lg p-3 text-center">
+                  <p className="text-2xl font-bold text-amber-700">
+                    {farm.sand_percentage ?? '-'}%
+                  </p>
+                  <p className="text-sm text-amber-600">Sand</p>
+                </div>
+                <div className="bg-stone-100 rounded-lg p-3 text-center">
+                  <p className="text-2xl font-bold text-stone-700">
+                    {farm.silt_percentage ?? '-'}%
+                  </p>
+                  <p className="text-sm text-stone-600">Silt</p>
+                </div>
+                <div className="bg-orange-50 rounded-lg p-3 text-center">
+                  <p className="text-2xl font-bold text-orange-700">
+                    {farm.clay_percentage ?? '-'}%
+                  </p>
+                  <p className="text-sm text-orange-600">Clay</p>
+                </div>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Lab Tests Section */}
+      <div className="space-y-4">
+        <h2 className="text-xl font-semibold">Lab Test Analysis</h2>
+
+        <Tabs defaultValue="soil" className="w-full">
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="soil" className="flex items-center gap-2">
+              <TestTube className="h-4 w-4" />
+              Soil Tests ({soilTests.length})
+            </TabsTrigger>
+            <TabsTrigger value="petiole" className="flex items-center gap-2">
+              <Leaf className="h-4 w-4" />
+              Petiole Tests ({petioleTests.length})
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="soil" className="space-y-4">
+            {soilTests.length === 0 ? (
+              <Card>
+                <CardContent className="flex flex-col items-center justify-center py-12">
+                  <TestTube className="h-12 w-12 text-muted-foreground mb-4" />
+                  <h3 className="text-lg font-semibold mb-2">No Soil Tests</h3>
+                  <p className="text-muted-foreground">No soil test records found for this farm.</p>
+                </CardContent>
+              </Card>
+            ) : (
+              <div className="grid gap-4">
+                {soilTests.map((test) => (
+                  <TestCard key={test.id} test={test} type="soil" />
+                ))}
+              </div>
+            )}
+          </TabsContent>
+
+          <TabsContent value="petiole" className="space-y-4">
+            {petioleTests.length === 0 ? (
+              <Card>
+                <CardContent className="flex flex-col items-center justify-center py-12">
+                  <Leaf className="h-12 w-12 text-muted-foreground mb-4" />
+                  <h3 className="text-lg font-semibold mb-2">No Petiole Tests</h3>
+                  <p className="text-muted-foreground">
+                    No petiole test records found for this farm.
+                  </p>
+                </CardContent>
+              </Card>
+            ) : (
+              <div className="grid gap-4">
+                {petioleTests.map((test) => (
+                  <TestCard key={test.id} test={test} type="petiole" />
+                ))}
+              </div>
+            )}
+          </TabsContent>
+        </Tabs>
+      </div>
+    </div>
+  )
+}
+
+function TestCard({ test, type }: { test: LabTestRecord; type: 'soil' | 'petiole' }) {
+  const [reportUrl, setReportUrl] = useState<string | null>(null)
+  const [loadingReport, setLoadingReport] = useState(false)
+
+  const loadReportUrl = useCallback(async () => {
+    if (!test.report_storage_path || reportUrl) return
+
+    setLoadingReport(true)
+    try {
+      const response = await fetch('/api/test-reports/signed-url', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: test.report_storage_path })
+      })
+
+      if (response.ok) {
+        const { signedUrl } = await response.json()
+        setReportUrl(signedUrl)
+      }
+    } catch (error) {
+      console.error('Error loading report:', error)
+    } finally {
+      setLoadingReport(false)
+    }
+  }, [test.report_storage_path, reportUrl])
+
+  useEffect(() => {
+    if (test.report_storage_path) {
+      loadReportUrl()
+    }
+  }, [test.report_storage_path, loadReportUrl])
+
+  const parameters = test.parameters || {}
+  const paramKeys = Object.keys(parameters)
+
+  const keyParams =
+    type === 'soil'
+      ? ['ph', 'ec', 'nitrogen', 'phosphorus', 'potassium']
+      : ['total_nitrogen', 'nitrate_nitrogen', 'phosphorus', 'potassium', 'calcium']
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle className="text-lg flex items-center gap-2">
+              {type === 'soil' ? (
+                <TestTube className="h-5 w-5 text-amber-600" />
+              ) : (
+                <Leaf className="h-5 w-5 text-green-600" />
+              )}
+              {type === 'soil' ? 'Soil Test' : 'Petiole Test'}
+            </CardTitle>
+            <CardDescription className="flex items-center gap-1">
+              <Calendar className="h-3.5 w-3.5" />
+              {new Date(test.date).toLocaleDateString()}
+            </CardDescription>
+          </div>
+          {test.report_storage_path && reportUrl && (
+            <Button variant="outline" size="sm" asChild>
+              <a href={reportUrl} target="_blank" rel="noopener noreferrer">
+                <FileImage className="h-4 w-4 mr-1" />
+                View Report
+                <ExternalLink className="h-3 w-3 ml-1" />
+              </a>
+            </Button>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        {/* Key Parameters */}
+        <div className="mb-4">
+          <p className="text-sm font-medium text-muted-foreground mb-2">Key Parameters</p>
+          <div className="grid grid-cols-3 sm:grid-cols-5 gap-3">
+            {keyParams.map((key) => {
+              const value = parameters[key]
+              if (value === undefined) return null
+              return (
+                <div key={key} className="bg-muted/50 rounded-lg p-2 text-center">
+                  <p className="text-xs text-muted-foreground capitalize">
+                    {key.replace(/_/g, ' ')}
+                  </p>
+                  <p className="font-semibold">
+                    {typeof value === 'number' ? value.toFixed(2) : value}
+                  </p>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* All Parameters */}
+        {paramKeys.length > 0 && (
+          <details className="group">
+            <summary className="text-sm text-muted-foreground cursor-pointer hover:text-foreground">
+              View all {paramKeys.length} parameters
+            </summary>
+            <div className="mt-3 grid grid-cols-2 sm:grid-cols-4 gap-2 text-sm">
+              {paramKeys.map((key) => (
+                <div key={key} className="flex justify-between bg-muted/30 rounded px-2 py-1">
+                  <span className="text-muted-foreground capitalize">{key.replace(/_/g, ' ')}</span>
+                  <span className="font-medium">
+                    {typeof parameters[key] === 'number'
+                      ? parameters[key].toFixed(2)
+                      : parameters[key]}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </details>
+        )}
+
+        {/* Report Preview */}
+        {test.report_storage_path && (
+          <div className="mt-4 pt-4 border-t">
+            <p className="text-sm font-medium text-muted-foreground mb-2">Report Preview</p>
+            {loadingReport ? (
+              <div className="flex items-center justify-center h-32 bg-muted/30 rounded-lg">
+                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+              </div>
+            ) : reportUrl ? (
+              <div className="relative aspect-[3/2] max-h-48 overflow-hidden rounded-lg border bg-muted/30">
+                {test.report_storage_path.endsWith('.pdf') ? (
+                  <div className="flex flex-col items-center justify-center h-full">
+                    <FileImage className="h-8 w-8 text-muted-foreground mb-2" />
+                    <a
+                      href={reportUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm text-primary hover:underline"
+                    >
+                      Open PDF Report
+                    </a>
+                  </div>
+                ) : (
+                  <div className="relative w-full h-full">
+                    <Image
+                      src={reportUrl}
+                      alt="Test Report"
+                      fill
+                      className="object-contain cursor-pointer"
+                      onClick={() => window.open(reportUrl, '_blank')}
+                      unoptimized
+                    />
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div className="flex items-center justify-center h-32 bg-muted/30 rounded-lg">
+                <p className="text-sm text-muted-foreground">Report preview unavailable</p>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Notes */}
+        {test.notes && (
+          <div className="mt-4 pt-4 border-t">
+            <p className="text-sm font-medium text-muted-foreground mb-1">Notes</p>
+            <p className="text-sm">{test.notes}</p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+// Inline helper to fetch farmer profile for the farm page header
+async function supabaseGetFarmerProfile(farmerId: string) {
+  const { getTypedSupabaseClient } = await import('@/lib/supabase')
+  const supabase = await getTypedSupabaseClient()
+  const { data } = await supabase
+    .from('profiles')
+    .select('full_name')
+    .eq('id', farmerId)
+    .maybeSingle()
+  return data
+}

--- a/src/app/consultant/farmers/[farmerId]/farms/[farmId]/page.tsx
+++ b/src/app/consultant/farmers/[farmerId]/farms/[farmId]/page.tsx
@@ -19,7 +19,7 @@ import {
 import Image from 'next/image'
 import { toast } from 'sonner'
 import type { LabTestRecord } from '@/types/lab-tests'
-import { getConsultantAccess, type ConsultantAccess } from '@/lib/consultant-access'
+import { getConsultantAccess } from '@/lib/consultant-access'
 import {
   validateFarmerClient,
   getFarmDetail,
@@ -31,7 +31,8 @@ export default function ConsultantFarmPage() {
   const params = useParams()
   const router = useRouter()
   const farmerId = params.farmerId as string
-  const farmId = parseInt(params.farmId as string, 10)
+  const rawFarmId = parseInt(params.farmId as string, 10)
+  const farmId = isNaN(rawFarmId) ? null : rawFarmId
 
   const [loading, setLoading] = useState(true)
   const [farm, setFarm] = useState<FarmDetail | null>(null)
@@ -58,6 +59,12 @@ export default function ConsultantFarmPage() {
       }
 
       // Validate farm belongs to farmer through farms.user_id
+      if (farmId === null) {
+        toast.error('Invalid farm ID')
+        router.push(`/consultant/farmers/${farmerId}`)
+        return
+      }
+
       const farmData = await getFarmDetail(farmId)
       if (!farmData || farmData.user_id !== farmerId) {
         toast.error('Farm not found or does not belong to this farmer')

--- a/src/app/consultant/farmers/[farmerId]/page.tsx
+++ b/src/app/consultant/farmers/[farmerId]/page.tsx
@@ -1,0 +1,192 @@
+'use client'
+
+import { useEffect, useState, useCallback } from 'react'
+import { useParams } from 'next/navigation'
+import Link from 'next/link'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { toast } from 'sonner'
+import { ArrowLeft, Loader2, User, Mail, Phone, Sprout, MapPin, ChevronRight } from 'lucide-react'
+import { getConsultantAccess, type ConsultantAccess } from '@/lib/consultant-access'
+import {
+  validateFarmerClient,
+  getFarmerProfile,
+  getFarmerFarms,
+  type FarmerFarm
+} from '@/lib/consultant-query-service'
+
+interface FarmerProfile {
+  id: string
+  full_name: string | null
+  email: string | null
+  phone: string | null
+}
+
+export default function FarmerProfilePage() {
+  const params = useParams()
+  const farmerId = params.farmerId as string
+
+  const [farmer, setFarmer] = useState<FarmerProfile | null>(null)
+  const [farms, setFarms] = useState<FarmerFarm[]>([])
+  const [loading, setLoading] = useState(true)
+  const [notFound, setNotFound] = useState(false)
+
+  const loadFarmerProfile = useCallback(async () => {
+    try {
+      setLoading(true)
+      setNotFound(false)
+
+      const access = await getConsultantAccess()
+      if (!access) {
+        toast.error('Not authenticated')
+        return
+      }
+
+      // Validate farmer is an active client of the organization
+      // Validate agronomist assignment if current user is agronomist
+      const validation = await validateFarmerClient(access, farmerId)
+      if (!validation.isValid) {
+        setNotFound(true)
+        return
+      }
+
+      const [profile, farmsData] = await Promise.all([
+        getFarmerProfile(farmerId),
+        getFarmerFarms(farmerId)
+      ])
+
+      if (!profile) {
+        setNotFound(true)
+        return
+      }
+
+      setFarmer(profile)
+      setFarms(farmsData)
+    } catch (error) {
+      console.error('Failed to load farmer profile:', error)
+      toast.error(error instanceof Error ? error.message : 'Failed to load farmer profile')
+    } finally {
+      setLoading(false)
+    }
+  }, [farmerId])
+
+  useEffect(() => {
+    loadFarmerProfile()
+  }, [loadFarmerProfile])
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <div className="text-center space-y-3">
+          <Loader2 className="h-8 w-8 animate-spin text-primary mx-auto" />
+          <p className="text-sm text-muted-foreground">Loading farmer profile...</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (notFound || !farmer) {
+    return (
+      <div className="space-y-6">
+        <Link href="/consultant/farmers">
+          <Button variant="ghost" size="sm">
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back to Farmers
+          </Button>
+        </Link>
+        <Card>
+          <CardContent className="p-12 text-center">
+            <User className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+            <h3 className="text-lg font-semibold">Farmer Not Found</h3>
+            <p className="text-muted-foreground mt-2">
+              This farmer does not exist or is not part of your organization.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Back button */}
+      <Link href="/consultant/farmers">
+        <Button variant="ghost" size="sm">
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Back to Farmers
+        </Button>
+      </Link>
+
+      {/* Farmer profile header */}
+      <div>
+        <h1 className="text-2xl font-bold flex items-center gap-2">
+          <User className="h-6 w-6 text-accent" />
+          {farmer.full_name || 'Unknown Farmer'}
+        </h1>
+        <div className="flex flex-wrap items-center gap-4 mt-1 text-sm text-muted-foreground">
+          {farmer.email && (
+            <span className="flex items-center gap-1">
+              <Mail className="h-3 w-3" />
+              {farmer.email}
+            </span>
+          )}
+          {farmer.phone && (
+            <span className="flex items-center gap-1">
+              <Phone className="h-3 w-3" />
+              {farmer.phone}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Farms section */}
+      <div>
+        <h2 className="text-lg font-semibold mb-3">Farms ({farms.length})</h2>
+
+        {farms.length === 0 ? (
+          <Card>
+            <CardContent className="p-12 text-center">
+              <Sprout className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+              <h3 className="text-lg font-semibold">No Farms</h3>
+              <p className="text-muted-foreground mt-2">This farmer has not added any farms yet.</p>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {farms.map((farm) => (
+              <Link key={farm.id} href={`/consultant/farmers/${farmerId}/farms/${farm.id}`}>
+                <Card className="hover:bg-muted/50 transition-colors cursor-pointer h-full">
+                  <CardHeader className="pb-2">
+                    <div className="flex items-start justify-between">
+                      <CardTitle className="text-base flex items-center gap-2">
+                        <Sprout className="h-4 w-4 text-accent flex-shrink-0" />
+                        {farm.name}
+                      </CardTitle>
+                    </div>
+                  </CardHeader>
+                  <CardContent className="pt-0">
+                    <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                      {farm.region && (
+                        <span className="flex items-center gap-1">
+                          <MapPin className="h-3 w-3" />
+                          {farm.region}
+                        </span>
+                      )}
+                      {farm.crop_variety && <span>{farm.crop_variety}</span>}
+                      {farm.area && <span>{farm.area} acres</span>}
+                      {farm.soil_texture_class && <span>{farm.soil_texture_class}</span>}
+                    </div>
+                    <div className="flex justify-end mt-3">
+                      <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                    </div>
+                  </CardContent>
+                </Card>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/consultant/farmers/page.tsx
+++ b/src/app/consultant/farmers/page.tsx
@@ -1,0 +1,232 @@
+'use client'
+
+import { useEffect, useState, useMemo } from 'react'
+import Link from 'next/link'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import { toast } from 'sonner'
+import {
+  Users,
+  Search,
+  MapPin,
+  Sprout,
+  User,
+  Phone,
+  Mail,
+  Loader2,
+  ChevronRight
+} from 'lucide-react'
+import { getConsultantAccess, type ConsultantAccess } from '@/lib/consultant-access'
+import { getFarmerClients, type FarmerWithFarms } from '@/lib/consultant-query-service'
+
+export default function FarmerDirectoryPage() {
+  const [farmers, setFarmers] = useState<FarmerWithFarms[]>([])
+  const [loading, setLoading] = useState(true)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [regionFilter, setRegionFilter] = useState<string>('all')
+  const [access, setAccess] = useState<ConsultantAccess | null>(null)
+
+  useEffect(() => {
+    loadFarmers()
+  }, [])
+
+  const loadFarmers = async () => {
+    try {
+      setLoading(true)
+      const currentAccess = await getConsultantAccess()
+      if (!currentAccess) {
+        toast.error('Not authenticated')
+        return
+      }
+      setAccess(currentAccess)
+      const data = await getFarmerClients(currentAccess)
+      setFarmers(data)
+    } catch (error) {
+      console.error('Failed to load farmers:', error)
+      toast.error(error instanceof Error ? error.message : 'Failed to load farmer directory')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // Extract unique regions
+  const regions = useMemo(() => {
+    const regionSet = new Set<string>()
+    for (const farmer of farmers) {
+      for (const farm of farmer.farms) {
+        if (farm.region) regionSet.add(farm.region)
+      }
+    }
+    return Array.from(regionSet).sort()
+  }, [farmers])
+
+  // Filtered farmers
+  const filteredFarmers = useMemo(() => {
+    return farmers.filter((farmer) => {
+      // Search filter
+      if (searchQuery) {
+        const query = searchQuery.toLowerCase()
+        const nameMatch = farmer.full_name?.toLowerCase().includes(query)
+        const farmMatch = farmer.farms.some((f) => f.name?.toLowerCase().includes(query))
+        if (!nameMatch && !farmMatch) return false
+      }
+
+      // Region filter
+      if (regionFilter !== 'all') {
+        const hasRegion = farmer.farms.some((f) => f.region === regionFilter)
+        if (!hasRegion) return false
+      }
+
+      return true
+    })
+  }, [farmers, searchQuery, regionFilter])
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <div className="text-center space-y-3">
+          <Loader2 className="h-8 w-8 animate-spin text-primary mx-auto" />
+          <p className="text-sm text-muted-foreground">Loading farmer directory...</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-bold">Farmer Directory</h1>
+        <p className="text-muted-foreground">
+          {farmers.length} farmer{farmers.length !== 1 ? 's' : ''}{' '}
+          {access?.isAgronomist ? 'assigned to you' : 'in your organization'}
+        </p>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search by farmer or farm name..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+
+        <Select value={regionFilter} onValueChange={setRegionFilter}>
+          <SelectTrigger className="w-full sm:w-[200px]">
+            <MapPin className="h-4 w-4 mr-2 text-muted-foreground" />
+            <SelectValue placeholder="All Regions" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Regions</SelectItem>
+            {regions.map((region) => (
+              <SelectItem key={region} value={region}>
+                {region}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Results */}
+      {filteredFarmers.length === 0 ? (
+        <Card>
+          <CardContent className="p-12 text-center">
+            <Users className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+            <h3 className="text-lg font-semibold">No Farmers Found</h3>
+            <p className="text-muted-foreground mt-2 max-w-md mx-auto">
+              {farmers.length === 0
+                ? 'No farmers are linked to your organization yet.'
+                : 'No farmers match your current filters. Try adjusting your search.'}
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-4">
+          {filteredFarmers.map((farmer) => (
+            <Card key={farmer.id}>
+              <CardHeader className="pb-3">
+                <div className="flex items-start justify-between">
+                  <div>
+                    <CardTitle className="text-lg flex items-center gap-2">
+                      <User className="h-5 w-5 text-accent" />
+                      <Link href={`/consultant/farmers/${farmer.id}`} className="hover:underline">
+                        {farmer.full_name || 'Unknown Farmer'}
+                      </Link>
+                    </CardTitle>
+                    <div className="flex flex-wrap items-center gap-4 mt-1 text-sm text-muted-foreground">
+                      {farmer.email && (
+                        <span className="flex items-center gap-1">
+                          <Mail className="h-3 w-3" />
+                          {farmer.email}
+                        </span>
+                      )}
+                      {farmer.phone && (
+                        <span className="flex items-center gap-1">
+                          <Phone className="h-3 w-3" />
+                          {farmer.phone}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <Badge variant="secondary" className="flex items-center gap-1">
+                    <Sprout className="h-3 w-3" />
+                    {farmer.farms.length} farm{farmer.farms.length !== 1 ? 's' : ''}
+                  </Badge>
+                </div>
+              </CardHeader>
+
+              {farmer.farms.length > 0 && (
+                <CardContent className="pt-0">
+                  <div className="space-y-2">
+                    {farmer.farms.map((farm) => (
+                      <Link
+                        key={farm.id}
+                        href={`/consultant/farmers/${farmer.id}/farms/${farm.id}`}
+                        className="block"
+                      >
+                        <div className="flex items-center gap-3 p-3 rounded-lg border bg-muted/50 hover:bg-muted transition-colors cursor-pointer">
+                          <Sprout className="h-4 w-4 text-accent flex-shrink-0" />
+
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-2">
+                              <span className="font-medium truncate">{farm.name}</span>
+                            </div>
+                            <div className="flex flex-wrap items-center gap-3 mt-1 text-xs text-muted-foreground">
+                              {farm.region && (
+                                <span className="flex items-center gap-1">
+                                  <MapPin className="h-3 w-3" />
+                                  {farm.region}
+                                </span>
+                              )}
+                              {farm.crop_variety && <span>{farm.crop_variety}</span>}
+                              {farm.area && <span>{farm.area} acres</span>}
+                              {farm.soil_texture_class && <span>{farm.soil_texture_class}</span>}
+                            </div>
+                          </div>
+
+                          <ChevronRight className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+                        </div>
+                      </Link>
+                    ))}
+                  </div>
+                </CardContent>
+              )}
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/consultant/layout.tsx
+++ b/src/app/consultant/layout.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { ProtectedRoute } from '@/components/auth/ProtectedRoute'
+import { Button } from '@/components/ui/button'
+import { Contact, ChevronLeft, ChevronRight } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { getTypedSupabaseClient } from '@/lib/supabase'
+import { toast } from 'sonner'
+import { useRouter } from 'next/navigation'
+
+interface DashboardLayoutProps {
+  children: React.ReactNode
+}
+
+const navItems = [
+  {
+    label: 'Farmers',
+    href: '/consultant/farmers',
+    icon: Contact
+  }
+]
+
+export default function ConsultantLayout({ children }: DashboardLayoutProps) {
+  const pathname = usePathname()
+  const router = useRouter()
+  const [collapsed, setCollapsed] = useState(false)
+  const [authorized, setAuthorized] = useState<boolean | null>(null)
+
+  useEffect(() => {
+    async function checkAccess() {
+      try {
+        const supabase = await getTypedSupabaseClient()
+        const {
+          data: { user }
+        } = await supabase.auth.getUser()
+
+        if (!user) {
+          setAuthorized(false)
+          return
+        }
+
+        const { data: membership } = await supabase
+          .from('organization_members')
+          .select('role, is_owner')
+          .eq('user_id', user.id)
+          .limit(1)
+          .maybeSingle()
+
+        const role = membership?.is_owner ? 'owner' : membership?.role
+        const isConsultant = role === 'owner' || role === 'admin' || role === 'agronomist'
+
+        if (!isConsultant) {
+          toast.error('Access denied. Consultant team members only.')
+          router.push('/dashboard')
+          setAuthorized(false)
+          return
+        }
+
+        setAuthorized(true)
+      } catch (error) {
+        console.error('Access check failed:', error)
+        setAuthorized(false)
+      }
+    }
+
+    checkAccess()
+  }, [router])
+
+  if (authorized === null) {
+    return (
+      <ProtectedRoute>
+        <div className="min-h-screen flex items-center justify-center">
+          <div className="animate-spin h-8 w-8 border-4 border-primary border-t-transparent rounded-full" />
+        </div>
+      </ProtectedRoute>
+    )
+  }
+
+  if (!authorized) {
+    return null
+  }
+
+  return (
+    <ProtectedRoute>
+      <div className="flex min-h-screen bg-background">
+        {/* Sidebar */}
+        <aside
+          className={cn(
+            'border-r bg-card transition-all duration-200 flex flex-col',
+            collapsed ? 'w-16' : 'w-64'
+          )}
+        >
+          <div className="p-4 border-b flex items-center justify-between">
+            {!collapsed && <span className="font-semibold text-sm">Consultant</span>}
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              onClick={() => setCollapsed(!collapsed)}
+            >
+              {collapsed ? (
+                <ChevronRight className="h-4 w-4" />
+              ) : (
+                <ChevronLeft className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
+
+          <nav className="flex-1 p-2 space-y-1">
+            {navItems.map((item) => {
+              const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`)
+              const Icon = item.icon
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className={cn(
+                    'flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-colors',
+                    isActive
+                      ? 'bg-primary/10 text-primary font-medium'
+                      : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                  )}
+                >
+                  <Icon className="h-4 w-4 flex-shrink-0" />
+                  {!collapsed && <span>{item.label}</span>}
+                </Link>
+              )
+            })}
+          </nav>
+        </aside>
+
+        {/* Main content */}
+        <main className="flex-1 overflow-auto">
+          <div className="p-4 sm:p-6 max-w-6xl mx-auto">{children}</div>
+        </main>
+      </div>
+    </ProtectedRoute>
+  )
+}

--- a/src/app/consultant/layout.tsx
+++ b/src/app/consultant/layout.tsx
@@ -7,7 +7,7 @@ import { ProtectedRoute } from '@/components/auth/ProtectedRoute'
 import { Button } from '@/components/ui/button'
 import { Contact, ChevronLeft, ChevronRight } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { getTypedSupabaseClient } from '@/lib/supabase'
+import { getConsultantAccess } from '@/lib/consultant-access'
 import { toast } from 'sonner'
 import { useRouter } from 'next/navigation'
 
@@ -32,27 +32,9 @@ export default function ConsultantLayout({ children }: DashboardLayoutProps) {
   useEffect(() => {
     async function checkAccess() {
       try {
-        const supabase = await getTypedSupabaseClient()
-        const {
-          data: { user }
-        } = await supabase.auth.getUser()
+        const access = await getConsultantAccess()
 
-        if (!user) {
-          setAuthorized(false)
-          return
-        }
-
-        const { data: membership } = await supabase
-          .from('organization_members')
-          .select('role, is_owner')
-          .eq('user_id', user.id)
-          .limit(1)
-          .maybeSingle()
-
-        const role = membership?.is_owner ? 'owner' : membership?.role
-        const isConsultant = role === 'owner' || role === 'admin' || role === 'agronomist'
-
-        if (!isConsultant) {
+        if (!access) {
           toast.error('Access denied. Consultant team members only.')
           router.push('/dashboard')
           setAuthorized(false)
@@ -80,7 +62,13 @@ export default function ConsultantLayout({ children }: DashboardLayoutProps) {
   }
 
   if (!authorized) {
-    return null
+    return (
+      <ProtectedRoute>
+        <div className="min-h-screen flex items-center justify-center">
+          <div className="animate-spin h-8 w-8 border-4 border-primary border-t-transparent rounded-full" />
+        </div>
+      </ProtectedRoute>
+    )
   }
 
   return (

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -151,7 +151,7 @@ function UsersPage() {
             <DialogHeader>
               <DialogTitle>Invite Team Member</DialogTitle>
               <DialogDescription>
-                Share this link with agronomists or admins to join your organization.
+                Share this link with consultant team members or admins to join your organization.
               </DialogDescription>
             </DialogHeader>
 
@@ -175,7 +175,7 @@ function UsersPage() {
                     </Button>
                   </div>
                   <p className="text-xs text-muted-foreground">
-                    New team members will join as agronomists
+                    New team members will join as consultant team members
                   </p>
                 </div>
               )}
@@ -197,7 +197,7 @@ function UsersPage() {
             <Users className="h-12 w-12 text-muted-foreground mb-4" />
             <h2 className="text-xl font-semibold mb-2">No Team Members</h2>
             <p className="text-muted-foreground text-center max-w-md mb-4">
-              Invite agronomists and admins to join your organization
+              Invite consultant team members and admins to join your organization
             </p>
             <Button onClick={() => setShowInviteDialog(true)} className="gap-2">
               <UserPlus className="h-4 w-4" />

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -151,7 +151,7 @@ function UsersPage() {
             <DialogHeader>
               <DialogTitle>Invite Team Member</DialogTitle>
               <DialogDescription>
-                Share this link with consultant team members or admins to join your organization.
+                Share this link with consultant team members to join your organization.
               </DialogDescription>
             </DialogHeader>
 
@@ -197,7 +197,7 @@ function UsersPage() {
             <Users className="h-12 w-12 text-muted-foreground mb-4" />
             <h2 className="text-xl font-semibold mb-2">No Team Members</h2>
             <p className="text-muted-foreground text-center max-w-md mb-4">
-              Invite consultant team members and admins to join your organization
+              Invite consultant team members to join your organization
             </p>
             <Button onClick={() => setShowInviteDialog(true)} className="gap-2">
               <UserPlus className="h-4 w-4" />

--- a/src/lib/consultant-access.ts
+++ b/src/lib/consultant-access.ts
@@ -39,7 +39,13 @@ export async function getConsultantAccess(): Promise<ConsultantAccess | null> {
     return null
   }
 
-  const role: ConsultantRole = membership.is_owner ? 'owner' : (membership.role as ConsultantRole)
+  const validRoles: string[] = ['owner', 'admin', 'agronomist']
+  const resolvedRole = membership.is_owner ? 'owner' : membership.role
+  if (!validRoles.includes(resolvedRole)) {
+    return null
+  }
+
+  const role = resolvedRole as ConsultantRole
 
   const canViewAllFarmers = role === 'owner' || role === 'admin'
 

--- a/src/lib/consultant-access.ts
+++ b/src/lib/consultant-access.ts
@@ -1,0 +1,53 @@
+import { getTypedSupabaseClient } from './supabase'
+
+export type ConsultantRole = 'owner' | 'admin' | 'agronomist'
+
+export interface ConsultantAccess {
+  userId: string
+  organizationId: string
+  role: ConsultantRole
+  canViewAllFarmers: boolean
+  isAgronomist: boolean
+}
+
+/**
+ * Returns the consultant's access context for the current session.
+ * Assumes one-org-per-user for V1 (deterministic: first membership by joined_at).
+ */
+export async function getConsultantAccess(): Promise<ConsultantAccess | null> {
+  const supabase = await getTypedSupabaseClient()
+
+  const {
+    data: { user },
+    error: authError
+  } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    return null
+  }
+
+  // Deterministic: one org per user for V1
+  const { data: membership, error: memberError } = await supabase
+    .from('organization_members')
+    .select('organization_id, role, is_owner')
+    .eq('user_id', user.id)
+    .order('joined_at', { ascending: true })
+    .limit(1)
+    .maybeSingle()
+
+  if (memberError || !membership) {
+    return null
+  }
+
+  const role: ConsultantRole = membership.is_owner ? 'owner' : (membership.role as ConsultantRole)
+
+  const canViewAllFarmers = role === 'owner' || role === 'admin'
+
+  return {
+    userId: user.id,
+    organizationId: membership.organization_id,
+    role,
+    canViewAllFarmers,
+    isAgronomist: role === 'agronomist'
+  }
+}

--- a/src/lib/consultant-query-service.ts
+++ b/src/lib/consultant-query-service.ts
@@ -1,0 +1,234 @@
+import { getTypedSupabaseClient } from './supabase'
+import { getConsultantAccess, type ConsultantAccess } from './consultant-access'
+
+export interface FarmerProfile {
+  id: string
+  full_name: string | null
+  email: string | null
+  phone: string | null
+}
+
+export interface FarmerFarm {
+  id: number
+  name: string
+  region: string | null
+  crop_variety: string | null
+  soil_texture_class: string | null
+  area: number | null
+}
+
+export interface FarmerWithFarms extends FarmerProfile {
+  farms: FarmerFarm[]
+  assigned_to: string | null
+}
+
+export interface FarmDetail {
+  id: number
+  name: string
+  region: string | null
+  crop_variety: string | null
+  area: number | null
+  date_of_pruning: string | null
+  bulk_density: number | null
+  cation_exchange_capacity: number | null
+  soil_water_retention: number | null
+  soil_texture_class: string | null
+  sand_percentage: number | null
+  silt_percentage: number | null
+  clay_percentage: number | null
+  user_id: string | null
+}
+
+/**
+ * Query active organization clients as the canonical source of truth.
+ * Owner/admin: all active org clients.
+ * Agronomist: only rows where assigned_to = user.id.
+ * Never trusts profiles.consultant_organization_id for directory reads.
+ */
+export async function getFarmerClients(access: ConsultantAccess): Promise<FarmerWithFarms[]> {
+  const supabase = await getTypedSupabaseClient()
+
+  let query = supabase
+    .from('organization_clients')
+    .select('client_user_id, assigned_to')
+    .eq('organization_id', access.organizationId)
+    .eq('status', 'active')
+
+  if (!access.canViewAllFarmers) {
+    query = query.eq('assigned_to', access.userId)
+  }
+
+  const { data: clients, error } = await query
+
+  if (error) {
+    throw new Error(`Failed to load organization clients: ${error.message}`)
+  }
+
+  if (!clients || clients.length === 0) {
+    return []
+  }
+
+  const clientUserIds = clients.map((c) => c.client_user_id)
+
+  // Fetch profile fields from profiles
+  const { data: profiles, error: profilesError } = await supabase
+    .from('profiles')
+    .select('id, full_name, email, phone')
+    .in('id', clientUserIds)
+
+  if (profilesError) {
+    throw new Error(`Failed to load farmer profiles: ${profilesError.message}`)
+  }
+
+  const profilesById = new Map((profiles ?? []).map((p) => [p.id, p as FarmerProfile]))
+
+  // Fetch farms by farms.user_id IN farmerIds
+  const { data: farms, error: farmsError } = await supabase
+    .from('farms')
+    .select('id, name, region, crop_variety, soil_texture_class, area, user_id')
+    .in('user_id', clientUserIds)
+
+  if (farmsError) {
+    throw new Error(`Failed to load farms: ${farmsError.message}`)
+  }
+
+  const farmsByUser: Record<string, FarmerFarm[]> = {}
+  for (const farm of farms ?? []) {
+    const uid = farm.user_id as string
+    if (!farmsByUser[uid]) farmsByUser[uid] = []
+    farmsByUser[uid].push({
+      id: farm.id,
+      name: farm.name,
+      region: farm.region,
+      crop_variety: farm.crop_variety,
+      soil_texture_class: farm.soil_texture_class,
+      area: farm.area
+    })
+  }
+
+  return clients.map((client) => {
+    const profile = profilesById.get(client.client_user_id)
+    return {
+      id: client.client_user_id,
+      full_name: profile?.full_name ?? null,
+      email: profile?.email ?? null,
+      phone: profile?.phone ?? null,
+      farms: farmsByUser[client.client_user_id] || [],
+      assigned_to: client.assigned_to
+    }
+  })
+}
+
+/**
+ * Validate a single farmer is an active client of the current organization.
+ * For agronomists, also validate assignment.
+ */
+export async function validateFarmerClient(
+  access: ConsultantAccess,
+  farmerId: string
+): Promise<{ isValid: boolean; assigned_to: string | null }> {
+  const supabase = await getTypedSupabaseClient()
+
+  let query = supabase
+    .from('organization_clients')
+    .select('assigned_to')
+    .eq('organization_id', access.organizationId)
+    .eq('client_user_id', farmerId)
+    .eq('status', 'active')
+    .maybeSingle()
+
+  const { data: client, error } = await query
+
+  if (error) {
+    throw new Error(`Failed to validate farmer: ${error.message}`)
+  }
+
+  if (!client) {
+    return { isValid: false, assigned_to: null }
+  }
+
+  if (!access.canViewAllFarmers && client.assigned_to !== access.userId) {
+    return { isValid: false, assigned_to: client.assigned_to }
+  }
+
+  return { isValid: true, assigned_to: client.assigned_to }
+}
+
+/**
+ * Fetch a farmer's profile fields.
+ */
+export async function getFarmerProfile(farmerId: string): Promise<FarmerProfile | null> {
+  const supabase = await getTypedSupabaseClient()
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('id, full_name, email, phone')
+    .eq('id', farmerId)
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(`Failed to load farmer profile: ${error.message}`)
+  }
+
+  return data
+}
+
+/**
+ * Fetch farms belonging to a specific farmer.
+ */
+export async function getFarmerFarms(farmerId: string): Promise<FarmerFarm[]> {
+  const supabase = await getTypedSupabaseClient()
+  const { data, error } = await supabase
+    .from('farms')
+    .select('id, name, region, crop_variety, soil_texture_class, area')
+    .eq('user_id', farmerId)
+
+  if (error) {
+    throw new Error(`Failed to load farms: ${error.message}`)
+  }
+
+  return (data ?? []).map((f) => ({
+    id: f.id,
+    name: f.name,
+    region: f.region,
+    crop_variety: f.crop_variety,
+    soil_texture_class: f.soil_texture_class,
+    area: f.area
+  }))
+}
+
+/**
+ * Fetch detailed farm data with all soil fields.
+ */
+export async function getFarmDetail(farmId: number): Promise<FarmDetail | null> {
+  const supabase = await getTypedSupabaseClient()
+  const { data, error } = await supabase
+    .from('farms')
+    .select(
+      'id, name, region, crop_variety, area, date_of_pruning, bulk_density, cation_exchange_capacity, soil_water_retention, soil_texture_class, sand_percentage, silt_percentage, clay_percentage, user_id'
+    )
+    .eq('id', farmId)
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(`Failed to load farm detail: ${error.message}`)
+  }
+
+  if (!data) return null
+
+  return {
+    id: data.id,
+    name: data.name,
+    region: data.region,
+    crop_variety: data.crop_variety,
+    area: data.area,
+    date_of_pruning: data.date_of_pruning,
+    bulk_density: data.bulk_density,
+    cation_exchange_capacity: data.cation_exchange_capacity,
+    soil_water_retention: data.soil_water_retention,
+    soil_texture_class: data.soil_texture_class,
+    sand_percentage: data.sand_percentage,
+    silt_percentage: data.silt_percentage,
+    clay_percentage: data.clay_percentage,
+    user_id: data.user_id
+  }
+}

--- a/src/lib/consultant-query-service.ts
+++ b/src/lib/consultant-query-service.ts
@@ -94,7 +94,8 @@ export async function getFarmerClients(access: ConsultantAccess): Promise<Farmer
 
   const farmsByUser: Record<string, FarmerFarm[]> = {}
   for (const farm of farms ?? []) {
-    const uid = farm.user_id as string
+    const uid = farm.user_id
+    if (!uid) continue
     if (!farmsByUser[uid]) farmsByUser[uid] = []
     farmsByUser[uid].push({
       id: farm.id,


### PR DESCRIPTION
Built on #134 DB foundation.

## What's added
- `src/lib/consultant-access.ts` — shared access helper returning userId, orgId, role (owner | admin | agronomist), and `canViewAllFarmers`.
- `src/lib/consultant-query-service.ts` — farmer query service using `organization_clients` as the canonical client mapping. Owner/admin see all active org clients; agronomists see only rows where `assigned_to = user.id`. Fetches related profiles and farms. Never trusts `profiles.consultant_organization_id` for reads.
- `/consultant/farmers` — searchable/filterable farmer list. Shows farmer name, contact, farm count, region summary, with empty state when no clients are linked. No triage indicators.
- `/consultant/farmers/[farmerId]` — validates farmer is an active client of the org, validates agronomist assignment, shows farmer profile and farm cards. Farm links use `/consultant/farmers/${farmerId}/farms/${farmId}`.
- `/consultant/farmers/[farmerId]/farms/[farmId]` — dual validation: farmer belongs to org via `organization_clients`, farm belongs to farmer via `farms.user_id`. Shows farm details and existing soil/petiole lab test records that are already safe to display.
- `/consultant/layout.tsx` — consultant route authorization. `/consultant/*` allows owner, admin, agronomist. Farmers and unrelated users are denied with a redirect to `/dashboard`.
- Copy update: "agronomist consultants" → "consultant team members" in invite flows.

## What's excluded by design
- triage-service / classify-petiole
- plan_templates / clusters
- AI fertilizer plan builder pages
- invite/settings changes (only copy update)
- Broad migration files
- .claude / agent-orchestrator.yaml

## Validation
- `bun run typecheck` — passes
- `bun run lint` — passes (only pre-existing warnings)
- `bun run build` — compiles successfully (build failure is an unrelated pre-existing issue in `/api/ai/insights` due to missing Supabase env in build environment)

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a consultant farmer directory with role-based access. Owners/admins see all org clients; agronomists see only assigned farmers. Includes farmer profiles, farm details, and soil/petiole lab test previews.

- **New Features**
  - `src/lib/consultant-access.ts`: returns `userId`, `organizationId`, `role`, `canViewAllFarmers`, `isAgronomist`.
  - `src/lib/consultant-query-service.ts`: reads via `organization_clients`; fetches profiles and farms; validates client status and agronomist assignment; ignores `profiles.consultant_organization_id`.
  - `/consultant/farmers`: searchable, region-filterable list with name, contact, farm count, regions.
  - `/consultant/farmers/[farmerId]`: validates client + assignment; shows profile and farm cards.
  - `/consultant/farmers/[farmerId]/farms/[farmId]`: validates farmer/farm links; shows farm details and existing lab tests with report preview.
  - `/consultant/layout.tsx`: guards `/consultant/*` for owner/admin/agronomist; others redirected to `/dashboard`.
  - Invite copy: “agronomist consultants” → “consultant team members”.

- **Bug Fixes**
  - Guard invalid `farmId` with `isNaN` before fetching farm details.
  - Validate role before casting in `getConsultantAccess`.
  - Handle null `farm.user_id` in farm queries safely.
  - Layout now uses `getConsultantAccess` with a `ProtectedRoute` fallback to avoid a blank unauthorized state.
  - Cleaned invite copy to remove “or admins”/“and admins” language.

<sup>Written for commit b702bb55bc79448a919f81a7bf1e42303b5a6ac5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ashish921998/Vinesight/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consultant dashboard with role-based access gating and protected navigation
  * Farmer directory with search and region filtering
  * Farmer profile pages showing contact info and linked farms
  * Farm detail pages with soil & petiole lab test analysis, report previews, and downloadable reports

* **Updates**
  * Invitation and onboarding messaging updated to use "consultant" terminology
<!-- end of auto-generated comment: release notes by coderabbit.ai -->