### PR TITLE
feat: consultant petiole triage review queue

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,4 @@
+[test]
+# Tests inject mock Supabase clients, but importing src/lib/supabase.ts eagerly
+# constructs a browser client that requires these env vars to be present.
+preload = ["./test/setup-env.ts"]

--- a/src/app/consultant/layout.tsx
+++ b/src/app/consultant/layout.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute'
 import { Button } from '@/components/ui/button'
-import { Contact, ChevronLeft, ChevronRight } from 'lucide-react'
+import { Contact, ClipboardList, ChevronLeft, ChevronRight } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { getConsultantAccess } from '@/lib/consultant-access'
 import { toast } from 'sonner'
@@ -20,6 +20,11 @@ const navItems = [
     label: 'Farmers',
     href: '/consultant/farmers',
     icon: Contact
+  },
+  {
+    label: 'Triage',
+    href: '/consultant/triage',
+    icon: ClipboardList
   }
 ]
 

--- a/src/app/consultant/triage/page.tsx
+++ b/src/app/consultant/triage/page.tsx
@@ -1,0 +1,526 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+  SheetFooter
+} from '@/components/ui/sheet'
+import { toast } from 'sonner'
+import { Search, Loader2, ClipboardList, ChevronRight, FlaskConical } from 'lucide-react'
+import { getConsultantAccess, type ConsultantAccess } from '@/lib/consultant-access'
+import {
+  getTriageItems,
+  getTriageItem,
+  updateTriageReview,
+  TRIAGE_STATUSES,
+  TRIAGE_SEVERITIES,
+  type TriageItem,
+  type TriageDetail,
+  type TriageStatus,
+  type TriageSeverity
+} from '@/lib/consultant-triage-service'
+
+const STATUS_LABELS: Record<TriageStatus, string> = {
+  pending: 'Pending',
+  in_review: 'In Review',
+  reviewed: 'Reviewed',
+  escalated: 'Escalated',
+  resolved: 'Resolved'
+}
+
+const SEVERITY_LABELS: Record<TriageSeverity, string> = {
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+  critical: 'Critical'
+}
+
+function severityVariant(severity: TriageSeverity | null) {
+  switch (severity) {
+    case 'critical':
+    case 'high':
+      return 'destructive' as const
+    case 'medium':
+      return 'default' as const
+    default:
+      return 'secondary' as const
+  }
+}
+
+function statusVariant(status: TriageStatus) {
+  switch (status) {
+    case 'pending':
+      return 'outline' as const
+    case 'escalated':
+      return 'destructive' as const
+    case 'resolved':
+    case 'reviewed':
+      return 'secondary' as const
+    default:
+      return 'default' as const
+  }
+}
+
+function formatDate(value: string | null) {
+  if (!value) return '—'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return '—'
+  return date.toLocaleDateString()
+}
+
+export default function TriagePage() {
+  const [items, setItems] = useState<TriageItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [access, setAccess] = useState<ConsultantAccess | null>(null)
+
+  const [searchQuery, setSearchQuery] = useState('')
+  const [statusFilter, setStatusFilter] = useState<string>('all')
+  const [severityFilter, setSeverityFilter] = useState<string>('all')
+
+  const [selected, setSelected] = useState<TriageDetail | null>(null)
+  const [detailLoading, setDetailLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+
+  // Review form state
+  const [formStatus, setFormStatus] = useState<TriageStatus>('pending')
+  const [formSeverity, setFormSeverity] = useState<string>('none')
+  const [formClassification, setFormClassification] = useState('')
+  const [formSummary, setFormSummary] = useState('')
+  const [formRecommendation, setFormRecommendation] = useState('')
+  const [formReviewNotes, setFormReviewNotes] = useState('')
+
+  useEffect(() => {
+    loadTriage()
+  }, [])
+
+  const loadTriage = async () => {
+    try {
+      setLoading(true)
+      const currentAccess = await getConsultantAccess()
+      if (!currentAccess) {
+        toast.error('Not authenticated')
+        return
+      }
+      setAccess(currentAccess)
+      const data = await getTriageItems(currentAccess)
+      setItems(data)
+    } catch (error) {
+      console.error('Failed to load triage:', error)
+      toast.error(error instanceof Error ? error.message : 'Failed to load triage queue')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const counts = useMemo(() => {
+    let pending = 0
+    let highSeverity = 0
+    let reviewed = 0
+    for (const item of items) {
+      if (item.status === 'pending') pending++
+      if (item.severity === 'high' || item.severity === 'critical') highSeverity++
+      if (item.status === 'reviewed' || item.status === 'resolved') reviewed++
+    }
+    return { pending, highSeverity, reviewed }
+  }, [items])
+
+  const filteredItems = useMemo(() => {
+    return items.filter((item) => {
+      if (statusFilter !== 'all' && item.status !== statusFilter) return false
+      if (severityFilter !== 'all' && item.severity !== severityFilter) return false
+      if (searchQuery) {
+        const q = searchQuery.toLowerCase()
+        const nameMatch = item.farmerName?.toLowerCase().includes(q)
+        const farmMatch = item.farmName?.toLowerCase().includes(q)
+        if (!nameMatch && !farmMatch) return false
+      }
+      return true
+    })
+  }, [items, statusFilter, severityFilter, searchQuery])
+
+  const openDetail = async (item: TriageItem) => {
+    if (!access) return
+    setDetailLoading(true)
+    setSelected({ ...item, petioleTest: null })
+    try {
+      const detail = await getTriageItem(access, item.id)
+      if (!detail) {
+        toast.error('Triage item is no longer available')
+        setSelected(null)
+        return
+      }
+      setSelected(detail)
+      setFormStatus(detail.status)
+      setFormSeverity(detail.severity ?? 'none')
+      setFormClassification(detail.classification ?? '')
+      setFormSummary(detail.summary ?? '')
+      setFormRecommendation(detail.recommendation ?? '')
+      setFormReviewNotes(detail.reviewNotes ?? '')
+    } catch (error) {
+      console.error('Failed to load triage detail:', error)
+      toast.error(error instanceof Error ? error.message : 'Failed to load triage detail')
+      setSelected(null)
+    } finally {
+      setDetailLoading(false)
+    }
+  }
+
+  const handleSave = async () => {
+    if (!access || !selected) return
+    setSaving(true)
+    try {
+      const updated = await updateTriageReview(access, selected.id, {
+        status: formStatus,
+        severity: formSeverity === 'none' ? null : (formSeverity as TriageSeverity),
+        classification: formClassification.trim() || null,
+        summary: formSummary.trim() || null,
+        recommendation: formRecommendation.trim() || null,
+        reviewNotes: formReviewNotes.trim() || null
+      })
+      // Merge updated review fields back into the list (preserve display fields).
+      setItems((prev) =>
+        prev.map((it) =>
+          it.id === updated.id
+            ? {
+                ...it,
+                status: updated.status,
+                severity: updated.severity,
+                classification: updated.classification,
+                summary: updated.summary,
+                recommendation: updated.recommendation,
+                reviewNotes: updated.reviewNotes,
+                reviewedBy: updated.reviewedBy,
+                reviewedAt: updated.reviewedAt
+              }
+            : it
+        )
+      )
+      toast.success('Triage updated')
+      setSelected(null)
+    } catch (error) {
+      console.error('Failed to update triage:', error)
+      toast.error(error instanceof Error ? error.message : 'Failed to update triage')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <div className="text-center space-y-3">
+          <Loader2 className="h-8 w-8 animate-spin text-primary mx-auto" />
+          <p className="text-sm text-muted-foreground">Loading triage queue...</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-bold">Triage</h1>
+        <p className="text-muted-foreground">
+          Review petiole test issues for{' '}
+          {access?.isAgronomist ? 'farmers assigned to you' : 'your organization'}
+        </p>
+      </div>
+
+      {/* Summary counts */}
+      <div className="grid grid-cols-3 gap-3">
+        <Card>
+          <CardContent className="p-4">
+            <p className="text-xs text-muted-foreground">Pending</p>
+            <p className="text-2xl font-bold">{counts.pending}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <p className="text-xs text-muted-foreground">High severity</p>
+            <p className="text-2xl font-bold text-destructive">{counts.highSeverity}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <p className="text-xs text-muted-foreground">Reviewed</p>
+            <p className="text-2xl font-bold">{counts.reviewed}</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search by farmer or farm name..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+
+        <Select value={statusFilter} onValueChange={setStatusFilter}>
+          <SelectTrigger className="w-full sm:w-[170px]">
+            <SelectValue placeholder="All statuses" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All statuses</SelectItem>
+            {TRIAGE_STATUSES.map((status) => (
+              <SelectItem key={status} value={status}>
+                {STATUS_LABELS[status]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select value={severityFilter} onValueChange={setSeverityFilter}>
+          <SelectTrigger className="w-full sm:w-[170px]">
+            <SelectValue placeholder="All severities" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All severities</SelectItem>
+            {TRIAGE_SEVERITIES.map((severity) => (
+              <SelectItem key={severity} value={severity}>
+                {SEVERITY_LABELS[severity]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Queue */}
+      {filteredItems.length === 0 ? (
+        <Card>
+          <CardContent className="p-12 text-center">
+            <ClipboardList className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+            <h3 className="text-lg font-semibold">No Triage Items</h3>
+            <p className="text-muted-foreground mt-2 max-w-md mx-auto">
+              {items.length === 0
+                ? 'There are no petiole test issues to review yet.'
+                : 'No items match your current filters. Try adjusting your search.'}
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <CardContent className="p-0">
+            {/* Header row (md+) */}
+            <div className="hidden md:grid grid-cols-[1.5fr_1.2fr_0.9fr_0.9fr_1fr_1.1fr_auto] gap-3 px-4 py-2 border-b text-xs font-medium text-muted-foreground">
+              <span>Farmer</span>
+              <span>Farm</span>
+              <span>Test date</span>
+              <span>Severity</span>
+              <span>Classification</span>
+              <span>Status</span>
+              <span />
+            </div>
+            <ul className="divide-y">
+              {filteredItems.map((item) => (
+                <li key={item.id}>
+                  <button
+                    type="button"
+                    onClick={() => openDetail(item)}
+                    className="w-full text-left px-4 py-3 hover:bg-muted/50 transition-colors md:grid md:grid-cols-[1.5fr_1.2fr_0.9fr_0.9fr_1fr_1.1fr_auto] md:items-center md:gap-3"
+                  >
+                    <span className="font-medium block md:truncate">
+                      {item.farmerName || 'Unknown farmer'}
+                    </span>
+                    <span className="text-sm text-muted-foreground block md:truncate">
+                      {item.farmName || '—'}
+                    </span>
+                    <span className="text-sm text-muted-foreground">
+                      {formatDate(item.testDate)}
+                    </span>
+                    <span className="mt-1 md:mt-0">
+                      <Badge variant={severityVariant(item.severity)}>
+                        {item.severity ? SEVERITY_LABELS[item.severity] : 'Unset'}
+                      </Badge>
+                    </span>
+                    <span className="text-sm text-muted-foreground block md:truncate">
+                      {item.classification || '—'}
+                    </span>
+                    <span className="mt-1 md:mt-0">
+                      <Badge variant={statusVariant(item.status)}>
+                        {STATUS_LABELS[item.status]}
+                      </Badge>
+                    </span>
+                    <ChevronRight className="hidden md:block h-4 w-4 text-muted-foreground" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Detail / review drawer */}
+      <Sheet open={selected !== null} onOpenChange={(open) => !open && setSelected(null)}>
+        <SheetContent className="w-full sm:max-w-lg overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle>{selected?.farmerName || 'Triage review'}</SheetTitle>
+            <SheetDescription>
+              {selected?.farmName || '—'} · Test {formatDate(selected?.testDate ?? null)}
+            </SheetDescription>
+          </SheetHeader>
+
+          {detailLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="h-6 w-6 animate-spin text-primary" />
+            </div>
+          ) : selected ? (
+            <div className="px-4 space-y-5">
+              {/* Linked petiole test values */}
+              {selected.petioleTest && (
+                <div className="rounded-lg border bg-muted/40 p-3">
+                  <div className="flex items-center gap-2 mb-2 text-sm font-medium">
+                    <FlaskConical className="h-4 w-4 text-accent" />
+                    Petiole test values
+                  </div>
+                  <PetioleParameters parameters={selected.petioleTest.parameters} />
+                  {selected.petioleTest.recommendations && (
+                    <p className="mt-2 text-xs text-muted-foreground">
+                      {selected.petioleTest.recommendations}
+                    </p>
+                  )}
+                </div>
+              )}
+
+              {/* Review form */}
+              <div className="space-y-2">
+                <Label>Status</Label>
+                <Select
+                  value={formStatus}
+                  onValueChange={(value) => setFormStatus(value as TriageStatus)}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {TRIAGE_STATUSES.map((status) => (
+                      <SelectItem key={status} value={status}>
+                        {STATUS_LABELS[status]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label>Severity</Label>
+                <Select value={formSeverity} onValueChange={setFormSeverity}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">Unset</SelectItem>
+                    {TRIAGE_SEVERITIES.map((severity) => (
+                      <SelectItem key={severity} value={severity}>
+                        {SEVERITY_LABELS[severity]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label>Classification</Label>
+                <Input
+                  value={formClassification}
+                  onChange={(e) => setFormClassification(e.target.value)}
+                  placeholder="e.g. Nitrogen deficiency"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label>Summary</Label>
+                <Textarea
+                  value={formSummary}
+                  onChange={(e) => setFormSummary(e.target.value)}
+                  placeholder="Short summary of the issue"
+                  rows={2}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label>Recommendation</Label>
+                <Textarea
+                  value={formRecommendation}
+                  onChange={(e) => setFormRecommendation(e.target.value)}
+                  placeholder="Recommended action for the farmer"
+                  rows={3}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label>Review notes</Label>
+                <Textarea
+                  value={formReviewNotes}
+                  onChange={(e) => setFormReviewNotes(e.target.value)}
+                  placeholder="Internal notes (not shown to farmer)"
+                  rows={2}
+                />
+              </div>
+
+              {selected.reviewedAt && (
+                <p className="text-xs text-muted-foreground">
+                  Last reviewed {formatDate(selected.reviewedAt)}
+                </p>
+              )}
+            </div>
+          ) : null}
+
+          <SheetFooter>
+            <Button onClick={handleSave} disabled={saving || detailLoading || !selected}>
+              {saving && <Loader2 className="h-4 w-4 animate-spin" />}
+              Save review
+            </Button>
+            <Button variant="outline" onClick={() => setSelected(null)} disabled={saving}>
+              Cancel
+            </Button>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+    </div>
+  )
+}
+
+function PetioleParameters({ parameters }: { parameters: unknown }) {
+  const entries =
+    parameters && typeof parameters === 'object' && !Array.isArray(parameters)
+      ? Object.entries(parameters as Record<string, unknown>)
+      : []
+
+  if (entries.length === 0) {
+    return <p className="text-xs text-muted-foreground">No parameter values recorded.</p>
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+      {entries.map(([key, value]) => (
+        <div key={key} className="flex items-center justify-between text-xs">
+          <span className="text-muted-foreground">{key}</span>
+          <span className="font-medium">{String(value)}</span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/app/consultant/triage/page.tsx
+++ b/src/app/consultant/triage/page.tsx
@@ -187,6 +187,13 @@ export default function TriagePage() {
     }
   }
 
+  // Close the drawer and invalidate any in-flight detail fetch, so a slow
+  // request that resolves after the user closes can't re-open the sheet.
+  const closeDetail = () => {
+    detailRequestRef.current = null
+    setSelected(null)
+  }
+
   const handleSave = async () => {
     if (!access || !selected) return
     setSaving(true)
@@ -218,7 +225,7 @@ export default function TriagePage() {
         )
       )
       toast.success('Triage updated')
-      setSelected(null)
+      closeDetail()
     } catch (error) {
       console.error('Failed to update triage:', error)
       toast.error('Failed to update triage')
@@ -378,7 +385,7 @@ export default function TriagePage() {
       )}
 
       {/* Detail / review drawer */}
-      <Sheet open={selected !== null} onOpenChange={(open) => !open && setSelected(null)}>
+      <Sheet open={selected !== null} onOpenChange={(open) => !open && closeDetail()}>
         <SheetContent className="w-full sm:max-w-lg overflow-y-auto">
           <SheetHeader>
             <SheetTitle>{selected?.farmerName || 'Triage review'}</SheetTitle>
@@ -498,7 +505,7 @@ export default function TriagePage() {
               {saving && <Loader2 className="h-4 w-4 animate-spin" />}
               Save review
             </Button>
-            <Button variant="outline" onClick={() => setSelected(null)} disabled={saving}>
+            <Button variant="outline" onClick={closeDetail} disabled={saving}>
               Cancel
             </Button>
           </SheetFooter>

--- a/src/app/consultant/triage/page.tsx
+++ b/src/app/consultant/triage/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -95,6 +95,7 @@ export default function TriagePage() {
   const [severityFilter, setSeverityFilter] = useState<string>('all')
 
   const [selected, setSelected] = useState<TriageDetail | null>(null)
+  const detailRequestRef = useRef<string | null>(null)
   const [detailLoading, setDetailLoading] = useState(false)
   const [saving, setSaving] = useState(false)
 
@@ -123,7 +124,7 @@ export default function TriagePage() {
       setItems(data)
     } catch (error) {
       console.error('Failed to load triage:', error)
-      toast.error(error instanceof Error ? error.message : 'Failed to load triage queue')
+      toast.error('Failed to load triage queue')
     } finally {
       setLoading(false)
     }
@@ -159,8 +160,11 @@ export default function TriagePage() {
     if (!access) return
     setDetailLoading(true)
     setSelected({ ...item, petioleTest: null })
+    detailRequestRef.current = item.id
     try {
       const detail = await getTriageItem(access, item.id)
+      // Ignore a stale response if a different item was opened in the meantime.
+      if (detailRequestRef.current !== item.id) return
       if (!detail) {
         toast.error('Triage item is no longer available')
         setSelected(null)
@@ -174,11 +178,12 @@ export default function TriagePage() {
       setFormRecommendation(detail.recommendation ?? '')
       setFormReviewNotes(detail.reviewNotes ?? '')
     } catch (error) {
+      if (detailRequestRef.current !== item.id) return
       console.error('Failed to load triage detail:', error)
-      toast.error(error instanceof Error ? error.message : 'Failed to load triage detail')
+      toast.error('Failed to load triage detail')
       setSelected(null)
     } finally {
-      setDetailLoading(false)
+      if (detailRequestRef.current === item.id) setDetailLoading(false)
     }
   }
 
@@ -216,7 +221,7 @@ export default function TriagePage() {
       setSelected(null)
     } catch (error) {
       console.error('Failed to update triage:', error)
-      toast.error(error instanceof Error ? error.message : 'Failed to update triage')
+      toast.error('Failed to update triage')
     } finally {
       setSaving(false)
     }
@@ -518,7 +523,9 @@ function PetioleParameters({ parameters }: { parameters: unknown }) {
       {entries.map(([key, value]) => (
         <div key={key} className="flex items-center justify-between text-xs">
           <span className="text-muted-foreground">{key}</span>
-          <span className="font-medium">{String(value)}</span>
+          <span className="font-medium">
+            {value !== null && typeof value === 'object' ? JSON.stringify(value) : String(value)}
+          </span>
         </div>
       ))}
     </div>

--- a/src/lib/__tests__/consultant-triage-service.test.ts
+++ b/src/lib/__tests__/consultant-triage-service.test.ts
@@ -240,6 +240,92 @@ describe('getTriageItems', () => {
     expect(items).toEqual([])
     expect(from).not.toHaveBeenCalledWith('petiole_triage')
   })
+
+  it('wires status, severity, and farmId filters into the triage query', async () => {
+    const triage = mockChain({ data: [], error: null })
+    const { client } = mockClient({
+      organization_clients: [
+        mockChain({ data: [{ client_user_id: 'farmer-1', assigned_to: null }], error: null })
+      ],
+      petiole_triage: [triage]
+    })
+
+    await getTriageItems(ownerAccess(), { status: 'reviewed', severity: 'high', farmId: 1 }, client)
+
+    expect(triage.calls).toContainEqual(['eq', ['status', 'reviewed']])
+    expect(triage.calls).toContainEqual(['eq', ['severity', 'high']])
+    expect(triage.calls).toContainEqual(['eq', ['farm_id', 1]])
+    // Newest-first ordering is requested from the DB, not sorted in memory.
+    expect(triage.calls).toContainEqual(['order', ['created_at', { ascending: false }]])
+  })
+
+  it('enriches items with the linked petiole test date', async () => {
+    const testChain = mockChain({ data: [{ id: 99, date: '2026-02-01' }], error: null })
+    const { client } = mockClient({
+      organization_clients: [
+        mockChain({ data: [{ client_user_id: 'farmer-1', assigned_to: null }], error: null })
+      ],
+      petiole_triage: [
+        mockChain({
+          data: [makeRow({ id: 't1', client_user_id: 'farmer-1', petiole_test_id: 99 })],
+          error: null
+        })
+      ],
+      profiles: [mockChain({ data: [{ id: 'farmer-1', full_name: 'Farmer One' }], error: null })],
+      farms: [mockChain({ data: [{ id: 1, name: 'Farm 1' }], error: null })],
+      petiole_test_records: [testChain]
+    })
+
+    const items = await getTriageItems(ownerAccess(), {}, client)
+
+    expect(items[0].testDate).toBe('2026-02-01')
+    expect(testChain.calls).toContainEqual(['in', ['id', [99]]])
+  })
+
+  it('applies the in-memory search filter on farmer and farm names', async () => {
+    const { client } = mockClient({
+      organization_clients: [
+        mockChain({
+          data: [
+            { client_user_id: 'farmer-1', assigned_to: null },
+            { client_user_id: 'farmer-2', assigned_to: null }
+          ],
+          error: null
+        })
+      ],
+      petiole_triage: [
+        mockChain({
+          data: [
+            makeRow({ id: 't1', client_user_id: 'farmer-1', farm_id: 1 }),
+            makeRow({ id: 't2', client_user_id: 'farmer-2', farm_id: 2 })
+          ],
+          error: null
+        })
+      ],
+      profiles: [
+        mockChain({
+          data: [
+            { id: 'farmer-1', full_name: 'Alice Grower' },
+            { id: 'farmer-2', full_name: 'Bob Vintner' }
+          ],
+          error: null
+        })
+      ],
+      farms: [
+        mockChain({
+          data: [
+            { id: 1, name: 'North Block' },
+            { id: 2, name: 'South Block' }
+          ],
+          error: null
+        })
+      ]
+    })
+
+    const items = await getTriageItems(ownerAccess(), { search: 'alice' }, client)
+
+    expect(items.map((i) => i.id)).toEqual(['t1'])
+  })
 })
 
 describe('getTriageItem', () => {
@@ -283,6 +369,42 @@ describe('getTriageItem', () => {
 
     expect(item).toBeNull()
   })
+
+  it('maps the linked petiole test values into the detail', async () => {
+    const { client } = mockClient({
+      petiole_triage: [
+        mockChain({
+          data: makeRow({ id: 't1', client_user_id: 'farmer-1', petiole_test_id: 99 }),
+          error: null
+        })
+      ],
+      organization_clients: [mockChain({ data: { assigned_to: null }, error: null })],
+      profiles: [mockChain({ data: [{ id: 'farmer-1', full_name: 'Farmer One' }], error: null })],
+      farms: [mockChain({ data: [{ id: 1, name: 'Farm 1' }], error: null })],
+      petiole_test_records: [
+        // First call: loadDisplayMaps .in() for the list test-date map.
+        mockChain({ data: [{ id: 99, date: '2026-02-01' }], error: null }),
+        // Second call: the detail .maybeSingle() fetch.
+        mockChain({
+          data: {
+            id: 99,
+            date: '2026-02-01',
+            date_of_pruning: '2025-12-15',
+            parameters: { N: 2.1, K: 1.4 },
+            recommendations: 'Increase N',
+            notes: null
+          },
+          error: null
+        })
+      ]
+    })
+
+    const item = await getTriageItem(ownerAccess(), 't1', client)
+
+    expect(item?.petioleTest?.id).toBe(99)
+    expect(item?.petioleTest?.dateOfPruning).toBe('2025-12-15')
+    expect(item?.petioleTest?.parameters).toEqual({ N: 2.1, K: 1.4 })
+  })
 })
 
 describe('updateTriageReview', () => {
@@ -322,13 +444,14 @@ describe('updateTriageReview', () => {
   })
 
   it('assigned agronomist can update review fields', async () => {
+    const updateChain = mockChain({ data: makeRow({ id: 't1', status: 'in_review' }), error: null })
     const { client } = mockClient({
       petiole_triage: [
         mockChain({
           data: { id: 't1', organization_id: 'org-1', client_user_id: 'farmer-2' },
           error: null
         }),
-        mockChain({ data: makeRow({ id: 't1', status: 'in_review' }), error: null })
+        updateChain
       ],
       organization_clients: [mockChain({ data: { assigned_to: 'agro-1' }, error: null })]
     })
@@ -341,6 +464,10 @@ describe('updateTriageReview', () => {
     )
 
     expect(result.status).toBe('in_review')
+    // Stamp must carry the acting agronomist's id, not a hardcoded reviewer.
+    const updateCall = updateChain.calls.find((c) => c[0] === 'update')
+    const payload = (updateCall?.[1] as Record<string, unknown>[])[0]
+    expect(payload.reviewed_by).toBe('agro-1')
   })
 
   it('unassigned agronomist cannot update and never issues an update', async () => {

--- a/src/lib/__tests__/consultant-triage-service.test.ts
+++ b/src/lib/__tests__/consultant-triage-service.test.ts
@@ -1,0 +1,389 @@
+import { describe, it, expect, vi } from 'vitest'
+import { getTriageItems, getTriageItem, updateTriageReview } from '../consultant-triage-service'
+import { type ConsultantAccess } from '../consultant-access'
+
+type Maybe<T> = { data: T | null; error: unknown }
+
+const ALLOWED_UPDATE_KEYS = new Set([
+  'reviewed_by',
+  'reviewed_at',
+  'status',
+  'severity',
+  'classification',
+  'summary',
+  'recommendation',
+  'review_notes'
+])
+
+function ownerAccess(): ConsultantAccess {
+  return {
+    userId: 'owner-1',
+    organizationId: 'org-1',
+    role: 'owner',
+    canViewAllFarmers: true,
+    isAgronomist: false
+  }
+}
+
+function adminAccess(): ConsultantAccess {
+  return {
+    userId: 'admin-1',
+    organizationId: 'org-1',
+    role: 'admin',
+    canViewAllFarmers: true,
+    isAgronomist: false
+  }
+}
+
+function agronomistAccess(userId = 'agro-1'): ConsultantAccess {
+  return {
+    userId,
+    organizationId: 'org-1',
+    role: 'agronomist',
+    canViewAllFarmers: false,
+    isAgronomist: true
+  }
+}
+
+function makeRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 't1',
+    organization_id: 'org-1',
+    farm_id: 1,
+    petiole_test_id: null,
+    client_user_id: 'farmer-1',
+    status: 'pending',
+    severity: null,
+    classification: null,
+    summary: null,
+    recommendation: null,
+    review_notes: null,
+    reviewed_by: null,
+    reviewed_at: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides
+  }
+}
+
+type ChainCalls = Array<[string, unknown[]]>
+
+interface MockChain {
+  calls: ChainCalls
+  select: (...a: unknown[]) => MockChain
+  eq: (...a: unknown[]) => MockChain
+  in: (...a: unknown[]) => MockChain
+  order: (...a: unknown[]) => MockChain
+  update: (...a: unknown[]) => MockChain
+  insert: (...a: unknown[]) => MockChain
+  single: () => Promise<Maybe<unknown>>
+  maybeSingle: () => Promise<Maybe<unknown>>
+  then: (
+    resolve: (v: Maybe<unknown>) => unknown,
+    reject: (e: unknown) => unknown
+  ) => Promise<unknown>
+}
+
+/** A chainable, awaitable mock query that records its calls. */
+function mockChain(result: Maybe<unknown> = { data: null, error: null }): MockChain {
+  const calls: ChainCalls = []
+  const chain: MockChain = {
+    calls,
+    select: vi.fn((...a: unknown[]) => (calls.push(['select', a]), chain)),
+    eq: vi.fn((...a: unknown[]) => (calls.push(['eq', a]), chain)),
+    in: vi.fn((...a: unknown[]) => (calls.push(['in', a]), chain)),
+    order: vi.fn((...a: unknown[]) => (calls.push(['order', a]), chain)),
+    update: vi.fn((...a: unknown[]) => (calls.push(['update', a]), chain)),
+    insert: vi.fn((...a: unknown[]) => (calls.push(['insert', a]), chain)),
+    single: vi.fn(() => Promise.resolve(result)),
+    maybeSingle: vi.fn(() => Promise.resolve(result)),
+    then: (resolve: (v: Maybe<unknown>) => unknown, reject: (e: unknown) => unknown) =>
+      Promise.resolve(result).then(resolve, reject)
+  }
+  return chain
+}
+
+/** Build a Supabase-like client that hands out queued chains per table. */
+function mockClient(queues: Record<string, MockChain[]>) {
+  const counters: Record<string, number> = {}
+  const handed: Record<string, MockChain[]> = {}
+  const from = vi.fn((table: string) => {
+    const i = counters[table] ?? 0
+    counters[table] = i + 1
+    const chain = (queues[table] ?? [])[i]
+    if (!chain) {
+      throw new Error(`No mock chain queued for "${table}" call #${i}`)
+    }
+    ;(handed[table] ??= []).push(chain)
+    return chain
+  })
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return { client: { from } as any, from, handed }
+}
+
+describe('getTriageItems', () => {
+  it('owner sees triage for all active org clients', async () => {
+    const orgClients = mockChain({
+      data: [
+        { client_user_id: 'farmer-1', assigned_to: null },
+        { client_user_id: 'farmer-2', assigned_to: 'agro-1' }
+      ],
+      error: null
+    })
+    const triage = mockChain({
+      data: [
+        makeRow({ id: 't1', client_user_id: 'farmer-1', farm_id: 1 }),
+        makeRow({ id: 't2', client_user_id: 'farmer-2', farm_id: 2 })
+      ],
+      error: null
+    })
+    const { client } = mockClient({
+      organization_clients: [orgClients],
+      petiole_triage: [triage],
+      profiles: [
+        mockChain({
+          data: [
+            { id: 'farmer-1', full_name: 'Farmer One' },
+            { id: 'farmer-2', full_name: 'Farmer Two' }
+          ],
+          error: null
+        })
+      ],
+      farms: [
+        mockChain({
+          data: [
+            { id: 1, name: 'Farm 1' },
+            { id: 2, name: 'Farm 2' }
+          ],
+          error: null
+        })
+      ]
+    })
+
+    const items = await getTriageItems(ownerAccess(), {}, client)
+
+    expect(items.map((i) => i.id)).toEqual(['t1', 't2'])
+    expect(items[0].farmerName).toBe('Farmer One')
+    // Owner must NOT be scoped by assigned_to
+    expect(orgClients.calls).not.toContainEqual(['eq', ['assigned_to', 'owner-1']])
+  })
+
+  it('admin sees triage for all active org clients', async () => {
+    const orgClients = mockChain({
+      data: [{ client_user_id: 'farmer-1', assigned_to: null }],
+      error: null
+    })
+    const { client } = mockClient({
+      organization_clients: [orgClients],
+      petiole_triage: [
+        mockChain({ data: [makeRow({ id: 't1', client_user_id: 'farmer-1' })], error: null })
+      ],
+      profiles: [mockChain({ data: [{ id: 'farmer-1', full_name: 'Farmer One' }], error: null })],
+      farms: [mockChain({ data: [{ id: 1, name: 'Farm 1' }], error: null })]
+    })
+
+    const items = await getTriageItems(adminAccess(), {}, client)
+
+    expect(items).toHaveLength(1)
+    expect(orgClients.calls).not.toContainEqual(['eq', ['assigned_to', 'admin-1']])
+  })
+
+  it('agronomist sees triage only for assigned clients', async () => {
+    const orgClients = mockChain({
+      data: [{ client_user_id: 'farmer-2', assigned_to: 'agro-1' }],
+      error: null
+    })
+    const triage = mockChain({
+      data: [makeRow({ id: 't2', client_user_id: 'farmer-2', farm_id: 2 })],
+      error: null
+    })
+    const { client } = mockClient({
+      organization_clients: [orgClients],
+      petiole_triage: [triage],
+      profiles: [mockChain({ data: [{ id: 'farmer-2', full_name: 'Farmer Two' }], error: null })],
+      farms: [mockChain({ data: [{ id: 2, name: 'Farm 2' }], error: null })]
+    })
+
+    const items = await getTriageItems(agronomistAccess('agro-1'), {}, client)
+
+    expect(items.map((i) => i.clientUserId)).toEqual(['farmer-2'])
+    // Visibility scoped to the agronomist's assignments...
+    expect(orgClients.calls).toContainEqual(['eq', ['assigned_to', 'agro-1']])
+    // ...and the triage query is restricted to only those client ids.
+    expect(triage.calls).toContainEqual(['in', ['client_user_id', ['farmer-2']]])
+  })
+
+  it('unassigned agronomist with no clients sees nothing and never queries triage', async () => {
+    const { client, from } = mockClient({
+      organization_clients: [mockChain({ data: [], error: null })]
+    })
+
+    const items = await getTriageItems(agronomistAccess('agro-unassigned'), {}, client)
+
+    expect(items).toEqual([])
+    expect(from).not.toHaveBeenCalledWith('petiole_triage')
+  })
+
+  it('ignores a farmerId filter outside the consultant visibility set', async () => {
+    const { client, from } = mockClient({
+      organization_clients: [
+        mockChain({ data: [{ client_user_id: 'farmer-1', assigned_to: 'agro-1' }], error: null })
+      ]
+    })
+
+    const items = await getTriageItems(
+      agronomistAccess('agro-1'),
+      { farmerId: 'someone-else' },
+      client
+    )
+
+    expect(items).toEqual([])
+    expect(from).not.toHaveBeenCalledWith('petiole_triage')
+  })
+})
+
+describe('getTriageItem', () => {
+  it('owner can read a triage item for an active org client', async () => {
+    const { client } = mockClient({
+      petiole_triage: [
+        mockChain({ data: makeRow({ id: 't1', client_user_id: 'farmer-1' }), error: null })
+      ],
+      organization_clients: [mockChain({ data: { assigned_to: null }, error: null })],
+      profiles: [mockChain({ data: [{ id: 'farmer-1', full_name: 'Farmer One' }], error: null })],
+      farms: [mockChain({ data: [{ id: 1, name: 'Farm 1' }], error: null })]
+    })
+
+    const item = await getTriageItem(ownerAccess(), 't1', client)
+
+    expect(item?.id).toBe('t1')
+    expect(item?.farmerName).toBe('Farmer One')
+  })
+
+  it('returns null for a triage item belonging to another organization', async () => {
+    const { client } = mockClient({
+      petiole_triage: [
+        mockChain({ data: makeRow({ id: 't1', organization_id: 'org-OTHER' }), error: null })
+      ]
+    })
+
+    const item = await getTriageItem(ownerAccess(), 't1', client)
+
+    expect(item).toBeNull()
+  })
+
+  it('returns null for an unassigned agronomist viewing another farmer triage', async () => {
+    const { client } = mockClient({
+      petiole_triage: [
+        mockChain({ data: makeRow({ id: 't1', client_user_id: 'farmer-1' }), error: null })
+      ],
+      organization_clients: [mockChain({ data: { assigned_to: 'other-agro' }, error: null })]
+    })
+
+    const item = await getTriageItem(agronomistAccess('agro-1'), 't1', client)
+
+    expect(item).toBeNull()
+  })
+})
+
+describe('updateTriageReview', () => {
+  it('owner can update review fields and only writes consultant fields', async () => {
+    const updateChain = mockChain({
+      data: makeRow({ id: 't1', status: 'reviewed', reviewed_by: 'owner-1' }),
+      error: null
+    })
+    const { client } = mockClient({
+      petiole_triage: [
+        mockChain({
+          data: { id: 't1', organization_id: 'org-1', client_user_id: 'farmer-1' },
+          error: null
+        }),
+        updateChain
+      ],
+      organization_clients: [mockChain({ data: { assigned_to: null }, error: null })]
+    })
+
+    const result = await updateTriageReview(
+      ownerAccess(),
+      't1',
+      { status: 'reviewed', classification: 'N deficiency', reviewNotes: 'looks fine' },
+      client
+    )
+
+    expect(result.status).toBe('reviewed')
+    const updateCall = updateChain.calls.find((c) => c[0] === 'update')
+    expect(updateCall).toBeDefined()
+    const payload = (updateCall?.[1] as Record<string, unknown>[])[0]
+    expect(payload.reviewed_by).toBe('owner-1')
+    expect(payload.reviewed_at).toBeTruthy()
+    // No farmer-facing / non-review fields may be written.
+    for (const key of Object.keys(payload)) {
+      expect(ALLOWED_UPDATE_KEYS.has(key)).toBe(true)
+    }
+  })
+
+  it('assigned agronomist can update review fields', async () => {
+    const { client } = mockClient({
+      petiole_triage: [
+        mockChain({
+          data: { id: 't1', organization_id: 'org-1', client_user_id: 'farmer-2' },
+          error: null
+        }),
+        mockChain({ data: makeRow({ id: 't1', status: 'in_review' }), error: null })
+      ],
+      organization_clients: [mockChain({ data: { assigned_to: 'agro-1' }, error: null })]
+    })
+
+    const result = await updateTriageReview(
+      agronomistAccess('agro-1'),
+      't1',
+      { status: 'in_review' },
+      client
+    )
+
+    expect(result.status).toBe('in_review')
+  })
+
+  it('unassigned agronomist cannot update and never issues an update', async () => {
+    const updateChain = mockChain({ data: makeRow(), error: null })
+    const { client } = mockClient({
+      petiole_triage: [
+        mockChain({
+          data: { id: 't1', organization_id: 'org-1', client_user_id: 'farmer-2' },
+          error: null
+        }),
+        updateChain
+      ],
+      organization_clients: [mockChain({ data: { assigned_to: 'other-agro' }, error: null })]
+    })
+
+    await expect(
+      updateTriageReview(agronomistAccess('agro-1'), 't1', { status: 'reviewed' }, client)
+    ).rejects.toThrow('Forbidden')
+    expect(updateChain.calls.find((c) => c[0] === 'update')).toBeUndefined()
+  })
+
+  it('throws when the triage item is in another organization', async () => {
+    const { client } = mockClient({
+      petiole_triage: [
+        mockChain({
+          data: { id: 't1', organization_id: 'org-OTHER', client_user_id: 'farmer-1' },
+          error: null
+        })
+      ]
+    })
+
+    await expect(
+      updateTriageReview(ownerAccess(), 't1', { status: 'reviewed' }, client)
+    ).rejects.toThrow('Triage item not found')
+  })
+
+  it('throws when the triage item does not exist', async () => {
+    const { client } = mockClient({
+      petiole_triage: [mockChain({ data: null, error: null })]
+    })
+
+    await expect(
+      updateTriageReview(ownerAccess(), 'missing', { status: 'reviewed' }, client)
+    ).rejects.toThrow('Triage item not found')
+  })
+})

--- a/src/lib/consultant-triage-service.ts
+++ b/src/lib/consultant-triage-service.ts
@@ -1,0 +1,413 @@
+import { type SupabaseClient } from '@supabase/supabase-js'
+import type { Database, Json } from '@/types/database'
+import { getTypedSupabaseClient } from './supabase'
+import { type ConsultantAccess } from './consultant-access'
+
+export type TriageStatus = 'pending' | 'in_review' | 'reviewed' | 'escalated' | 'resolved'
+export type TriageSeverity = 'low' | 'medium' | 'high' | 'critical'
+
+export const TRIAGE_STATUSES: TriageStatus[] = [
+  'pending',
+  'in_review',
+  'reviewed',
+  'escalated',
+  'resolved'
+]
+export const TRIAGE_SEVERITIES: TriageSeverity[] = ['low', 'medium', 'high', 'critical']
+
+/** A triage row enriched with farmer/farm display fields for the review queue. */
+export interface TriageItem {
+  id: string
+  organizationId: string
+  farmId: number
+  petioleTestId: number | null
+  clientUserId: string
+  status: TriageStatus
+  severity: TriageSeverity | null
+  classification: string | null
+  summary: string | null
+  recommendation: string | null
+  reviewNotes: string | null
+  reviewedBy: string | null
+  reviewedAt: string | null
+  createdAt: string | null
+  updatedAt: string | null
+  // Enriched (display-only) fields
+  farmerName: string | null
+  farmName: string | null
+  testDate: string | null
+}
+
+export interface TriagePetioleTest {
+  id: number
+  date: string | null
+  dateOfPruning: string | null
+  parameters: Json | null
+  recommendations: string | null
+  notes: string | null
+}
+
+export interface TriageDetail extends TriageItem {
+  petioleTest: TriagePetioleTest | null
+}
+
+export interface TriageFilters {
+  status?: TriageStatus
+  severity?: TriageSeverity
+  farmerId?: string
+  farmId?: number
+  /** Free-text match against farmer or farm name (applied in-memory). */
+  search?: string
+}
+
+/** Consultant-only review fields. Farmer-facing fields are intentionally excluded. */
+export interface TriageReviewPayload {
+  status?: TriageStatus
+  severity?: TriageSeverity | null
+  classification?: string | null
+  summary?: string | null
+  recommendation?: string | null
+  reviewNotes?: string | null
+}
+
+type TriageClient = SupabaseClient<Database>
+type TriageRow = Database['public']['Tables']['petiole_triage']['Row']
+
+async function resolveClient(client?: TriageClient): Promise<TriageClient> {
+  return client ?? (await getTypedSupabaseClient())
+}
+
+/**
+ * Resolve the set of farmer (client_user_id) values the consultant may act on.
+ * Owner/admin: all active clients in the org.
+ * Agronomist: only active clients where assigned_to = access.userId.
+ * Always sourced from organization_clients — never profiles.consultant_organization_id.
+ */
+async function getVisibleClientIds(
+  access: ConsultantAccess,
+  supabase: TriageClient
+): Promise<string[]> {
+  let query = supabase
+    .from('organization_clients')
+    .select('client_user_id, assigned_to')
+    .eq('organization_id', access.organizationId)
+    .eq('status', 'active')
+
+  if (!access.canViewAllFarmers) {
+    query = query.eq('assigned_to', access.userId)
+  }
+
+  const { data, error } = await query
+
+  if (error) {
+    throw new Error(`Failed to load organization clients: ${error.message}`)
+  }
+
+  return (data ?? []).map((row) => row.client_user_id)
+}
+
+/**
+ * Confirm the consultant may act on a specific farmer (active client of the org,
+ * and — for agronomists — assigned to them). Returns false when not permitted.
+ */
+async function canAccessClient(
+  access: ConsultantAccess,
+  clientUserId: string,
+  supabase: TriageClient
+): Promise<boolean> {
+  const { data, error } = await supabase
+    .from('organization_clients')
+    .select('assigned_to')
+    .eq('organization_id', access.organizationId)
+    .eq('client_user_id', clientUserId)
+    .eq('status', 'active')
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(`Failed to validate triage access: ${error.message}`)
+  }
+
+  if (!data) {
+    return false
+  }
+
+  if (!access.canViewAllFarmers && data.assigned_to !== access.userId) {
+    return false
+  }
+
+  return true
+}
+
+function toTriageItem(
+  row: TriageRow,
+  farmerName: string | null,
+  farmName: string | null,
+  testDate: string | null
+): TriageItem {
+  return {
+    id: row.id,
+    organizationId: row.organization_id,
+    farmId: row.farm_id,
+    petioleTestId: row.petiole_test_id,
+    clientUserId: row.client_user_id,
+    status: row.status,
+    severity: row.severity,
+    classification: row.classification,
+    summary: row.summary,
+    recommendation: row.recommendation,
+    reviewNotes: row.review_notes,
+    reviewedBy: row.reviewed_by,
+    reviewedAt: row.reviewed_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    farmerName,
+    farmName,
+    testDate
+  }
+}
+
+/**
+ * List triage items the consultant is allowed to see, newest first.
+ * Visibility is enforced here (in addition to RLS) so the UI gets clear,
+ * scoped results: owner/admin see all active org clients; agronomists see
+ * only their assigned clients.
+ */
+export async function getTriageItems(
+  access: ConsultantAccess,
+  filters: TriageFilters = {},
+  client?: TriageClient
+): Promise<TriageItem[]> {
+  const supabase = await resolveClient(client)
+
+  const visibleClientIds = await getVisibleClientIds(access, supabase)
+  if (visibleClientIds.length === 0) {
+    return []
+  }
+
+  // Honor an explicit farmerId filter without widening visibility.
+  const targetClientIds = filters.farmerId
+    ? visibleClientIds.filter((id) => id === filters.farmerId)
+    : visibleClientIds
+  if (targetClientIds.length === 0) {
+    return []
+  }
+
+  let query = supabase
+    .from('petiole_triage')
+    .select('*')
+    .eq('organization_id', access.organizationId)
+    .in('client_user_id', targetClientIds)
+
+  if (filters.status) query = query.eq('status', filters.status)
+  if (filters.severity) query = query.eq('severity', filters.severity)
+  if (typeof filters.farmId === 'number') query = query.eq('farm_id', filters.farmId)
+
+  const { data, error } = await query.order('created_at', { ascending: false })
+
+  if (error) {
+    throw new Error(`Failed to load triage items: ${error.message}`)
+  }
+
+  const rows = (data ?? []) as TriageRow[]
+  if (rows.length === 0) {
+    return []
+  }
+
+  const { farmerNames, farmNames, testDates } = await loadDisplayMaps(rows, supabase)
+
+  let items = rows.map((row) =>
+    toTriageItem(
+      row,
+      farmerNames.get(row.client_user_id) ?? null,
+      farmNames.get(row.farm_id) ?? null,
+      row.petiole_test_id != null ? (testDates.get(row.petiole_test_id) ?? null) : null
+    )
+  )
+
+  if (filters.search) {
+    const q = filters.search.toLowerCase()
+    items = items.filter(
+      (item) =>
+        item.farmerName?.toLowerCase().includes(q) || item.farmName?.toLowerCase().includes(q)
+    )
+  }
+
+  return items
+}
+
+/**
+ * Fetch a single triage item (with its linked petiole test values), scoped to
+ * what the consultant may access. Returns null when the item does not exist or
+ * is outside the consultant's visibility.
+ */
+export async function getTriageItem(
+  access: ConsultantAccess,
+  triageId: string,
+  client?: TriageClient
+): Promise<TriageDetail | null> {
+  const supabase = await resolveClient(client)
+
+  const { data, error } = await supabase
+    .from('petiole_triage')
+    .select('*')
+    .eq('id', triageId)
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(`Failed to load triage item: ${error.message}`)
+  }
+
+  const row = data as TriageRow | null
+  if (!row) {
+    return null
+  }
+
+  if (row.organization_id !== access.organizationId) {
+    return null
+  }
+
+  const allowed = await canAccessClient(access, row.client_user_id, supabase)
+  if (!allowed) {
+    return null
+  }
+
+  const { farmerNames, farmNames, testDates } = await loadDisplayMaps([row], supabase)
+
+  const item = toTriageItem(
+    row,
+    farmerNames.get(row.client_user_id) ?? null,
+    farmNames.get(row.farm_id) ?? null,
+    row.petiole_test_id != null ? (testDates.get(row.petiole_test_id) ?? null) : null
+  )
+
+  let petioleTest: TriagePetioleTest | null = null
+  if (row.petiole_test_id != null) {
+    const { data: test, error: testError } = await supabase
+      .from('petiole_test_records')
+      .select('id, date, date_of_pruning, parameters, recommendations, notes')
+      .eq('id', row.petiole_test_id)
+      .maybeSingle()
+
+    if (testError) {
+      throw new Error(`Failed to load petiole test: ${testError.message}`)
+    }
+
+    if (test) {
+      petioleTest = {
+        id: test.id,
+        date: test.date,
+        dateOfPruning: test.date_of_pruning,
+        parameters: test.parameters,
+        recommendations: test.recommendations,
+        notes: test.notes
+      }
+    }
+  }
+
+  return { ...item, petioleTest }
+}
+
+/**
+ * Update consultant review fields on a triage item after confirming the
+ * consultant may act on the underlying client. Stamps reviewed_by/reviewed_at.
+ * Throws on not-found or forbidden so callers can surface a clear error.
+ */
+export async function updateTriageReview(
+  access: ConsultantAccess,
+  triageId: string,
+  payload: TriageReviewPayload,
+  client?: TriageClient
+): Promise<TriageItem> {
+  const supabase = await resolveClient(client)
+
+  const { data, error } = await supabase
+    .from('petiole_triage')
+    .select('id, organization_id, client_user_id')
+    .eq('id', triageId)
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(`Failed to load triage item: ${error.message}`)
+  }
+
+  if (!data || data.organization_id !== access.organizationId) {
+    throw new Error('Triage item not found')
+  }
+
+  const allowed = await canAccessClient(access, data.client_user_id, supabase)
+  if (!allowed) {
+    throw new Error('Forbidden')
+  }
+
+  const update: Database['public']['Tables']['petiole_triage']['Update'] = {
+    reviewed_by: access.userId,
+    reviewed_at: new Date().toISOString()
+  }
+
+  if (payload.status !== undefined) update.status = payload.status
+  if (payload.severity !== undefined) update.severity = payload.severity
+  if (payload.classification !== undefined) update.classification = payload.classification
+  if (payload.summary !== undefined) update.summary = payload.summary
+  if (payload.recommendation !== undefined) update.recommendation = payload.recommendation
+  if (payload.reviewNotes !== undefined) update.review_notes = payload.reviewNotes
+
+  const { data: updated, error: updateError } = await supabase
+    .from('petiole_triage')
+    .update(update)
+    .eq('id', triageId)
+    .select('*')
+    .single()
+
+  if (updateError) {
+    throw new Error(`Failed to update triage review: ${updateError.message}`)
+  }
+
+  const row = updated as TriageRow
+  return toTriageItem(row, null, null, null)
+}
+
+/** Batch-load farmer names, farm names, and petiole test dates for display. */
+async function loadDisplayMaps(
+  rows: TriageRow[],
+  supabase: TriageClient
+): Promise<{
+  farmerNames: Map<string, string | null>
+  farmNames: Map<number, string | null>
+  testDates: Map<number, string | null>
+}> {
+  const clientIds = Array.from(new Set(rows.map((r) => r.client_user_id)))
+  const farmIds = Array.from(new Set(rows.map((r) => r.farm_id)))
+  const testIds = Array.from(
+    new Set(rows.map((r) => r.petiole_test_id).filter((id): id is number => id != null))
+  )
+
+  const farmerNames = new Map<string, string | null>()
+  const farmNames = new Map<number, string | null>()
+  const testDates = new Map<number, string | null>()
+
+  if (clientIds.length > 0) {
+    const { data: profiles, error } = await supabase
+      .from('profiles')
+      .select('id, full_name')
+      .in('id', clientIds)
+    if (error) throw new Error(`Failed to load farmer profiles: ${error.message}`)
+    for (const p of profiles ?? []) farmerNames.set(p.id, p.full_name)
+  }
+
+  if (farmIds.length > 0) {
+    const { data: farms, error } = await supabase.from('farms').select('id, name').in('id', farmIds)
+    if (error) throw new Error(`Failed to load farms: ${error.message}`)
+    for (const f of farms ?? []) farmNames.set(f.id, f.name)
+  }
+
+  if (testIds.length > 0) {
+    const { data: tests, error } = await supabase
+      .from('petiole_test_records')
+      .select('id, date')
+      .in('id', testIds)
+    if (error) throw new Error(`Failed to load petiole tests: ${error.message}`)
+    for (const t of tests ?? []) testDates.set(t.id, t.date)
+  }
+
+  return { farmerNames, farmNames, testDates }
+}

--- a/src/lib/consultant-triage-service.ts
+++ b/src/lib/consultant-triage-service.ts
@@ -355,6 +355,7 @@ export async function updateTriageReview(
     .from('petiole_triage')
     .update(update)
     .eq('id', triageId)
+    .eq('organization_id', access.organizationId)
     .select('*')
     .single()
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -2139,6 +2139,82 @@ export type Database = {
           }
         ]
       }
+      petiole_triage: {
+        Row: {
+          id: string
+          organization_id: string
+          farm_id: number
+          petiole_test_id: number | null
+          client_user_id: string
+          status: 'pending' | 'in_review' | 'reviewed' | 'escalated' | 'resolved'
+          severity: 'low' | 'medium' | 'high' | 'critical' | null
+          classification: string | null
+          summary: string | null
+          recommendation: string | null
+          review_notes: string | null
+          reviewed_by: string | null
+          reviewed_at: string | null
+          created_at: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          id?: string
+          organization_id: string
+          farm_id: number
+          petiole_test_id?: number | null
+          client_user_id: string
+          status?: 'pending' | 'in_review' | 'reviewed' | 'escalated' | 'resolved'
+          severity?: 'low' | 'medium' | 'high' | 'critical' | null
+          classification?: string | null
+          summary?: string | null
+          recommendation?: string | null
+          review_notes?: string | null
+          reviewed_by?: string | null
+          reviewed_at?: string | null
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          id?: string
+          organization_id?: string
+          farm_id?: number
+          petiole_test_id?: number | null
+          client_user_id?: string
+          status?: 'pending' | 'in_review' | 'reviewed' | 'escalated' | 'resolved'
+          severity?: 'low' | 'medium' | 'high' | 'critical' | null
+          classification?: string | null
+          summary?: string | null
+          recommendation?: string | null
+          review_notes?: string | null
+          reviewed_by?: string | null
+          reviewed_at?: string | null
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'petiole_triage_organization_id_fkey'
+            columns: ['organization_id']
+            isOneToOne: false
+            referencedRelation: 'organizations'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'petiole_triage_farm_id_fkey'
+            columns: ['farm_id']
+            isOneToOne: false
+            referencedRelation: 'farms'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'petiole_triage_petiole_test_id_fkey'
+            columns: ['petiole_test_id']
+            isOneToOne: false
+            referencedRelation: 'petiole_test_records'
+            referencedColumns: ['id']
+          }
+        ]
+      }
       farmer_invitations: {
         Row: {
           id: string

--- a/supabase/supabase-schema.sql
+++ b/supabase/supabase-schema.sql
@@ -1058,6 +1058,29 @@ CREATE TABLE fertilizer_plan_items (
   created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Petiole triage table (consultant review queue for client petiole tests)
+-- organization_id and client_user_id are kept denormalized for simpler RLS/querying;
+-- visibility is never derived from joins through farms alone.
+CREATE TABLE petiole_triage (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  farm_id BIGINT NOT NULL REFERENCES farms(id) ON DELETE CASCADE,
+  petiole_test_id BIGINT REFERENCES petiole_test_records(id) ON DELETE CASCADE,
+  client_user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  status VARCHAR(50) DEFAULT 'pending' NOT NULL
+    CHECK (status IN ('pending', 'in_review', 'reviewed', 'escalated', 'resolved')),
+  severity VARCHAR(50)
+    CHECK (severity IN ('low', 'medium', 'high', 'critical')),
+  classification TEXT,
+  summary TEXT,
+  recommendation TEXT,
+  review_notes TEXT,
+  reviewed_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  reviewed_at TIMESTAMP WITH TIME ZONE,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
 -- Add organization_id to farms table (for farms managed by organizations)
 -- Note: This is an ALTER TABLE statement - run separately if table already exists
 -- ALTER TABLE farms ADD COLUMN organization_id UUID REFERENCES organizations(id) ON DELETE SET NULL;
@@ -1077,6 +1100,11 @@ CREATE INDEX idx_farmer_invitations_status ON farmer_invitations(status);
 CREATE INDEX idx_fertilizer_plans_farm_id ON fertilizer_plans(farm_id);
 CREATE INDEX idx_fertilizer_plans_organization_id ON fertilizer_plans(organization_id);
 CREATE INDEX idx_fertilizer_plan_items_plan_id ON fertilizer_plan_items(plan_id);
+CREATE INDEX idx_petiole_triage_organization_id ON petiole_triage(organization_id);
+CREATE INDEX idx_petiole_triage_client_user_id ON petiole_triage(client_user_id);
+CREATE INDEX idx_petiole_triage_farm_id ON petiole_triage(farm_id);
+CREATE INDEX idx_petiole_triage_petiole_test_id ON petiole_triage(petiole_test_id);
+CREATE INDEX idx_petiole_triage_status ON petiole_triage(status);
 
 -- Composite indexes for AI and analytics queries
 CREATE INDEX idx_organization_members_org_user ON organization_members(organization_id, user_id);
@@ -1092,6 +1120,7 @@ ALTER TABLE organization_clients ENABLE ROW LEVEL SECURITY;
 ALTER TABLE farmer_invitations ENABLE ROW LEVEL SECURITY;
 ALTER TABLE fertilizer_plans ENABLE ROW LEVEL SECURITY;
 ALTER TABLE fertilizer_plan_items ENABLE ROW LEVEL SECURITY;
+ALTER TABLE petiole_triage ENABLE ROW LEVEL SECURITY;
 
 -- RLS Policies for organizations
 CREATE POLICY "Users can view organizations they belong to" ON organizations FOR SELECT USING (
@@ -1215,6 +1244,72 @@ CREATE POLICY "Org members can delete fertilizer plan items" ON fertilizer_plan_
     WHERE fp.id = fertilizer_plan_items.plan_id AND om.user_id = auth.uid()
   )
 );
+
+-- RLS Policies for petiole_triage
+-- Read: farmers see their own triage; owner/admin see all active org clients;
+-- agronomists see only clients assigned to them. Uses the denormalized
+-- client_user_id + organization_id so visibility never relies on farm joins alone.
+CREATE POLICY "Farmers can view their own triage" ON petiole_triage FOR SELECT USING (
+  auth.uid() = client_user_id
+);
+CREATE POLICY "Org members can view client triage" ON petiole_triage FOR SELECT USING (
+  EXISTS (
+    SELECT 1 FROM organization_clients oc
+    JOIN organization_members om
+      ON om.organization_id = oc.organization_id
+     AND om.user_id = auth.uid()
+    WHERE oc.organization_id = petiole_triage.organization_id
+      AND oc.client_user_id = petiole_triage.client_user_id
+      AND oc.status = 'active'
+      AND (
+        om.role IN ('owner', 'admin')
+        OR om.is_owner = TRUE
+        OR (om.role = 'agronomist' AND oc.assigned_to = auth.uid())
+      )
+  )
+);
+-- Insert: org members can create triage for clients they can see
+-- (owner/admin any active client; agronomist only assigned clients).
+CREATE POLICY "Org members can insert client triage" ON petiole_triage FOR INSERT WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM organization_clients oc
+    JOIN organization_members om
+      ON om.organization_id = oc.organization_id
+     AND om.user_id = auth.uid()
+    WHERE oc.organization_id = petiole_triage.organization_id
+      AND oc.client_user_id = petiole_triage.client_user_id
+      AND oc.status = 'active'
+      AND (
+        om.role IN ('owner', 'admin')
+        OR om.is_owner = TRUE
+        OR (om.role = 'agronomist' AND oc.assigned_to = auth.uid())
+      )
+  )
+);
+-- Update: consultant review fields. Owner/admin for all active clients;
+-- agronomist only for assigned clients. Farmers cannot update triage.
+CREATE POLICY "Org members can update client triage" ON petiole_triage FOR UPDATE USING (
+  EXISTS (
+    SELECT 1 FROM organization_clients oc
+    JOIN organization_members om
+      ON om.organization_id = oc.organization_id
+     AND om.user_id = auth.uid()
+    WHERE oc.organization_id = petiole_triage.organization_id
+      AND oc.client_user_id = petiole_triage.client_user_id
+      AND oc.status = 'active'
+      AND (
+        om.role IN ('owner', 'admin')
+        OR om.is_owner = TRUE
+        OR (om.role = 'agronomist' AND oc.assigned_to = auth.uid())
+      )
+  )
+);
+
+-- Trigger to keep petiole_triage updated_at current
+CREATE TRIGGER update_petiole_triage_updated_at
+  BEFORE UPDATE ON petiole_triage
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
 
 -- Trigger to update fertilizer_plans updated_at timestamp
 CREATE TRIGGER update_fertilizer_plans_updated_at

--- a/supabase/supabase-schema.sql
+++ b/supabase/supabase-schema.sql
@@ -1105,6 +1105,7 @@ CREATE INDEX idx_petiole_triage_client_user_id ON petiole_triage(client_user_id)
 CREATE INDEX idx_petiole_triage_farm_id ON petiole_triage(farm_id);
 CREATE INDEX idx_petiole_triage_petiole_test_id ON petiole_triage(petiole_test_id);
 CREATE INDEX idx_petiole_triage_status ON petiole_triage(status);
+CREATE INDEX idx_petiole_triage_org_status ON petiole_triage(organization_id, status);
 
 -- Composite indexes for AI and analytics queries
 CREATE INDEX idx_organization_members_org_user ON organization_members(organization_id, user_id);
@@ -1246,12 +1247,14 @@ CREATE POLICY "Org members can delete fertilizer plan items" ON fertilizer_plan_
 );
 
 -- RLS Policies for petiole_triage
--- Read: farmers see their own triage; owner/admin see all active org clients;
--- agronomists see only clients assigned to them. Uses the denormalized
--- client_user_id + organization_id so visibility never relies on farm joins alone.
-CREATE POLICY "Farmers can view their own triage" ON petiole_triage FOR SELECT USING (
-  auth.uid() = client_user_id
-);
+-- Read: owner/admin see all active org clients; agronomists see only clients
+-- assigned to them. Uses the denormalized client_user_id + organization_id so
+-- visibility never relies on farm joins alone.
+-- NOTE: This slice is consultant-facing only. There is intentionally NO farmer
+-- SELECT policy: petiole_triage carries consultant-only columns (review_notes,
+-- reviewed_by) and RLS cannot hide individual columns. If farmer-facing triage
+-- is added later, expose it via a farmer-safe view that omits internal fields
+-- rather than granting direct SELECT on this table.
 CREATE POLICY "Org members can view client triage" ON petiole_triage FOR SELECT USING (
   EXISTS (
     SELECT 1 FROM organization_clients oc
@@ -1310,6 +1313,57 @@ CREATE TRIGGER update_petiole_triage_updated_at
   BEFORE UPDATE ON petiole_triage
   FOR EACH ROW
   EXECUTE FUNCTION update_updated_at_column();
+
+-- Enforce that a triage row's denormalized scope is internally consistent:
+-- the farm must belong to the client, and the linked petiole test (if any) must
+-- belong to that farm. RLS only checks organization_id + client_user_id, so
+-- without this a row could reference another farmer's farm/test.
+CREATE OR REPLACE FUNCTION validate_petiole_triage_consistency()
+RETURNS TRIGGER AS $$
+DECLARE
+  farm_owner UUID;
+  test_farm_id BIGINT;
+BEGIN
+  SELECT f.user_id INTO farm_owner FROM farms f WHERE f.id = NEW.farm_id;
+  IF farm_owner IS NULL OR farm_owner <> NEW.client_user_id THEN
+    RAISE EXCEPTION 'farm_id % does not belong to client_user_id %', NEW.farm_id, NEW.client_user_id;
+  END IF;
+
+  IF NEW.petiole_test_id IS NOT NULL THEN
+    SELECT p.farm_id INTO test_farm_id FROM petiole_test_records p WHERE p.id = NEW.petiole_test_id;
+    IF test_farm_id IS NULL OR test_farm_id <> NEW.farm_id THEN
+      RAISE EXCEPTION 'petiole_test_id % does not belong to farm_id %', NEW.petiole_test_id, NEW.farm_id;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER validate_petiole_triage_consistency_trigger
+  BEFORE INSERT OR UPDATE ON petiole_triage
+  FOR EACH ROW
+  EXECUTE FUNCTION validate_petiole_triage_consistency();
+
+-- Identity/scope columns are immutable after insert. RLS cannot reference OLD,
+-- so a trigger is the only way to stop an authorized member from silently
+-- re-attributing an existing triage row to a different org/client/farm/test.
+CREATE OR REPLACE FUNCTION prevent_petiole_triage_scope_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF (OLD.organization_id, OLD.client_user_id, OLD.farm_id, OLD.petiole_test_id)
+     IS DISTINCT FROM
+     (NEW.organization_id, NEW.client_user_id, NEW.farm_id, NEW.petiole_test_id) THEN
+    RAISE EXCEPTION 'petiole_triage scope columns (organization_id, client_user_id, farm_id, petiole_test_id) are immutable after creation';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER prevent_petiole_triage_scope_mutation_trigger
+  BEFORE UPDATE ON petiole_triage
+  FOR EACH ROW
+  EXECUTE FUNCTION prevent_petiole_triage_scope_mutation();
 
 -- Trigger to update fertilizer_plans updated_at timestamp
 CREATE TRIGGER update_fertilizer_plans_updated_at

--- a/test/setup-env.ts
+++ b/test/setup-env.ts
@@ -1,0 +1,6 @@
+// Preloaded before the test suite (see bunfig.toml).
+// Supplies placeholder Supabase credentials so modules that eagerly construct a
+// Supabase client at import time can load. Tests inject mock clients, so these
+// values are never used for real network calls.
+process.env.NEXT_PUBLIC_SUPABASE_URL ||= 'http://localhost:54321'
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||= 'test-anon-key'


### PR DESCRIPTION
## Summary

Adds a consultant-facing **triage** slice: consultant teams can review client petiole test issues in an operational queue, with strict owner/admin/agronomist visibility rules. **Triage only — no plans, templates, clusters, or farmer feedback.**

## What's included

- **Schema + RLS** (`supabase/supabase-schema.sql`): new `petiole_triage` table keeping `organization_id` and a denormalized `client_user_id` so visibility never relies on farm joins alone. RLS mirrors the existing consultant model:
  - Read: farmer → own rows only; owner/admin → all active org clients; agronomist → only `assigned_to = auth.uid()` clients.
  - Insert/Update: owner/admin vs assigned-agronomist scoping. **No farmer update policy.**
- **DB types** (`src/types/database.ts`): hand-maintained `petiole_triage` Row/Insert/Update.
- **Service** (`src/lib/consultant-triage-service.ts`): `getTriageItems` / `getTriageItem` / `updateTriageReview`, accepting `ConsultantAccess` and scoping via `organization_clients` (never `profiles.consultant_organization_id`). Optional injectable client for tests.
- **UI** (`src/app/consultant/triage/page.tsx`): queue with summary counts (pending / high severity / reviewed), status + severity + search filters, a table, and a review drawer showing linked petiole values + a status-update action.
- **Nav** (`src/app/consultant/layout.tsx`): single "Triage" link.
- **Tests** (`src/lib/__tests__/consultant-triage-service.test.ts`): 13 access/mutation cases — owner/admin see all, agronomist sees only assigned, unassigned sees nothing, cross-org isolation, and update permission rules.

## Validation

- `bun run typecheck` — clean
- `bun run lint` — clean for all new files (one pre-existing unrelated error remains in `src/lib/route-persistence.ts`)
- `bun test` — 23/23 pass
- `bun run build` — succeeds; `/consultant/triage` route emitted

## Notes

- Added `bunfig.toml` + `test/setup-env.ts` (test env preload) because importing the service pulls in `supabase.ts`, which eagerly constructs a client. Tests inject mocks, so no real calls happen.
- Apply the `supabase-schema.sql` migration to the Supabase instance before using the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a consultant-only triage queue to review client petiole test issues with strict visibility, DB integrity checks, and a focused review UI. Also fixes a race so the review drawer stays closed if a slow detail fetch resolves after closing.

- **New Features**
  - Schema: new `petiole_triage` with denormalized `client_user_id`; consultant-only RLS (owner/admin → all active org clients; agronomist → only `assigned_to`); no farmer SELECT policy; triggers validate farm/test consistency and make scope columns immutable; indexes incl. `(organization_id, status)`.
  - Service: `getTriageItems`, `getTriageItem`, `updateTriageReview` scoped via `organization_clients` (not `profiles.consultant_organization_id`); UPDATE also scoped by `organization_id`; injectable client for tests.
  - UI: `/consultant/triage` queue with counts, filters, search, and a review drawer with linked petiole values; stale-fetch guard and keeps the drawer closed after a close action; generic error toasts; adds a "Triage" nav link.
  - Tests: access and mutation coverage for owner/admin vs agronomist, unassigned cases, cross-org isolation, and update permissions.

- **Migration**
  - Apply `supabase/supabase-schema.sql` to create `petiole_triage`, indexes, RLS, and triggers (`updated_at`, farm/test consistency, scope immutability) before using the page.

<sup>Written for commit bb99f1b36938cee9cb1d12f023d4a02d9ca282db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ashish921998/Vinesight/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consultant Triage page added with sidebar entry: queue list, filters (status, severity, farm, search), side-drawer details, and in-app review editing with toasts and list updates.

* **Backend**
  * New triage queue table with row-level access controls, indexes, and data-integrity triggers to enforce scope and consistency.

* **API**
  * Server-side triage service and types: listing, single-item fetch, and review updates with consultant visibility/authorization.

* **Tests**
  * Comprehensive tests covering triage read/update logic and visibility rules.

* **Chores**
  * Test environment preload to ensure tests run reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->