### PR TITLE
feat: Add Factory Droid automated code review workflows

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -1,0 +1,31 @@
+name: Droid Auto Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  droid-review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Run Droid Auto Review
+        uses: Factory-AI/droid-action@main
+        with:
+          factory_api_key: ${{ secrets.FACTORY_API_KEY }}
+          automatic_review: true
+          automatic_security_review: true

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
       id-token: write
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Run Droid Auto Review
-        uses: Factory-AI/droid-action@main
+        uses: Factory-AI/droid-action@8ea31f351ee6636ebef918ccb64682f477af7184
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           automatic_review: true

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -1,0 +1,38 @@
+name: Droid Tag
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  droid:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@droid')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@droid')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@droid')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@droid') || contains(github.event.issue.title, '@droid'))) ||
+      (github.event_name == 'pull_request' && (contains(github.event.pull_request.body, '@droid') || contains(github.event.pull_request.title, '@droid')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Run Droid Exec
+        uses: Factory-AI/droid-action@main
+        with:
+          factory_api_key: ${{ secrets.FACTORY_API_KEY }}

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -6,11 +6,15 @@ on:
   pull_request_review_comment:
     types: [created]
   issues:
-    types: [opened, assigned]
+    types: [opened]
   pull_request_review:
     types: [submitted]
   pull_request:
     types: [opened, edited]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
 
 jobs:
   droid:
@@ -33,6 +37,6 @@ jobs:
         with:
           fetch-depth: 1
       - name: Run Droid Exec
-        uses: Factory-AI/droid-action@main
+        uses: Factory-AI/droid-action@8ea31f351ee6636ebef918ccb64682f477af7184
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}


### PR DESCRIPTION
## Factory Droid Automated Code Review

This PR adds two GitHub Actions workflows for automated code review:

### Workflows Added

**1. `droid.yml` — @droid Tag Responses**
- Triggers on `@droid` mentions in issues, PRs, and comments
- Responds with AI-powered code review and assistance

**2. `droid-review.yml` — Automatic Code Review**
- Triggers automatically on new pull requests (non-draft)
- Runs deep code review with security analysis
- Uses concurrency control to avoid duplicate reviews

### Setup Required

After merging, add your Factory API key as a repository secret:
1. Generate a key at https://app.factory.ai/settings/api-keys
2. Go to **Settings > Secrets and variables > Actions > New repository secret**
3. Name: `FACTORY_API_KEY`, Value: your generated key

### Learn More

- Documentation: https://docs.factory.ai
- API Keys: https://app.factory.ai/settings/api-keys

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two GitHub Actions for automated code reviews: automatic reviews on non-draft PRs with security checks, and on-demand responses to `@droid` mentions. Workflows are pinned to a specific `Factory-AI/droid-action` SHA with least-privilege permissions.

- **New Features**
  - Added `droid-review.yml`: runs on opened/ready/reopened PRs, skips drafts, includes security checks, and cancels duplicate runs via concurrency.
  - Added `droid.yml`: responds to `@droid` in issue/PR titles, bodies, comments, review bodies, and review comments; includes concurrency without canceling in-progress runs.

- **Migration**
  - Generate an API key at https://app.factory.ai/settings/api-keys.
  - Add a repo secret named `FACTORY_API_KEY` with that key.

<sup>Written for commit ad904e00e77d1df4622e1b7a2c208994aa86a1eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ashish921998/Vinesight/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated pull request review workflow that runs on PR opened/ready_for_review/reopened, enforces concurrency with cancel-in-progress, only runs for non-draft PRs, sets necessary job permissions, and enables automatic review and security review.
  * Added a mention-triggered workflow that runs on comment/review/issue/PR events when the trigger token is present, with concurrency to avoid overlapping runs and scoped job permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->