### PR TITLE
fix: identify users in PostHog on all auth paths, reset on sign-out

### DIFF
--- a/src/hooks/useSupabaseAuth.ts
+++ b/src/hooks/useSupabaseAuth.ts
@@ -161,10 +161,25 @@ export function useSupabaseAuth() {
     } = supabase.auth.onAuthStateChange((event, session) => {
       // Only update the user state, don't change loading state here
       // to avoid interfering with the loading states from auth operations
+      const sessionUser = session?.user ?? null
       setAuthState((prev) => ({
         ...prev,
-        user: session?.user ?? null
+        user: sessionUser
       }))
+
+      // Keep PostHog's distinct_id in sync with the authenticated user so every
+      // event is attributed to a stable unique identifier across all entry
+      // paths — email login, Google OAuth, and session restore — not just the
+      // signup OTP flow. The id guard avoids redundant identify calls (this
+      // listener runs once per mounted hook instance). Reset on sign-out so the
+      // next user on a shared browser doesn't inherit this identity.
+      if (sessionUser) {
+        if (posthog.get_distinct_id() !== sessionUser.id) {
+          posthog.identify(sessionUser.id, { email: sessionUser.email })
+        }
+      } else if (event === 'SIGNED_OUT') {
+        posthog.reset()
+      }
     })
 
     getInitialUser()


### PR DESCRIPTION
## What changed

PostHog `identify()` — the call that attaches a stable unique identifier (`distinct_id`) to a user — was only being called on the **signup OTP flow** ([useSupabaseAuth.ts](src/hooks/useSupabaseAuth.ts)). This moves identity handling to the `onAuthStateChange` listener, the single chokepoint every auth transition flows through, so identity is kept in sync on **all** entry paths:

```ts
if (sessionUser) {
  if (posthog.get_distinct_id() !== sessionUser.id) {
    posthog.identify(sessionUser.id, { email: sessionUser.email })
  }
} else if (event === 'SIGNED_OUT') {
  posthog.reset()
}
```

## Why

Every path other than signup left users without a stable identifier:

| Path | Before | After |
|------|--------|-------|
| New signup (email OTP) | ✅ identified | ✅ identified |
| Returning email/password login | ❌ not identified | ✅ identified |
| Google OAuth (`/auth/callback`) | ❌ never identified | ✅ identified |
| Session restore on page refresh | ❌ relied on persisted id | ✅ re-identified |
| Logout — `posthog.reset()` | ❌ missing | ✅ reset |

The missing `reset()` on logout was the riskiest gap: on a shared browser, the next person's pre-login anonymous events were being merged into the previous user's identity, contaminating analytics.

## Reviewer notes

- **Why the listener, not each login function:** there's no central `AuthProvider` — the hook is used in ~30 components. `onAuthStateChange` fires for login, OAuth, magic-link, and session restore, so it covers them all in one place.
- **The `get_distinct_id()` guard** prevents redundant `identify` calls, since each mounted hook instance gets its own listener. `posthog-js` also dedupes same-id identify, so this is belt-and-suspenders.
- **Email stays in `identify()` only**, never in `capture()` event properties — consistent with the existing PII convention (commit 39f7c4c).
- The signup-only `verifyOtp` path keeps its explicit `identify` + `New user created` capture (guarantees ordering for that event; the new guard makes it naturally non-duplicative).

## Verification

- `tsc --noEmit` → exit 0, zero errors
- `eslint` on the file → 0 errors
- Confirmed `get_distinct_id()`, `identify()`, `reset()` exist in installed `posthog-js@^1.310.2`

Not runtime-verified yet (not deployed). The functional check post-merge: log in and confirm `posthog.get_distinct_id()` returns the Supabase user UUID, then log out and confirm it flips to a fresh anonymous id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure PostHog identifies users on every auth transition and resets on sign-out to keep analytics accurate and prevent identity leakage. Identity handling now lives in the `onAuthStateChange` listener in `useSupabaseAuth.ts` with a guard to avoid duplicate calls.

- **Bug Fixes**
  - Identify when a `session.user` exists across email/password, Google OAuth, and session restore using `posthog.identify(sessionUser.id, { email })`.
  - Reset on `SIGNED_OUT` with `posthog.reset()` to avoid cross-user mixing on shared browsers.
  - Avoid redundant calls with `posthog.get_distinct_id()` check; keep email only in `identify`, not in event properties.

<sup>Written for commit 80d83649c02cfdcfe5a29eeea80dae25f8318310. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ashish921998/Vinesight/pull/148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication state synchronization for more reliable user session handling
  * Enhanced analytics tracking to properly identify authenticated users across sessions
  * Fixed analytics data reset on user sign-out

<!-- end of auto-generated comment: release notes by coderabbit.ai -->