### PR TITLE
feat: consultant lab test and report access control

### DIFF
--- a/src/app/api/test-reports/signed-url/route.ts
+++ b/src/app/api/test-reports/signed-url/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { DocumentService } from '@/lib/document-service'
 import { validateUserSession } from '@/lib/auth-utils'
+import { checkFarmAccess } from '@/lib/farm-access'
 import type { Database } from '@/types/database'
 
 export const runtime = 'nodejs'
@@ -66,21 +67,9 @@ export async function POST(request: NextRequest) {
       auth: { persistSession: false }
     })
 
-    const { data: farm, error: farmError } = await supabaseAdmin
-      .from('farms')
-      .select('id, user_id')
-      .eq('id', farmId)
-      .single()
-
-    if (farmError) {
-      if (farmError.code === 'PGRST116') {
-        return NextResponse.json({ error: 'Resource not found' }, { status: 404 })
-      }
-      throw farmError
-    }
-
-    if (!farm || farm.user_id !== user.id) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    const access = await checkFarmAccess(user.id, farmId, { supabaseAdmin })
+    if (!access.allowed) {
+      return NextResponse.json({ error: access.reason }, { status: access.status })
     }
 
     // Validate expiresIn type

--- a/src/app/consultant/farmers/[farmerId]/farms/[farmId]/page.tsx
+++ b/src/app/consultant/farmers/[farmerId]/farms/[farmId]/page.tsx
@@ -330,6 +330,9 @@ function TestCard({ test, type }: { test: LabTestRecord; type: 'soil' | 'petiole
       if (response.ok) {
         const { signedUrl } = await response.json()
         setReportUrl(signedUrl)
+      } else {
+        const body = await response.text().catch(() => null)
+        console.warn(`Failed to load report signed URL (${response.status}):`, body)
       }
     } catch (error) {
       console.error('Error loading report:', error)

--- a/src/lib/__tests__/farm-access.test.ts
+++ b/src/lib/__tests__/farm-access.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi } from 'vitest'
+import { checkFarmAccess, type FarmAccessDeps } from '../farm-access'
+
+type Maybe<T> = { data: T | null; error: any }
+
+function mockSupabaseClient(partial: { from: any }): FarmAccessDeps['supabaseAdmin'] {
+  return partial as unknown as FarmAccessDeps['supabaseAdmin']
+}
+
+function mockChain(result: Maybe<any> = { data: null, error: null }) {
+  const chain: any = {
+    select: vi.fn(() => chain),
+    eq: vi.fn(() => chain),
+    single: vi.fn().mockResolvedValue(result),
+    maybeSingle: vi.fn().mockResolvedValue(result),
+    limit: vi.fn(() => chain)
+  }
+  return chain
+}
+
+describe('checkFarmAccess', () => {
+  it('allows farm owner', async () => {
+    const farmId = 1
+    const ownerId = 'user-owner'
+
+    const from = vi
+      .fn()
+      .mockReturnValue(mockChain({ data: { id: farmId, user_id: ownerId }, error: null }))
+    const supabaseAdmin = mockSupabaseClient({ from })
+
+    const result = await checkFarmAccess(ownerId, farmId, { supabaseAdmin })
+
+    expect(result).toEqual({ allowed: true })
+  })
+
+  it('returns 404 when farm not found', async () => {
+    const from = vi.fn().mockReturnValue(mockChain({ data: null, error: { code: 'PGRST116' } }))
+    const supabaseAdmin = mockSupabaseClient({ from })
+
+    const result = await checkFarmAccess('any-user', 1, { supabaseAdmin })
+
+    expect(result).toEqual({ allowed: false, reason: 'Farm not found', status: 404 })
+  })
+
+  it('throws on unexpected farm query error', async () => {
+    const from = vi.fn().mockReturnValue(mockChain({ data: null, error: new Error('db down') }))
+    const supabaseAdmin = mockSupabaseClient({ from })
+
+    await expect(checkFarmAccess('any-user', 1, { supabaseAdmin })).rejects.toThrow('db down')
+  })
+
+  it('allows consultant owner for their org client farm', async () => {
+    const farmId = 2
+    const farmerId = 'user-farmer'
+    const consultantId = 'user-consultant'
+    const orgId = 'org-1'
+
+    const chains: Record<string, any> = {
+      farms: mockChain({ data: { id: farmId, user_id: farmerId }, error: null }),
+      organization_members: mockChain({
+        data: { organization_id: orgId, role: 'owner', is_owner: true },
+        error: null
+      }),
+      organization_clients: mockChain({
+        data: { id: 'oc-1', assigned_to: null, status: 'active' },
+        error: null
+      })
+    }
+
+    const from = vi.fn((table: string) => chains[table])
+    const supabaseAdmin = mockSupabaseClient({ from })
+
+    const result = await checkFarmAccess(consultantId, farmId, { supabaseAdmin })
+
+    expect(result).toEqual({ allowed: true })
+  })
+
+  it('allows consultant admin for their org client farm', async () => {
+    const farmId = 3
+    const farmerId = 'user-farmer'
+    const adminId = 'user-admin'
+    const orgId = 'org-2'
+
+    const chains: Record<string, any> = {
+      farms: mockChain({ data: { id: farmId, user_id: farmerId }, error: null }),
+      organization_members: mockChain({
+        data: { organization_id: orgId, role: 'admin', is_owner: false },
+        error: null
+      }),
+      organization_clients: mockChain({
+        data: { id: 'oc-2', assigned_to: null, status: 'active' },
+        error: null
+      })
+    }
+
+    const from = vi.fn((table: string) => chains[table])
+    const supabaseAdmin = mockSupabaseClient({ from })
+
+    const result = await checkFarmAccess(adminId, farmId, { supabaseAdmin })
+
+    expect(result).toEqual({ allowed: true })
+  })
+
+  it('allows assigned agronomist for their client farm', async () => {
+    const farmId = 4
+    const farmerId = 'user-farmer'
+    const agronomistId = 'user-agro'
+    const orgId = 'org-3'
+
+    const chains: Record<string, any> = {
+      farms: mockChain({ data: { id: farmId, user_id: farmerId }, error: null }),
+      organization_members: mockChain({
+        data: { organization_id: orgId, role: 'agronomist', is_owner: false },
+        error: null
+      }),
+      organization_clients: mockChain({
+        data: { id: 'oc-3', assigned_to: agronomistId, status: 'active' },
+        error: null
+      })
+    }
+
+    const from = vi.fn((table: string) => chains[table])
+    const supabaseAdmin = mockSupabaseClient({ from })
+
+    const result = await checkFarmAccess(agronomistId, farmId, { supabaseAdmin })
+
+    expect(result).toEqual({ allowed: true })
+  })
+
+  it('denies unassigned agronomist (403)', async () => {
+    const farmId = 5
+    const farmerId = 'user-farmer'
+    const agronomistId = 'user-agro'
+    const orgId = 'org-4'
+
+    const chains: Record<string, any> = {
+      farms: mockChain({ data: { id: farmId, user_id: farmerId }, error: null }),
+      organization_members: mockChain({
+        data: { organization_id: orgId, role: 'agronomist', is_owner: false },
+        error: null
+      }),
+      organization_clients: mockChain({
+        data: { id: 'oc-4', assigned_to: 'other-agro', status: 'active' },
+        error: null
+      })
+    }
+
+    const from = vi.fn((table: string) => chains[table])
+    const supabaseAdmin = mockSupabaseClient({ from })
+
+    const result = await checkFarmAccess(agronomistId, farmId, { supabaseAdmin })
+
+    expect(result).toEqual({ allowed: false, reason: 'Forbidden', status: 403 })
+  })
+
+  it('denies unrelated user with no org membership (403)', async () => {
+    const farmId = 6
+    const farmerId = 'user-farmer'
+    const unrelatedId = 'user-stranger'
+
+    const chains: Record<string, any> = {
+      farms: mockChain({ data: { id: farmId, user_id: farmerId }, error: null }),
+      organization_members: mockChain({ data: null, error: null })
+    }
+
+    const from = vi.fn((table: string) => chains[table])
+    const supabaseAdmin = mockSupabaseClient({ from })
+
+    const result = await checkFarmAccess(unrelatedId, farmId, { supabaseAdmin })
+
+    expect(result).toEqual({ allowed: false, reason: 'Forbidden', status: 403 })
+  })
+
+  it('denies user whose org has no active client link to the farmer (403)', async () => {
+    const farmId = 7
+    const farmerId = 'user-farmer'
+    const memberId = 'user-member'
+    const orgId = 'org-5'
+
+    const chains: Record<string, any> = {
+      farms: mockChain({ data: { id: farmId, user_id: farmerId }, error: null }),
+      organization_members: mockChain({
+        data: { organization_id: orgId, role: 'owner', is_owner: true },
+        error: null
+      }),
+      organization_clients: mockChain({ data: null, error: null })
+    }
+
+    const from = vi.fn((table: string) => chains[table])
+    const supabaseAdmin = mockSupabaseClient({ from })
+
+    const result = await checkFarmAccess(memberId, farmId, { supabaseAdmin })
+
+    expect(result).toEqual({ allowed: false, reason: 'Forbidden', status: 403 })
+  })
+})

--- a/src/lib/__tests__/farm-access.test.ts
+++ b/src/lib/__tests__/farm-access.test.ts
@@ -11,9 +11,11 @@ function mockChain(result: Maybe<any> = { data: null, error: null }) {
   const chain: any = {
     select: vi.fn(() => chain),
     eq: vi.fn(() => chain),
+    in: vi.fn(() => chain),
     single: vi.fn().mockResolvedValue(result),
     maybeSingle: vi.fn().mockResolvedValue(result),
-    limit: vi.fn(() => chain)
+    limit: vi.fn(() => chain),
+    then: vi.fn((resolve, reject) => Promise.resolve(result).then(resolve, reject))
   }
   return chain
 }
@@ -58,11 +60,11 @@ describe('checkFarmAccess', () => {
     const chains: Record<string, any> = {
       farms: mockChain({ data: { id: farmId, user_id: farmerId }, error: null }),
       organization_members: mockChain({
-        data: { organization_id: orgId, role: 'owner', is_owner: true },
+        data: [{ organization_id: orgId, role: 'owner', is_owner: true }],
         error: null
       }),
       organization_clients: mockChain({
-        data: { id: 'oc-1', assigned_to: null, status: 'active' },
+        data: [{ organization_id: orgId, assigned_to: null, status: 'active' }],
         error: null
       })
     }
@@ -84,11 +86,11 @@ describe('checkFarmAccess', () => {
     const chains: Record<string, any> = {
       farms: mockChain({ data: { id: farmId, user_id: farmerId }, error: null }),
       organization_members: mockChain({
-        data: { organization_id: orgId, role: 'admin', is_owner: false },
+        data: [{ organization_id: orgId, role: 'admin', is_owner: false }],
         error: null
       }),
       organization_clients: mockChain({
-        data: { id: 'oc-2', assigned_to: null, status: 'active' },
+        data: [{ organization_id: orgId, assigned_to: null, status: 'active' }],
         error: null
       })
     }
@@ -110,11 +112,11 @@ describe('checkFarmAccess', () => {
     const chains: Record<string, any> = {
       farms: mockChain({ data: { id: farmId, user_id: farmerId }, error: null }),
       organization_members: mockChain({
-        data: { organization_id: orgId, role: 'agronomist', is_owner: false },
+        data: [{ organization_id: orgId, role: 'agronomist', is_owner: false }],
         error: null
       }),
       organization_clients: mockChain({
-        data: { id: 'oc-3', assigned_to: agronomistId, status: 'active' },
+        data: [{ organization_id: orgId, assigned_to: agronomistId, status: 'active' }],
         error: null
       })
     }
@@ -136,11 +138,11 @@ describe('checkFarmAccess', () => {
     const chains: Record<string, any> = {
       farms: mockChain({ data: { id: farmId, user_id: farmerId }, error: null }),
       organization_members: mockChain({
-        data: { organization_id: orgId, role: 'agronomist', is_owner: false },
+        data: [{ organization_id: orgId, role: 'agronomist', is_owner: false }],
         error: null
       }),
       organization_clients: mockChain({
-        data: { id: 'oc-4', assigned_to: 'other-agro', status: 'active' },
+        data: [{ organization_id: orgId, assigned_to: 'other-agro', status: 'active' }],
         error: null
       })
     }
@@ -180,10 +182,10 @@ describe('checkFarmAccess', () => {
     const chains: Record<string, any> = {
       farms: mockChain({ data: { id: farmId, user_id: farmerId }, error: null }),
       organization_members: mockChain({
-        data: { organization_id: orgId, role: 'owner', is_owner: true },
+        data: [{ organization_id: orgId, role: 'owner', is_owner: true }],
         error: null
       }),
-      organization_clients: mockChain({ data: null, error: null })
+      organization_clients: mockChain({ data: [], error: null })
     }
 
     const from = vi.fn((table: string) => chains[table])
@@ -192,5 +194,40 @@ describe('checkFarmAccess', () => {
     const result = await checkFarmAccess(memberId, farmId, { supabaseAdmin })
 
     expect(result).toEqual({ allowed: false, reason: 'Forbidden', status: 403 })
+  })
+
+  it('allows a multi-org member through the org with the active client link', async () => {
+    const farmId = 8
+    const farmerId = 'user-farmer'
+    const consultantId = 'user-consultant'
+    const inactiveOrgId = 'org-inactive'
+    const activeOrgId = 'org-active'
+
+    const chains: Record<string, any> = {
+      farms: mockChain({ data: { id: farmId, user_id: farmerId }, error: null }),
+      organization_members: mockChain({
+        data: [
+          { organization_id: inactiveOrgId, role: 'agronomist', is_owner: false },
+          { organization_id: activeOrgId, role: 'admin', is_owner: false }
+        ],
+        error: null
+      }),
+      organization_clients: mockChain({
+        data: [{ organization_id: activeOrgId, assigned_to: null, status: 'active' }],
+        error: null
+      })
+    }
+
+    const from = vi.fn((table: string) => chains[table])
+    const supabaseAdmin = mockSupabaseClient({ from })
+
+    const result = await checkFarmAccess(consultantId, farmId, { supabaseAdmin })
+
+    expect(result).toEqual({ allowed: true })
+    expect(chains.organization_members.maybeSingle).not.toHaveBeenCalled()
+    expect(chains.organization_clients.in).toHaveBeenCalledWith('organization_id', [
+      inactiveOrgId,
+      activeOrgId
+    ])
   })
 })

--- a/src/lib/farm-access.ts
+++ b/src/lib/farm-access.ts
@@ -42,6 +42,10 @@ export async function checkFarmAccess(
     return { allowed: false, reason: 'Farm not found', status: 404 }
   }
 
+  if (!farm.user_id) {
+    return { allowed: false, reason: 'Forbidden', status: 403 }
+  }
+
   // Rule 1: Farm owner
   if (farm.user_id === userId) {
     return { allowed: true }
@@ -59,7 +63,13 @@ export async function checkFarmAccess(
     return { allowed: false, reason: 'Forbidden', status: 403 }
   }
 
-  const orgIds = memberships.map((m) => m.organization_id)
+  const orgIds = memberships
+    .map((membership) => membership.organization_id)
+    .filter((organizationId): organizationId is string => Boolean(organizationId))
+
+  if (orgIds.length === 0) {
+    return { allowed: false, reason: 'Forbidden', status: 403 }
+  }
 
   // Check active client links across all orgs
   const { data: clientLinks, error: clientLinksError } = await supabaseAdmin

--- a/src/lib/farm-access.ts
+++ b/src/lib/farm-access.ts
@@ -1,0 +1,90 @@
+import { type SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/types/database'
+
+export type FarmAccessResult =
+  | { allowed: true }
+  | { allowed: false; reason: string; status: 403 | 404 }
+
+export interface FarmAccessDeps {
+  supabaseAdmin: SupabaseClient<Database>
+}
+
+/**
+ * Check whether a user is allowed to access a farm for reading lab tests / reports.
+ *
+ * Rules:
+ * 1. Farm owner (farms.user_id === userId) -> allowed.
+ * 2. Consultant owner/admin whose org has an active organization_clients link to the farm owner -> allowed.
+ * 3. Agronomist whose org has an active organization_clients link to the farm owner AND assigned_to === userId -> allowed.
+ * 4. Everyone else -> denied.
+ */
+export async function checkFarmAccess(
+  userId: string,
+  farmId: number,
+  deps: FarmAccessDeps
+): Promise<FarmAccessResult> {
+  const { supabaseAdmin } = deps
+
+  const { data: farm, error: farmError } = await supabaseAdmin
+    .from('farms')
+    .select('id, user_id')
+    .eq('id', farmId)
+    .single()
+
+  if (farmError) {
+    if (farmError.code === 'PGRST116') {
+      return { allowed: false, reason: 'Farm not found', status: 404 }
+    }
+    throw farmError
+  }
+
+  if (!farm) {
+    return { allowed: false, reason: 'Farm not found', status: 404 }
+  }
+
+  // Rule 1: Farm owner
+  if (farm.user_id === userId) {
+    return { allowed: true }
+  }
+
+  // Check organization membership and client links
+  const { data: membership, error: membershipError } = await supabaseAdmin
+    .from('organization_members')
+    .select('organization_id, role, is_owner')
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  if (membershipError) throw membershipError
+
+  if (!membership) {
+    return { allowed: false, reason: 'Forbidden', status: 403 }
+  }
+
+  const { data: clientLink, error: clientLinkError } = await supabaseAdmin
+    .from('organization_clients')
+    .select('id, assigned_to, status')
+    .eq('organization_id', membership.organization_id)
+    .eq('client_user_id', farm.user_id)
+    .eq('status', 'active')
+    .maybeSingle()
+
+  if (clientLinkError) throw clientLinkError
+
+  if (!clientLink) {
+    return { allowed: false, reason: 'Forbidden', status: 403 }
+  }
+
+  // Rule 2: Consultant owner/admin
+  const isAdmin = membership.is_owner || membership.role === 'owner' || membership.role === 'admin'
+
+  if (isAdmin) {
+    return { allowed: true }
+  }
+
+  // Rule 3: Agronomist assigned to this client
+  if (membership.role === 'agronomist' && clientLink.assigned_to === userId) {
+    return { allowed: true }
+  }
+
+  return { allowed: false, reason: 'Forbidden', status: 403 }
+}

--- a/src/lib/farm-access.ts
+++ b/src/lib/farm-access.ts
@@ -47,43 +47,48 @@ export async function checkFarmAccess(
     return { allowed: true }
   }
 
-  // Check organization membership and client links
-  const { data: membership, error: membershipError } = await supabaseAdmin
+  // Fetch all org memberships for the user
+  const { data: memberships, error: membershipsError } = await supabaseAdmin
     .from('organization_members')
     .select('organization_id, role, is_owner')
     .eq('user_id', userId)
-    .maybeSingle()
 
-  if (membershipError) throw membershipError
+  if (membershipsError) throw membershipsError
 
-  if (!membership) {
+  if (!memberships || memberships.length === 0) {
     return { allowed: false, reason: 'Forbidden', status: 403 }
   }
 
-  const { data: clientLink, error: clientLinkError } = await supabaseAdmin
+  const orgIds = memberships.map((m) => m.organization_id)
+
+  // Check active client links across all orgs
+  const { data: clientLinks, error: clientLinksError } = await supabaseAdmin
     .from('organization_clients')
-    .select('id, assigned_to, status')
-    .eq('organization_id', membership.organization_id)
+    .select('organization_id, assigned_to, status')
+    .in('organization_id', orgIds)
     .eq('client_user_id', farm.user_id)
     .eq('status', 'active')
-    .maybeSingle()
 
-  if (clientLinkError) throw clientLinkError
+  if (clientLinksError) throw clientLinksError
 
-  if (!clientLink) {
+  if (!clientLinks || clientLinks.length === 0) {
     return { allowed: false, reason: 'Forbidden', status: 403 }
   }
 
-  // Rule 2: Consultant owner/admin
-  const isAdmin = membership.is_owner || membership.role === 'owner' || membership.role === 'admin'
+  for (const link of clientLinks) {
+    const member = memberships.find((m) => m.organization_id === link.organization_id)
+    if (!member) continue
 
-  if (isAdmin) {
-    return { allowed: true }
-  }
+    // Rule 2: Consultant owner/admin
+    const isAdmin = member.is_owner || member.role === 'owner' || member.role === 'admin'
+    if (isAdmin) {
+      return { allowed: true }
+    }
 
-  // Rule 3: Agronomist assigned to this client
-  if (membership.role === 'agronomist' && clientLink.assigned_to === userId) {
-    return { allowed: true }
+    // Rule 3: Agronomist assigned to this client
+    if (member.role === 'agronomist' && link.assigned_to === userId) {
+      return { allowed: true }
+    }
   }
 
   return { allowed: false, reason: 'Forbidden', status: 403 }

--- a/supabase/supabase-schema.sql
+++ b/supabase/supabase-schema.sql
@@ -420,6 +420,21 @@ ALTER TABLE soil_profiles ENABLE ROW LEVEL SECURITY;
 
 -- RLS Policies for farms table
 CREATE POLICY "Users can view their own farms" ON farms FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "Org members can view client farms" ON farms FOR SELECT USING (
+  EXISTS (
+    SELECT 1 FROM organization_clients oc
+    JOIN organization_members om
+      ON om.organization_id = oc.organization_id
+     AND om.user_id = auth.uid()
+    WHERE oc.client_user_id = farms.user_id
+      AND oc.status = 'active'
+      AND (
+        om.role IN ('owner', 'admin')
+        OR om.is_owner = TRUE
+        OR (om.role = 'agronomist' AND oc.assigned_to = auth.uid())
+      )
+  )
+);
 CREATE POLICY "Users can insert their own farms" ON farms FOR INSERT WITH CHECK (auth.uid() = user_id);
 CREATE POLICY "Users can update their own farms" ON farms FOR UPDATE USING (auth.uid() = user_id);
 CREATE POLICY "Users can delete their own farms" ON farms FOR DELETE USING (auth.uid() = user_id);
@@ -576,6 +591,7 @@ CREATE POLICY "Org members can view client soil tests" ON soil_test_records FOR 
       AND oc.status = 'active'
       AND (
         om.role IN ('owner', 'admin')
+        OR om.is_owner = TRUE
         OR (om.role = 'agronomist' AND oc.assigned_to = auth.uid())
       )
   )
@@ -605,6 +621,7 @@ CREATE POLICY "Org members can view client petiole tests" ON petiole_test_record
       AND oc.status = 'active'
       AND (
         om.role IN ('owner', 'admin')
+        OR om.is_owner = TRUE
         OR (om.role = 'agronomist' AND oc.assigned_to = auth.uid())
       )
   )

--- a/supabase/supabase-schema.sql
+++ b/supabase/supabase-schema.sql
@@ -565,6 +565,21 @@ CREATE POLICY "Users can delete their warehouse items" ON warehouse_items FOR DE
 CREATE POLICY "Users can view their farm soil test records" ON soil_test_records FOR SELECT USING (
   EXISTS (SELECT 1 FROM farms WHERE farms.id = soil_test_records.farm_id AND farms.user_id = auth.uid())
 );
+CREATE POLICY "Org members can view client soil tests" ON soil_test_records FOR SELECT USING (
+  EXISTS (SELECT 1 FROM farms WHERE farms.id = soil_test_records.farm_id AND farms.user_id = auth.uid())
+  OR EXISTS (
+    SELECT 1 FROM organization_clients oc
+    JOIN organization_members om
+      ON om.organization_id = oc.organization_id
+     AND om.user_id = auth.uid()
+    JOIN farms f ON f.user_id = oc.client_user_id
+    WHERE f.id = soil_test_records.farm_id
+      AND (
+        om.role IN ('owner', 'admin')
+        OR (om.role = 'agronomist' AND oc.assigned_to = auth.uid())
+      )
+  )
+);
 CREATE POLICY "Users can insert soil test records for their farms" ON soil_test_records FOR INSERT WITH CHECK (
   EXISTS (SELECT 1 FROM farms WHERE farms.id = soil_test_records.farm_id AND farms.user_id = auth.uid())
 );
@@ -578,6 +593,21 @@ CREATE POLICY "Users can delete soil test records for their farms" ON soil_test_
 -- Petiole test records
 CREATE POLICY "Users can view their farm petiole test records" ON petiole_test_records FOR SELECT USING (
   EXISTS (SELECT 1 FROM farms WHERE farms.id = petiole_test_records.farm_id AND farms.user_id = auth.uid())
+);
+CREATE POLICY "Org members can view client petiole tests" ON petiole_test_records FOR SELECT USING (
+  EXISTS (SELECT 1 FROM farms WHERE farms.id = petiole_test_records.farm_id AND farms.user_id = auth.uid())
+  OR EXISTS (
+    SELECT 1 FROM organization_clients oc
+    JOIN organization_members om
+      ON om.organization_id = oc.organization_id
+     AND om.user_id = auth.uid()
+    JOIN farms f ON f.user_id = oc.client_user_id
+    WHERE f.id = petiole_test_records.farm_id
+      AND (
+        om.role IN ('owner', 'admin')
+        OR (om.role = 'agronomist' AND oc.assigned_to = auth.uid())
+      )
+  )
 );
 CREATE POLICY "Users can insert petiole test records for their farms" ON petiole_test_records FOR INSERT WITH CHECK (
   EXISTS (SELECT 1 FROM farms WHERE farms.id = petiole_test_records.farm_id AND farms.user_id = auth.uid())

--- a/supabase/supabase-schema.sql
+++ b/supabase/supabase-schema.sql
@@ -566,14 +566,14 @@ CREATE POLICY "Users can view their farm soil test records" ON soil_test_records
   EXISTS (SELECT 1 FROM farms WHERE farms.id = soil_test_records.farm_id AND farms.user_id = auth.uid())
 );
 CREATE POLICY "Org members can view client soil tests" ON soil_test_records FOR SELECT USING (
-  EXISTS (SELECT 1 FROM farms WHERE farms.id = soil_test_records.farm_id AND farms.user_id = auth.uid())
-  OR EXISTS (
+  EXISTS (
     SELECT 1 FROM organization_clients oc
     JOIN organization_members om
       ON om.organization_id = oc.organization_id
      AND om.user_id = auth.uid()
     JOIN farms f ON f.user_id = oc.client_user_id
     WHERE f.id = soil_test_records.farm_id
+      AND oc.status = 'active'
       AND (
         om.role IN ('owner', 'admin')
         OR (om.role = 'agronomist' AND oc.assigned_to = auth.uid())
@@ -595,14 +595,14 @@ CREATE POLICY "Users can view their farm petiole test records" ON petiole_test_r
   EXISTS (SELECT 1 FROM farms WHERE farms.id = petiole_test_records.farm_id AND farms.user_id = auth.uid())
 );
 CREATE POLICY "Org members can view client petiole tests" ON petiole_test_records FOR SELECT USING (
-  EXISTS (SELECT 1 FROM farms WHERE farms.id = petiole_test_records.farm_id AND farms.user_id = auth.uid())
-  OR EXISTS (
+  EXISTS (
     SELECT 1 FROM organization_clients oc
     JOIN organization_members om
       ON om.organization_id = oc.organization_id
      AND om.user_id = auth.uid()
     JOIN farms f ON f.user_id = oc.client_user_id
     WHERE f.id = petiole_test_records.farm_id
+      AND oc.status = 'active'
       AND (
         om.role IN ('owner', 'admin')
         OR (om.role = 'agronomist' AND oc.assigned_to = auth.uid())


### PR DESCRIPTION
## Summary
Adds farm-level authorization so consultants (owner/admin/agronomist) can view lab tests and report previews for their assigned client farms.

## Changes
- **New src/lib/farm-access.ts** — shared checkFarmAccess helper enforcing:
  - farmer owner access
  - consultant owner/admin access via active organization_clients link
  - agronomist access only when assigned_to matches them
  - returns 403/404 with reason for denied requests

- **Updated src/app/api/test-reports/signed-url/route.ts** — replaced hardcoded farm-owner-only check with checkFarmAccess, supporting all authorized roles while keeping path validation and expiresIn checks unchanged.

- **Added RLS policies** in supabase/supabase-schema.sql:
  - Org members can view client soil tests
  - Org members can view client petiole tests
  - Both mirror the existing migration pattern (owner/admin or agronomist with assignment check).

- **UI tweak** in src/app/consultant/farmers/[farmerId]/farms/[farmId]/page.tsx:
  - Logs status and body on failed signed-URL fetches
  - Keeps quiet fallback UI, no per-card toast spam

- **Tests** — src/lib/__tests__/farm-access.test.ts covers all 8 authorization scenarios plus error handling.

## Verification checklist
- [x] farmer owner can open own report
- [x] consultant owner/admin can open client report
- [x] assigned agronomist can open assigned farmer report
- [x] unassigned agronomist gets 403
- [x] unrelated user gets 403
- [x] invalid path gets 400

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds farm-level access control so consultants (org owner/admin or assigned agronomist) can view client lab tests and report previews. Tightens rules to be multi‑org aware and limited to active `organization_clients` links; adds RLS so authorized org members can read client farm rows with clear 403/404 responses.

- **New Features**
  - Added `checkFarmAccess` enforcing: farm owner; org owner/admin via active link; agronomist only if assigned; multi‑org aware; structured denials.
  - Updated `api/test-reports/signed-url` to use `checkFarmAccess`; kept path and `expiresIn` validation.
  - Added RLS SELECT policies for `farms`, `soil_test_records`, and `petiole_test_records` allowing org members via active client links; include `om.is_owner = TRUE`; removed redundant owner checks.
  - UI: log status/body on signed‑URL failures; tests cover all auth paths and error cases.

<sup>Written for commit e15ce0267628acb11594e577f9ddc5890047624a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ashish921998/Vinesight/pull/138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * DB-level RLS policies expanded so organization members can view client farms and test records; owner/admin/agronomist access rules enforced.

* **New Features**
  * Centralized farm-access authorization added and integrated for report requests.

* **Bug Fixes**
  * Improved error logging for failed test report fetches (captures HTTP status and response body).

* **Tests**
  * Added unit tests covering owner, org roles, assignments, not-found, and forbidden scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->