### PR TITLE
feat(agent-auth): implement auth.md user-claimed agent registration

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -93,7 +93,9 @@ export async function middleware(req: NextRequest) {
   }
 
   const { pathname } = req.nextUrl
-  const isAuthRoute = pathname.startsWith('/auth')
+  // Match the /auth area only — NOT sibling paths like /auth.md (the agent-registration
+  // discovery doc), which must stay publicly reachable for signed-in users too.
+  const isAuthRoute = pathname === '/auth' || pathname.startsWith('/auth/')
   const onFarmerRoute = matchesRoot(pathname, FARMER_ROOTS)
   const onOrgRoute = matchesRoot(pathname, ORG_ROOTS)
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -122,7 +122,7 @@ const nextConfig = {
     ]
   },
 
-  // Rewrites for PostHog analytics ingestion
+  // Rewrites for PostHog analytics ingestion + auth.md agent-registration discovery.
   async rewrites() {
     return [
       {
@@ -132,6 +132,20 @@ const nextConfig = {
       {
         source: '/ingest/:path*',
         destination: 'https://us.i.posthog.com/:path*'
+      },
+      // auth.md: expose the discovery artifacts at their well-known public paths while the
+      // route handlers live under /api (so the request origin can be computed dynamically).
+      {
+        source: '/.well-known/oauth-protected-resource',
+        destination: '/api/agent-auth/oauth-protected-resource'
+      },
+      {
+        source: '/.well-known/oauth-authorization-server',
+        destination: '/api/agent-auth/oauth-authorization-server'
+      },
+      {
+        source: '/auth.md',
+        destination: '/api/agent-auth/auth-md'
       }
     ]
   },

--- a/src/app/agent/claim/page.tsx
+++ b/src/app/agent/claim/page.tsx
@@ -1,0 +1,202 @@
+'use client'
+
+import { Suspense, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { CheckCircle2, Loader2, ShieldCheck, Sprout } from 'lucide-react'
+import { useSupabaseAuth } from '@/hooks/useSupabaseAuth'
+
+const PAGE_SHELL =
+  'min-h-screen flex items-center justify-center bg-gradient-to-br from-green-50 to-blue-50 p-4'
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className={PAGE_SHELL}>
+      <Card className="w-full max-w-md shadow-xl">
+        <CardContent className="p-8">{children}</CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function Header({ title, subtitle }: { title: string; subtitle: string }) {
+  return (
+    <div className="text-center mb-6">
+      <div className="flex justify-center mb-4">
+        <div className="p-3 bg-green-100 rounded-full">
+          <Sprout className="h-8 w-8 text-green-600" />
+        </div>
+      </div>
+      <h1 className="text-2xl font-bold text-gray-900">{title}</h1>
+      <p className="text-gray-600 mt-2 text-sm">{subtitle}</p>
+    </div>
+  )
+}
+
+function ClaimContent() {
+  const searchParams = useSearchParams()
+  const claimAttemptToken = searchParams.get('claim_attempt_token')
+  const { user, loading, signInWithGoogle } = useSupabaseAuth()
+
+  const [code, setCode] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [confirmed, setConfirmed] = useState(false)
+
+  // No token in the URL — the verification link is malformed or truncated.
+  if (!claimAttemptToken) {
+    return (
+      <Shell>
+        <Header title="Invalid link" subtitle="This connection link is missing or incomplete." />
+        <p className="text-sm text-gray-500 text-center">
+          Ask the agent to show you the connection link again, then open it in full.
+        </p>
+      </Shell>
+    )
+  }
+
+  if (loading) {
+    return (
+      <Shell>
+        <div className="text-center py-6">
+          <Loader2 className="h-6 w-6 animate-spin mx-auto text-green-600" />
+          <p className="text-gray-600 mt-2 text-sm">Loading…</p>
+        </div>
+      </Shell>
+    )
+  }
+
+  // Not signed in — round-trip through Google sign-in and come back to this exact URL.
+  if (!user) {
+    const handleSignIn = () => {
+      const returnTo = `${window.location.pathname}${window.location.search}`
+      signInWithGoogle({
+        redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent(returnTo)}`
+      })
+    }
+    return (
+      <Shell>
+        <Header
+          title="Connect an agent"
+          subtitle="Sign in to VineSight to review and approve this request."
+        />
+        <Button onClick={handleSignIn} className="h-12 w-full bg-green-600 hover:bg-green-700">
+          Continue with Google
+        </Button>
+      </Shell>
+    )
+  }
+
+  if (confirmed) {
+    return (
+      <Shell>
+        <div className="text-center">
+          <div className="flex justify-center mb-4">
+            <div className="p-3 bg-green-100 rounded-full">
+              <CheckCircle2 className="h-8 w-8 text-green-600" />
+            </div>
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900">Agent connected</h1>
+          <p className="text-gray-600 mt-2 text-sm">
+            You can return to your agent — it now has access on your behalf. You can revoke it
+            anytime from your VineSight settings.
+          </p>
+        </div>
+      </Shell>
+    )
+  }
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    setSubmitting(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/agent/claim/confirm', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ claim_attempt_token: claimAttemptToken, user_code: code })
+      })
+      const data = await res.json().catch(() => ({}))
+      if (res.ok && data?.status === 'confirmed') {
+        setConfirmed(true)
+      } else {
+        setError(data?.error_description || 'Could not confirm the code. Please try again.')
+      }
+    } catch {
+      setError('Network error. Please try again.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Shell>
+      <Header title="Approve agent access" subtitle={`Signed in as ${user.email}`} />
+
+      <div className="flex items-start gap-3 rounded-lg bg-green-50 border border-green-100 p-3 mb-6">
+        <ShieldCheck className="h-5 w-5 text-green-600 mt-0.5 shrink-0" />
+        <p className="text-sm text-gray-600">
+          An AI agent is requesting permission to <strong>read your farms and tasks</strong> on your
+          behalf. Enter the 6-digit code it shows you to approve.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="user_code">Confirmation code</Label>
+          <Input
+            id="user_code"
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            placeholder="123456"
+            value={code}
+            onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+            className="text-center text-2xl tracking-[0.5em] font-mono h-14"
+            aria-describedby={error ? 'claim-error' : undefined}
+          />
+        </div>
+
+        {error && (
+          <p id="claim-error" className="text-sm text-red-600" role="alert">
+            {error}
+          </p>
+        )}
+
+        <Button
+          type="submit"
+          disabled={submitting || code.length !== 6}
+          className="h-12 w-full bg-green-600 hover:bg-green-700"
+        >
+          {submitting ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Approving…
+            </>
+          ) : (
+            'Approve access'
+          )}
+        </Button>
+      </form>
+    </Shell>
+  )
+}
+
+export default function AgentClaimPage() {
+  return (
+    <Suspense
+      fallback={
+        <Shell>
+          <div className="text-center py-6">
+            <Loader2 className="h-6 w-6 animate-spin mx-auto text-green-600" />
+            <p className="text-gray-600 mt-2 text-sm">Loading…</p>
+          </div>
+        </Shell>
+      }
+    >
+      <ClaimContent />
+    </Suspense>
+  )
+}

--- a/src/app/api/agent-auth/auth-md/route.ts
+++ b/src/app/api/agent-auth/auth-md/route.ts
@@ -1,0 +1,162 @@
+/**
+ * The human- and agent-readable `auth.md`, served at /auth.md via a next.config rewrite.
+ * It is the prose companion to the Protected Resource Metadata, which stays authoritative.
+ */
+
+import { NextRequest } from 'next/server'
+import { POST_CLAIM_SCOPES, asMetadataUrl, getBaseUrl, prmUrl } from '@/lib/agent-auth/config'
+
+export const dynamic = 'force-dynamic'
+
+function buildAuthMd(base: string): string {
+  return `# auth.md — VineSight
+
+VineSight is a digital companion for grape farmers. This file describes how an AI agent can
+register with VineSight **on behalf of a user** and obtain a scoped, revocable access token,
+following the [auth.md](https://workos.com/auth-md/docs) profile.
+
+- Resource server (API base): \`${base}/\`
+- Authorization server: \`${base}\`
+- Protected Resource Metadata (authoritative): ${prmUrl(base)}
+- Authorization Server Metadata: ${asMetadataUrl(base)}
+
+VineSight supports the **user-claimed** flow only — there is no agent-verified / ID-JAG path.
+A user authorizes the agent by signing in to VineSight and confirming a short code the agent
+shows them. Two entrypoints are available: \`anonymous\` and \`service_auth\`.
+
+## 1. Discover
+
+Read the Protected Resource Metadata, then the Authorization Server Metadata. On any conflict
+with this file, **the metadata is authoritative**.
+
+\`\`\`http
+GET ${prmUrl(base)}
+GET ${asMetadataUrl(base)}
+\`\`\`
+
+The \`agent_auth\` block in the AS metadata gives you \`identity_endpoint\`, \`claim_endpoint\`,
+\`token_endpoint\`, \`revocation_endpoint\`, and \`identity_types_supported\`.
+
+## 2. Scopes
+
+| scope | grants |
+| --- | --- |
+| \`farms.read\` | read the user's farms (\`GET /api/farms\`) |
+| \`tasks.read\` | read the user's task reminders (\`GET /api/tasks\`) |
+
+An anonymous registration has **no scopes** until a user claims it. After a claim it receives:
+\`${POST_CLAIM_SCOPES.join(' ')}\`.
+
+## 3. Register
+
+Pick an entrypoint:
+
+- You only have the user's email → **service_auth** (a claim is required before any access).
+- You have neither → **anonymous** (you get a pre-claim identity immediately; claim later).
+
+### anonymous
+
+\`\`\`http
+POST ${base}/api/agent/identity
+Content-Type: application/json
+
+{ "type": "anonymous" }
+\`\`\`
+
+Returns a pre-claim \`identity_assertion\` plus a \`claim_token\` you use to run the claim
+ceremony (step 4) and to poll the token endpoint (step 6).
+
+### service_auth
+
+\`\`\`http
+POST ${base}/api/agent/identity
+Content-Type: application/json
+
+{ "type": "service_auth", "login_hint": "user@example.com" }
+\`\`\`
+
+Returns a \`claim\` block (\`user_code\` + \`verification_uri\`) and a \`claim_token\`, but **no
+assertion** until the ceremony completes.
+
+## 4. Claim ceremony
+
+1. For **anonymous**, first obtain ceremony material (service_auth already has it):
+
+   \`\`\`http
+   POST ${base}/api/agent/identity/claim
+   Content-Type: application/json
+
+   { "claim_token": "clm_…", "email": "user@example.com" }
+   \`\`\`
+
+2. Show the user the \`user_code\` and the \`verification_uri\` in a single message.
+3. The user opens the link, signs in to VineSight, and types the code on a VineSight page.
+4. Meanwhile, poll the token endpoint with the claim grant (step 6).
+
+VineSight never emails the code — it travels agent → user and is confirmed on a VineSight page.
+
+## 5. Exchange the assertion (jwt-bearer)
+
+Trade an \`identity_assertion\` for an access token. Re-exchange the same assertion to refresh;
+there is no refresh token.
+
+\`\`\`http
+POST ${base}/api/oauth2/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=<identity_assertion>&resource=${base}/
+\`\`\`
+
+## 6. Poll during a claim (claim grant)
+
+\`\`\`http
+POST ${base}/api/oauth2/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=urn:workos:agent-auth:grant-type:claim&claim_token=<clm_…>
+\`\`\`
+
+Returns \`{ "error": "authorization_pending" }\` until the user confirms, then an
+\`access_token\` plus a freshly minted \`identity_assertion\`.
+
+## 7. Use the access token
+
+\`\`\`http
+GET ${base}/api/farms
+Authorization: Bearer <access_token>
+\`\`\`
+
+## 8. Revoke
+
+\`\`\`http
+POST ${base}/api/oauth2/revoke
+Content-Type: application/x-www-form-urlencoded
+
+token=<access_token>&token_type_hint=access_token
+\`\`\`
+
+Revoking a token does not invalidate the assertion; mint a fresh access token by re-exchanging.
+
+## Errors
+
+Errors use the OAuth \`{ "error", "error_description" }\` shape. Notable codes:
+\`invalid_request\`, \`invalid_grant\`, \`unsupported_grant_type\`, \`authorization_pending\`,
+\`expired_token\`, \`invalid_claim_token\`, \`claimed_or_in_flight\`, \`claim_expired\`,
+\`invalid_token\`, \`insufficient_scope\`.
+
+## Contact
+
+Questions about this integration: hello@vinesight.app
+`
+}
+
+export async function GET(request: NextRequest) {
+  const base = getBaseUrl(request)
+  return new Response(buildAuthMd(base), {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=300'
+    }
+  })
+}

--- a/src/app/api/agent-auth/oauth-authorization-server/route.ts
+++ b/src/app/api/agent-auth/oauth-authorization-server/route.ts
@@ -1,0 +1,52 @@
+/**
+ * Authorization Server Metadata (RFC 8414) with the auth.md `agent_auth` profile block.
+ * Served at /.well-known/oauth-authorization-server via a next.config rewrite.
+ *
+ * VineSight implements the user-claimed flow only, so `identity_types_supported` advertises
+ * just `anonymous` and `service_auth` — no agent-verified ID-JAG type, and no events
+ * endpoint (provider-pushed revocation belongs to the verified flow).
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  GRANT_TYPES,
+  IDENTITY_TYPES_SUPPORTED,
+  SCOPES_SUPPORTED,
+  asMetadataUrl,
+  authMdUrl,
+  claimEndpoint,
+  getBaseUrl,
+  identityEndpoint,
+  issuerFor,
+  resourceFor,
+  revocationEndpoint,
+  tokenEndpoint
+} from '@/lib/agent-auth/config'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  const base = getBaseUrl(request)
+  return NextResponse.json(
+    {
+      resource: resourceFor(base),
+      authorization_servers: [issuerFor(base)],
+      scopes_supported: [...SCOPES_SUPPORTED],
+      bearer_methods_supported: ['header'],
+
+      issuer: issuerFor(base),
+      token_endpoint: tokenEndpoint(base),
+      revocation_endpoint: revocationEndpoint(base),
+      grant_types_supported: [GRANT_TYPES.jwtBearer, GRANT_TYPES.claim],
+      service_documentation: asMetadataUrl(base),
+
+      agent_auth: {
+        skill: authMdUrl(base),
+        identity_endpoint: identityEndpoint(base),
+        claim_endpoint: claimEndpoint(base),
+        identity_types_supported: [...IDENTITY_TYPES_SUPPORTED]
+      }
+    },
+    { headers: { 'Cache-Control': 'public, max-age=300' } }
+  )
+}

--- a/src/app/api/agent-auth/oauth-protected-resource/route.ts
+++ b/src/app/api/agent-auth/oauth-protected-resource/route.ts
@@ -1,0 +1,24 @@
+/**
+ * Protected Resource Metadata (RFC 9728). The authoritative description of this resource
+ * server. Served at /.well-known/oauth-protected-resource via a next.config rewrite.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { getBaseUrl, issuerFor, resourceFor, SCOPES_SUPPORTED } from '@/lib/agent-auth/config'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest) {
+  const base = getBaseUrl(request)
+  return NextResponse.json(
+    {
+      resource: resourceFor(base),
+      resource_name: 'VineSight',
+      resource_logo_uri: `${base}/logo.png`,
+      authorization_servers: [issuerFor(base)],
+      scopes_supported: [...SCOPES_SUPPORTED],
+      bearer_methods_supported: ['header']
+    },
+    { headers: { 'Cache-Control': 'public, max-age=300' } }
+  )
+}

--- a/src/app/api/agent/claim/confirm/route.ts
+++ b/src/app/api/agent/claim/confirm/route.ts
@@ -1,0 +1,128 @@
+/**
+ * POST /api/agent/claim/confirm — the form-action behind the VineSight claim page. It runs
+ * as the *signed-in user* (cookie session), verifies the typed user_code against the active
+ * claim attempt, enforces the same-account check, and on success binds the registration to
+ * the user. This is the only place a registration becomes `claimed`.
+ *
+ * The agent never calls this endpoint; it polls /api/oauth2/token and sees the result.
+ */
+
+import { NextRequest } from 'next/server'
+import { createServerSupabaseClient } from '@/lib/auth-utils'
+import { MAX_USER_CODE_ATTEMPTS } from '@/lib/agent-auth/config'
+import { checkRateLimit, jsonNoStore, oauthError, readJsonBody } from '@/lib/agent-auth/responses'
+import { sha256Hex, timingSafeEqual } from '@/lib/agent-auth/tokens'
+import {
+  getClaimAttemptByTokenHash,
+  getRegistrationById,
+  recordEvent,
+  revokePreClaimTokens,
+  updateClaimAttempt,
+  updateRegistration
+} from '@/lib/agent-auth/store'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(request: NextRequest) {
+  const limited = checkRateLimit(request, 'agent-claim-confirm')
+  if (limited) return limited
+
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
+
+  const claimAttemptToken = body?.claim_attempt_token
+  const userCode = String(body?.user_code ?? '').replace(/\D/g, '')
+  if (typeof claimAttemptToken !== 'string' || !claimAttemptToken) {
+    return oauthError('invalid_request', { description: 'claim_attempt_token is required' })
+  }
+  if (userCode.length !== 6) {
+    return oauthError('invalid_request', { description: 'Enter the 6-digit code' })
+  }
+
+  // Identify the human completing the ceremony.
+  const supabase = await createServerSupabaseClient()
+  const {
+    data: { user }
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return jsonNoStore(
+      { error: 'authentication_required', error_description: 'Sign in to confirm this request.' },
+      { status: 401 }
+    )
+  }
+
+  try {
+    const attempt = await getClaimAttemptByTokenHash(sha256Hex(claimAttemptToken))
+    if (!attempt) {
+      return oauthError('invalid_request', { description: 'Unknown claim link', status: 404 })
+    }
+    if (attempt.status !== 'initiated' || new Date(attempt.expires_at).getTime() <= Date.now()) {
+      if (attempt.status === 'initiated') {
+        await updateClaimAttempt(attempt.id, { status: 'expired' })
+      }
+      return oauthError('claim_expired', { description: 'This claim link has expired' })
+    }
+    if (attempt.attempts >= MAX_USER_CODE_ATTEMPTS) {
+      await updateClaimAttempt(attempt.id, { status: 'expired' })
+      return oauthError('claim_expired', { description: 'Too many incorrect attempts' })
+    }
+
+    const registration = await getRegistrationById(attempt.registration_id)
+    if (!registration || registration.status === 'revoked') {
+      return oauthError('invalid_request', { description: 'Registration unavailable', status: 404 })
+    }
+    if (registration.status === 'claimed') {
+      return oauthError('claimed_or_in_flight', { description: 'Already claimed' })
+    }
+
+    // Same-account check: only the user the ceremony was started for may complete it.
+    const claimEmail = registration.claim_email?.toLowerCase()
+    const userEmail = (user.email || '').toLowerCase()
+    if (!claimEmail || !userEmail || claimEmail !== userEmail) {
+      return jsonNoStore(
+        {
+          error: 'account_mismatch',
+          error_description: `This request was started for ${claimEmail ?? 'a different account'}. Sign in with that account to continue.`
+        },
+        { status: 403 }
+      )
+    }
+
+    // Verify the user_code (constant-time over the stored hash).
+    if (!timingSafeEqual(sha256Hex(userCode), attempt.user_code_hash)) {
+      await updateClaimAttempt(attempt.id, { attempts: attempt.attempts + 1 })
+      const remaining = Math.max(0, MAX_USER_CODE_ATTEMPTS - (attempt.attempts + 1))
+      return jsonNoStore(
+        {
+          error: 'invalid_user_code',
+          error_description: `Incorrect code. ${remaining} attempt${remaining === 1 ? '' : 's'} left.`
+        },
+        { status: 400 }
+      )
+    }
+
+    // Success — bind the registration to this user.
+    const now = new Date().toISOString()
+    await updateClaimAttempt(attempt.id, {
+      status: 'confirmed',
+      confirmed_at: now,
+      claimed_by_user_id: user.id
+    })
+    await updateRegistration(registration.id, {
+      status: 'claimed',
+      claimed_by_user_id: user.id,
+      claimed_at: now
+    })
+    // Anonymous pre-claim tokens must not survive the binding.
+    await revokePreClaimTokens(registration.id)
+    await recordEvent('claim.confirmed', { registrationId: registration.id, userId: user.id })
+
+    return jsonNoStore({ status: 'confirmed' })
+  } catch (error) {
+    if (process.env.NODE_ENV === 'development') {
+      console.error('[agent/claim/confirm] error', error)
+    }
+    return oauthError('server_error', { description: 'Could not confirm the claim', status: 500 })
+  }
+}

--- a/src/app/api/agent/identity/claim/route.ts
+++ b/src/app/api/agent/identity/claim/route.ts
@@ -1,0 +1,107 @@
+/**
+ * POST /api/agent/identity/claim — anonymous-only. Binds an email to an anonymous
+ * registration and mints fresh claim-ceremony material (a new user_code + verification_uri),
+ * invalidating any previous attempt. service_auth registrations already get their material
+ * at /api/agent/identity, so they do not use this endpoint.
+ */
+
+import { NextRequest } from 'next/server'
+import {
+  CLAIM_POLL_INTERVAL_SEC,
+  CLAIM_TTL_SEC,
+  getBaseUrl,
+  verificationUri
+} from '@/lib/agent-auth/config'
+import {
+  checkRateLimit,
+  getClientIp,
+  isEmail,
+  jsonNoStore,
+  oauthError,
+  readJsonBody
+} from '@/lib/agent-auth/responses'
+import { generateUserCode, randomSecret, sha256Hex } from '@/lib/agent-auth/tokens'
+import {
+  createClaimAttempt,
+  expireActiveAttempts,
+  getRegistrationByClaimTokenHash,
+  inSeconds,
+  isRegistrationExpired,
+  recordEvent,
+  updateRegistration
+} from '@/lib/agent-auth/store'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(request: NextRequest) {
+  const limited = checkRateLimit(request, 'agent-claim')
+  if (limited) return limited
+
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
+
+  const claimToken = body?.claim_token
+  if (typeof claimToken !== 'string' || !claimToken) {
+    return oauthError('invalid_request', { description: 'claim_token is required' })
+  }
+  if (!isEmail(body?.email)) {
+    return oauthError('invalid_request', { description: 'email must be a valid email address' })
+  }
+  const email = (body.email as string).toLowerCase()
+  const ip = getClientIp(request)
+
+  try {
+    const registration = await getRegistrationByClaimTokenHash(sha256Hex(claimToken))
+    if (!registration) {
+      return oauthError('invalid_claim_token', { description: 'Unknown claim token' })
+    }
+    if (registration.registration_type !== 'anonymous') {
+      return oauthError('invalid_request', {
+        description: 'This registration already has claim material'
+      })
+    }
+    if (registration.status === 'claimed') {
+      return oauthError('claimed_or_in_flight', { description: 'Registration already claimed' })
+    }
+    if (isRegistrationExpired(registration)) {
+      return oauthError('claim_expired', { description: 'Registration is no longer claimable' })
+    }
+
+    // Bind the email (only this signed-in user may complete the ceremony) and rotate material.
+    await updateRegistration(registration.id, { claim_email: email })
+    await expireActiveAttempts(registration.id)
+
+    const claimAttemptToken = randomSecret('cat')
+    const userCode = generateUserCode()
+    const expiresAt = inSeconds(CLAIM_TTL_SEC)
+    const attempt = await createClaimAttempt({
+      registrationId: registration.id,
+      claimAttemptTokenHash: sha256Hex(claimAttemptToken),
+      userCodeHash: sha256Hex(userCode),
+      expiresAt,
+      clientIp: ip
+    })
+
+    await recordEvent('claim.requested', { registrationId: registration.id })
+    await recordEvent('user_code.minted', { registrationId: registration.id })
+
+    return jsonNoStore({
+      registration_id: registration.id,
+      claim_attempt_id: attempt.id,
+      status: 'initiated',
+      expires_at: expiresAt,
+      claim_attempt: {
+        user_code: userCode,
+        expires_in: CLAIM_TTL_SEC,
+        verification_uri: verificationUri(getBaseUrl(request), claimAttemptToken),
+        interval: CLAIM_POLL_INTERVAL_SEC
+      }
+    })
+  } catch (error) {
+    if (process.env.NODE_ENV === 'development') {
+      console.error('[agent/identity/claim] error', error)
+    }
+    return oauthError('server_error', { description: 'Claim initiation failed', status: 500 })
+  }
+}

--- a/src/app/api/agent/identity/route.ts
+++ b/src/app/api/agent/identity/route.ts
@@ -1,0 +1,150 @@
+/**
+ * POST /api/agent/identity — agent registration entrypoint for the user-claimed flow.
+ * Dispatches on `type`: `anonymous` (immediate pre-claim assertion) or `service_auth`
+ * (returns claim-ceremony material, withholds the assertion until the user claims it).
+ */
+
+import { NextRequest } from 'next/server'
+import { mintIdentityAssertion } from '@/lib/agent-auth/assertion'
+import {
+  ASSERTION_TTL_SEC,
+  CLAIM_PATH,
+  CLAIM_POLL_INTERVAL_SEC,
+  CLAIM_TTL_SEC,
+  POST_CLAIM_SCOPES,
+  PRE_CLAIM_SCOPES,
+  REGISTRATION_UNCLAIMED_TTL_SEC,
+  getBaseUrl,
+  verificationUri
+} from '@/lib/agent-auth/config'
+import {
+  checkRateLimit,
+  getClientIp,
+  isEmail,
+  jsonNoStore,
+  oauthError,
+  readJsonBody
+} from '@/lib/agent-auth/responses'
+import { generateUserCode, randomSecret, sha256Hex } from '@/lib/agent-auth/tokens'
+import {
+  createClaimAttempt,
+  createRegistration,
+  inSeconds,
+  recordEvent
+} from '@/lib/agent-auth/store'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(request: NextRequest) {
+  const limited = checkRateLimit(request, 'agent-identity')
+  if (limited) return limited
+
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
+
+  const ip = getClientIp(request)
+  const base = getBaseUrl(request)
+  const agentLabel = (request.headers.get('user-agent') || '').slice(0, 255) || null
+
+  try {
+    if (body?.type === 'anonymous') {
+      const claimToken = randomSecret('clm')
+      const expiresAt = inSeconds(REGISTRATION_UNCLAIMED_TTL_SEC)
+      const registration = await createRegistration({
+        registrationType: 'anonymous',
+        claimTokenHash: sha256Hex(claimToken),
+        assertionExpiresAt: inSeconds(ASSERTION_TTL_SEC),
+        expiresAt,
+        agentLabel,
+        clientIp: ip
+      })
+
+      const { assertion, expiresAt: assertionExpires } = mintIdentityAssertion(
+        base,
+        registration.id
+      )
+      await recordEvent('registration.created', {
+        registrationId: registration.id,
+        metadata: { registration_type: 'anonymous' }
+      })
+      await recordEvent('assertion.issued', { registrationId: registration.id })
+
+      return jsonNoStore(
+        {
+          registration_id: registration.id,
+          registration_type: 'anonymous',
+          identity_assertion: assertion,
+          assertion_expires: assertionExpires,
+          pre_claim_scopes: PRE_CLAIM_SCOPES,
+          claim_url: CLAIM_PATH,
+          claim_token: claimToken,
+          claim_token_expires: expiresAt,
+          post_claim_scopes: POST_CLAIM_SCOPES
+        },
+        { status: 201 }
+      )
+    }
+
+    if (body?.type === 'service_auth') {
+      if (!isEmail(body?.login_hint)) {
+        return oauthError('invalid_request', { description: 'login_hint must be a valid email' })
+      }
+      const email = (body.login_hint as string).toLowerCase()
+      const claimToken = randomSecret('clm')
+      const expiresAt = inSeconds(REGISTRATION_UNCLAIMED_TTL_SEC)
+      const registration = await createRegistration({
+        registrationType: 'service_auth',
+        claimTokenHash: sha256Hex(claimToken),
+        claimEmail: email,
+        assertionExpiresAt: inSeconds(ASSERTION_TTL_SEC),
+        expiresAt,
+        agentLabel,
+        clientIp: ip
+      })
+
+      const claimAttemptToken = randomSecret('cat')
+      const userCode = generateUserCode()
+      await createClaimAttempt({
+        registrationId: registration.id,
+        claimAttemptTokenHash: sha256Hex(claimAttemptToken),
+        userCodeHash: sha256Hex(userCode),
+        expiresAt: inSeconds(CLAIM_TTL_SEC),
+        clientIp: ip
+      })
+
+      await recordEvent('registration.created', {
+        registrationId: registration.id,
+        metadata: { registration_type: 'service_auth' }
+      })
+      await recordEvent('user_code.minted', { registrationId: registration.id })
+
+      return jsonNoStore(
+        {
+          registration_id: registration.id,
+          registration_type: 'service_auth',
+          claim_url: CLAIM_PATH,
+          claim_token: claimToken,
+          claim_token_expires: expiresAt,
+          post_claim_scopes: POST_CLAIM_SCOPES,
+          claim: {
+            user_code: userCode,
+            expires_in: CLAIM_TTL_SEC,
+            verification_uri: verificationUri(base, claimAttemptToken),
+            interval: CLAIM_POLL_INTERVAL_SEC
+          }
+        },
+        { status: 201 }
+      )
+    }
+
+    return oauthError('invalid_request', {
+      description: 'Unsupported or missing "type" (expected "anonymous" or "service_auth")'
+    })
+  } catch (error) {
+    if (process.env.NODE_ENV === 'development') {
+      console.error('[agent/identity] error', error)
+    }
+    return oauthError('server_error', { description: 'Registration failed', status: 500 })
+  }
+}

--- a/src/app/api/farms/route.ts
+++ b/src/app/api/farms/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getSupabaseClient } from '@/lib/supabase'
 import { FarmSchema, validateAndSanitize, globalRateLimiter } from '@/lib/validation'
+import { authenticateResourceRequest } from '@/lib/agent-auth/resource'
 
 export async function GET(request: NextRequest) {
   try {
@@ -16,22 +17,14 @@ export async function GET(request: NextRequest) {
       )
     }
 
-    const supabase = getSupabaseClient()
+    // Accept either a browser cookie session or an agent bearer token (scope: farms.read).
+    const auth = await authenticateResourceRequest(request, 'farms.read')
+    if (!auth.ok) return auth.response
 
-    // Get the current authenticated user
-    const {
-      data: { user },
-      error: userError
-    } = await supabase.auth.getUser()
-
-    if (userError || !user) {
-      return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
-    }
-
-    const { data, error } = await supabase
+    const { data, error } = await auth.db
       .from('farms')
       .select('*')
-      .eq('user_id', user.id)
+      .eq('user_id', auth.userId)
       .order('created_at', { ascending: false })
 
     if (error) {

--- a/src/app/api/oauth2/revoke/route.ts
+++ b/src/app/api/oauth2/revoke/route.ts
@@ -1,0 +1,43 @@
+/**
+ * POST /api/oauth2/revoke — RFC 7009 token revocation. Invalidates a single access_token by
+ * value. Idempotent; always returns 200 even for unknown tokens (per the RFC). The
+ * identity_assertion is unaffected — a fresh access_token can still be minted from it.
+ *
+ * Form-encoded request body (application/x-www-form-urlencoded).
+ */
+
+import { NextRequest } from 'next/server'
+import { checkRateLimit, readFormBody } from '@/lib/agent-auth/responses'
+import { sha256Hex } from '@/lib/agent-auth/tokens'
+import { getAccessTokenByHash, recordEvent, revokeAccessTokenByHash } from '@/lib/agent-auth/store'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(request: NextRequest) {
+  const limited = checkRateLimit(request, 'oauth-revoke')
+  if (limited) return limited
+
+  const params = await readFormBody(request)
+  const token = params.get('token')
+
+  if (token) {
+    try {
+      const hash = sha256Hex(token)
+      const existing = await getAccessTokenByHash(hash)
+      await revokeAccessTokenByHash(hash)
+      if (existing) {
+        await recordEvent('token.revoked', {
+          registrationId: existing.registration_id,
+          userId: existing.user_id
+        })
+      }
+    } catch (error) {
+      if (process.env.NODE_ENV === 'development') {
+        console.error('[oauth2/revoke] error', error)
+      }
+      // RFC 7009: still respond 200 — the client cannot act on a revocation error.
+    }
+  }
+
+  return new Response(null, { status: 200, headers: { 'Cache-Control': 'no-store' } })
+}

--- a/src/app/api/oauth2/token/route.ts
+++ b/src/app/api/oauth2/token/route.ts
@@ -1,0 +1,157 @@
+/**
+ * POST /api/oauth2/token — the token endpoint. Dispatches on `grant_type`:
+ *  - urn:ietf:params:oauth:grant-type:jwt-bearer (RFC 7523): exchange an identity_assertion
+ *    for a short-lived access_token. Re-exchange to refresh; no refresh_token is issued.
+ *  - urn:workos:agent-auth:grant-type:claim: poll while a user-claimed registration is being
+ *    confirmed; returns authorization_pending until claimed, then an access_token + assertion.
+ *
+ * Form-encoded request body (application/x-www-form-urlencoded).
+ */
+
+import { NextRequest } from 'next/server'
+import { mintIdentityAssertion, verifyIdentityAssertion } from '@/lib/agent-auth/assertion'
+import {
+  ACCESS_TOKEN_TTL_SEC,
+  GRANT_TYPES,
+  POST_CLAIM_SCOPES,
+  PRE_CLAIM_SCOPES,
+  getBaseUrl
+} from '@/lib/agent-auth/config'
+import {
+  checkRateLimit,
+  getClientIp,
+  jsonNoStore,
+  oauthError,
+  readFormBody
+} from '@/lib/agent-auth/responses'
+import { randomSecret, sha256Hex } from '@/lib/agent-auth/tokens'
+import {
+  createAccessToken,
+  getRegistrationByClaimTokenHash,
+  getRegistrationById,
+  inSeconds,
+  isRegistrationExpired,
+  recordEvent,
+  revokePreClaimTokens
+} from '@/lib/agent-auth/store'
+
+export const dynamic = 'force-dynamic'
+
+async function issueAccessToken(opts: {
+  registrationId: string
+  userId: string | null
+  scopes: string[]
+  clientIp: string
+}): Promise<{ access_token: string; token_type: 'Bearer'; expires_in: number; scope: string }> {
+  const accessToken = randomSecret('vsat')
+  await createAccessToken({
+    registrationId: opts.registrationId,
+    userId: opts.userId,
+    tokenHash: sha256Hex(accessToken),
+    scopes: opts.scopes,
+    expiresAt: inSeconds(ACCESS_TOKEN_TTL_SEC),
+    clientIp: opts.clientIp
+  })
+  await recordEvent('token.issued', {
+    registrationId: opts.registrationId,
+    userId: opts.userId,
+    metadata: { scope: opts.scopes.join(' ') }
+  })
+  return {
+    access_token: accessToken,
+    token_type: 'Bearer',
+    expires_in: ACCESS_TOKEN_TTL_SEC,
+    scope: opts.scopes.join(' ')
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const limited = checkRateLimit(request, 'oauth-token')
+  if (limited) return limited
+
+  const ip = getClientIp(request)
+  const params = await readFormBody(request)
+  const grantType = params.get('grant_type')
+  const base = getBaseUrl(request)
+
+  try {
+    // --- Claim grant (poll while the user completes the ceremony) ---
+    if (grantType === GRANT_TYPES.claim) {
+      const claimToken = params.get('claim_token')
+      if (!claimToken) {
+        return oauthError('invalid_request', { description: 'claim_token is required' })
+      }
+
+      const registration = await getRegistrationByClaimTokenHash(sha256Hex(claimToken))
+      if (!registration) return oauthError('expired_token', { description: 'Unknown claim token' })
+      if (registration.status === 'revoked') {
+        return oauthError('invalid_grant', { description: 'Registration revoked' })
+      }
+      if (registration.status !== 'claimed') {
+        if (isRegistrationExpired(registration)) {
+          return oauthError('expired_token', { description: 'Claim window expired' })
+        }
+        return oauthError('authorization_pending', {
+          description: 'The user has not yet confirmed the claim'
+        })
+      }
+
+      // A claimed registration is still bounded by its assertion outer bound — the long-lived
+      // claim_token must not keep minting credentials past it.
+      if (isRegistrationExpired(registration)) {
+        return oauthError('invalid_grant', { description: 'Registration is no longer valid' })
+      }
+
+      // Claimed: drop any pre-claim tokens, then mint the post-claim token + fresh assertion.
+      await revokePreClaimTokens(registration.id)
+      const token = await issueAccessToken({
+        registrationId: registration.id,
+        userId: registration.claimed_by_user_id,
+        scopes: POST_CLAIM_SCOPES,
+        clientIp: ip
+      })
+      const { assertion, expiresAt } = mintIdentityAssertion(base, registration.id)
+      return jsonNoStore({ ...token, identity_assertion: assertion, assertion_expires: expiresAt })
+    }
+
+    // --- JWT-bearer grant (exchange/refresh an identity_assertion) ---
+    if (grantType === GRANT_TYPES.jwtBearer) {
+      const assertion = params.get('assertion')
+      if (!assertion) return oauthError('invalid_request', { description: 'assertion is required' })
+
+      let registrationId: string
+      try {
+        ;({ registrationId } = verifyIdentityAssertion(assertion, base))
+      } catch {
+        return oauthError('invalid_grant', { description: 'Invalid or expired assertion' })
+      }
+
+      const registration = await getRegistrationById(registrationId)
+      if (
+        !registration ||
+        registration.status === 'revoked' ||
+        isRegistrationExpired(registration)
+      ) {
+        return oauthError('invalid_grant', { description: 'Registration is no longer valid' })
+      }
+
+      // Claimed registrations act on behalf of their user with full scopes; an unclaimed
+      // anonymous registration gets only its pre-claim scopes (and no bound user).
+      const claimed = registration.status === 'claimed'
+      const token = await issueAccessToken({
+        registrationId: registration.id,
+        userId: claimed ? registration.claimed_by_user_id : null,
+        scopes: claimed ? POST_CLAIM_SCOPES : PRE_CLAIM_SCOPES,
+        clientIp: ip
+      })
+      return jsonNoStore(token)
+    }
+
+    return oauthError('unsupported_grant_type', { description: 'Unsupported grant_type' })
+  } catch (error) {
+    if (process.env.NODE_ENV === 'development') {
+      console.error('[oauth2/token] error', error)
+    }
+    return oauthError('server_error', { description: 'Token request failed', status: 500 })
+  }
+}

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { createServerSupabaseClient } from '@/lib/auth-utils'
 import { TaskReminderSchema, validateAndSanitize, globalRateLimiter } from '@/lib/validation'
+import { authenticateResourceRequest } from '@/lib/agent-auth/resource'
 import {
   TaskReminderCreateInput,
   toApplicationTaskReminder,
@@ -28,15 +29,10 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: rateLimit.reason || 'Too many requests' }, { status: 429 })
     }
 
-    const supabase = await createServerSupabaseClient()
-    const {
-      data: { user },
-      error: userError
-    } = await supabase.auth.getUser()
-
-    if (userError || !user) {
-      return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
-    }
+    // Accept either a browser cookie session or an agent bearer token (scope: tasks.read).
+    const auth = await authenticateResourceRequest(request, 'tasks.read')
+    if (!auth.ok) return auth.response
+    const supabase = auth.db
 
     const searchParams = request.nextUrl.searchParams
     const farmIdParam = searchParams.get('farmId')
@@ -48,6 +44,17 @@ export async function GET(request: NextRequest) {
       .order('due_date', { ascending: true })
       .order('priority', { ascending: false })
       .order('created_at', { ascending: true })
+
+    // Cookie sessions are scoped by RLS. Agent tokens use the service-role client (RLS
+    // bypassed), so restrict tasks to farms the bound user owns.
+    if (auth.viaAgent) {
+      const { data: ownFarms } = await supabase
+        .from('farms')
+        .select('id')
+        .eq('user_id', auth.userId)
+      const farmIds = (ownFarms || []).map((farm: any) => farm.id)
+      query = query.in('farm_id', farmIds.length ? farmIds : [-1])
+    }
 
     if (farmIdParam) {
       const parsedFarmId = Number.parseInt(farmIdParam, 10)

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -22,6 +22,18 @@ function AuthCallbackContent() {
         const code = currentUrl.searchParams.get('code')
         const error = currentUrl.searchParams.get('error')
 
+        // Optional post-login destination (e.g. the agent claim page). Only same-origin
+        // relative paths are honored, to avoid open-redirects; everything else → dashboard.
+        // Reject protocol-relative ('//host') and backslash forms ('/\host', which browsers
+        // normalize toward '//host'), and anything not starting with a single slash.
+        const nextParam = currentUrl.searchParams.get('next')
+        const isSafeInternalPath =
+          !!nextParam &&
+          nextParam.startsWith('/') &&
+          !nextParam.startsWith('//') &&
+          !nextParam.includes('\\')
+        const dest = isSafeInternalPath ? (nextParam as string) : '/dashboard'
+
         // Handle errors
         if (error) {
           if (isMounted) router.push(`/auth/auth-code-error?error=${error}`)
@@ -44,7 +56,7 @@ function AuthCallbackContent() {
             // Successfully exchanged code for session
             // Add a small delay to ensure the auth state is properly set
             redirectTimer = setTimeout(() => {
-              router.push('/dashboard')
+              router.push(dest)
             }, 500)
             return
           }
@@ -65,7 +77,7 @@ function AuthCallbackContent() {
           // User is authenticated, redirect to dashboard
           // Add a small delay to ensure the auth state is properly set
           redirectTimer = setTimeout(() => {
-            router.push('/dashboard')
+            router.push(dest)
           }, 500)
           return
         }

--- a/src/lib/agent-auth/README.md
+++ b/src/lib/agent-auth/README.md
@@ -1,0 +1,49 @@
+# agent-auth — auth.md agent registration
+
+Implements the [WorkOS `auth.md`](https://workos.com/auth-md/docs) **user-claimed** flow so AI
+agents can register on behalf of a VineSight user and receive scoped, revocable bearer tokens.
+The authorization server and resource server are co-located on the VineSight origin.
+
+## What an agent sees
+
+| Public URL                                | Purpose                                        |
+| ----------------------------------------- | ---------------------------------------------- |
+| `/auth.md`                                | Human + agent readable integration guide       |
+| `/.well-known/oauth-protected-resource`   | Protected Resource Metadata (authoritative)    |
+| `/.well-known/oauth-authorization-server` | AS metadata incl. the `agent_auth` block       |
+| `POST /api/agent/identity`                | Register (`anonymous` or `service_auth`)       |
+| `POST /api/agent/identity/claim`          | Mint claim material (anonymous only)           |
+| `POST /api/oauth2/token`                  | jwt-bearer exchange + claim-grant poll         |
+| `POST /api/oauth2/revoke`                 | RFC 7009 token revocation                      |
+| `/agent/claim`                            | The page where a signed-in user types the code |
+
+Issued access tokens are accepted (alongside cookie sessions) on `GET /api/farms`
+(`farms.read`) and `GET /api/tasks` (`tasks.read`).
+
+## Setup
+
+1. **Run the migration** `supabase/migrations/202606140001_agent_auth.sql` against your
+   Supabase project (it creates the `agent_*` tables with RLS enabled / deny-all — they are
+   only ever touched by the service role).
+
+2. **Environment variables:**
+
+   | Var                         | Required | Notes                                                                                                                                                                                                                                                       |
+   | --------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | `AGENT_AUTH_JWT_SECRET`     | yes      | Random string ≥ 16 chars; signs the identity_assertion (HS256).                                                                                                                                                                                             |
+   | `SUPABASE_SERVICE_ROLE_KEY` | yes      | Already used elsewhere; the agent-auth tables require it.                                                                                                                                                                                                   |
+   | `AGENT_AUTH_BASE_URL`       | prod     | Canonical public origin (e.g. `https://vinesight.app`). Falls back to `NEXT_PUBLIC_SITE_URL`, then proxy headers. **Set this in production** — otherwise the issuer/audience and discovery URLs derive from the request `Host`, which is client-controlled. |
+   | `AGENT_AUTH_ALLOWED_HOSTS`  | no       | Comma-separated Host allow-list used only when no base URL is set; an unrecognized `Host` falls back to the first entry (host-poisoning guard).                                                                                                             |
+
+## Design notes
+
+- **Tokens at rest:** `claim_token`, `claim_attempt_token`, `user_code`, and `access_token`
+  are bearer secrets — only their SHA-256 hashes are stored; the plaintext is returned once.
+- **identity_assertion:** a service-signed HS256 JWT (`sub` = registration id), re-exchangeable
+  until it expires. There is no refresh token; agents re-exchange the assertion to refresh.
+- **Pre-claim:** an anonymous registration gets an assertion immediately but **no scopes** until
+  a user claims it; its pre-claim tokens are revoked at claim time.
+- **No agent-verified flow:** the ID-JAG / JWKS / provider-trust-list path is intentionally not
+  implemented. `identity_types_supported` advertises only `anonymous` and `service_auth`.
+- **Rate limiting** reuses the in-process `globalRateLimiter`. For multi-instance production,
+  move these counters to a shared store (e.g. Redis).

--- a/src/lib/agent-auth/assertion.ts
+++ b/src/lib/agent-auth/assertion.ts
@@ -1,0 +1,34 @@
+/**
+ * The service-signed identity_assertion. It is a re-exchangeable JWT whose `sub` is the
+ * registration id; agents trade it at /api/oauth2/token (RFC 7523 jwt-bearer) for an
+ * access_token, and re-exchange it to refresh until it expires.
+ */
+
+import { ASSERTION_JWT_TYP, ASSERTION_TTL_SEC, getJwtSecret, issuerFor } from './config'
+import { JwtError, randomId, signJwt, verifyJwt } from './tokens'
+
+export function mintIdentityAssertion(
+  base: string,
+  registrationId: string,
+  ttlSec: number = ASSERTION_TTL_SEC
+): { assertion: string; expiresAt: string } {
+  const now = Math.floor(Date.now() / 1000)
+  const exp = now + ttlSec
+  const issuer = issuerFor(base)
+  const assertion = signJwt(
+    { iss: issuer, aud: issuer, sub: registrationId, iat: now, exp, jti: randomId('jti') },
+    getJwtSecret(),
+    ASSERTION_JWT_TYP
+  )
+  return { assertion, expiresAt: new Date(exp * 1000).toISOString() }
+}
+
+/** Verifies signature, time bounds, and iss/aud, returning the registration id. */
+export function verifyIdentityAssertion(token: string, base: string): { registrationId: string } {
+  const payload = verifyJwt(token, getJwtSecret())
+  const issuer = issuerFor(base)
+  if (payload.iss !== issuer) throw new JwtError('Invalid issuer')
+  if (payload.aud !== issuer) throw new JwtError('Invalid audience')
+  if (typeof payload.sub !== 'string' || !payload.sub) throw new JwtError('Missing subject')
+  return { registrationId: payload.sub }
+}

--- a/src/lib/agent-auth/config.ts
+++ b/src/lib/agent-auth/config.ts
@@ -1,0 +1,104 @@
+/**
+ * Configuration + small helpers for the auth.md agent-registration implementation.
+ *
+ * VineSight runs the authorization server (AS) and resource server (RS) on a single
+ * origin, so the issuer, the PRM `resource`, and the API base all derive from the same
+ * request origin (overridable with AGENT_AUTH_BASE_URL for proxied/canonical hosts).
+ */
+
+// Scopes an agent token can be granted. Keep in sync with the wired resource routes
+// (src/app/api/farms/route.ts, src/app/api/tasks/route.ts).
+export const SCOPES_SUPPORTED = ['farms.read', 'tasks.read'] as const
+export type AgentScope = (typeof SCOPES_SUPPORTED)[number]
+
+// Anonymous registrations are usable before a user claims them, but with no data
+// access until bound to a user. Everything meaningful is granted post-claim.
+export const PRE_CLAIM_SCOPES: string[] = []
+export const POST_CLAIM_SCOPES: string[] = [...SCOPES_SUPPORTED]
+
+// Lifetimes (seconds).
+export const ASSERTION_TTL_SEC = 30 * 24 * 60 * 60 // re-exchangeable identity_assertion
+export const ACCESS_TOKEN_TTL_SEC = 60 * 60 // short-lived bearer access_token
+export const CLAIM_TTL_SEC = 10 * 60 // user_code / verification window (RFC 8628)
+export const REGISTRATION_UNCLAIMED_TTL_SEC = 7 * 24 * 60 * 60 // window to complete a claim
+
+// Claim-poll hint and user_code lockout.
+export const CLAIM_POLL_INTERVAL_SEC = 5
+export const MAX_USER_CODE_ATTEMPTS = 5
+
+// JWT typ for the service-signed identity assertion (aligns with the auth.md spec).
+export const ASSERTION_JWT_TYP = 'oauth-id-jag+jwt'
+
+export const GRANT_TYPES = {
+  jwtBearer: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+  claim: 'urn:workos:agent-auth:grant-type:claim'
+} as const
+
+export const IDENTITY_TYPES_SUPPORTED = ['anonymous', 'service_auth'] as const
+
+/**
+ * The canonical public origin of this deployment, with no trailing slash.
+ * Prefers an explicit env override, then standard proxy headers, then the request URL.
+ */
+export function getBaseUrl(request: Request): string {
+  const override = process.env.AGENT_AUTH_BASE_URL || process.env.NEXT_PUBLIC_SITE_URL
+  if (override) return override.replace(/\/+$/, '')
+
+  // No canonical origin configured: derive from proxy headers. The issuer/audience of signed
+  // assertions and every discovery URL come from here, so an attacker-set Host could poison
+  // them. If AGENT_AUTH_ALLOWED_HOSTS is set we only honor a Host on that list (falling back to
+  // the first allowed host for anything unrecognized). Set AGENT_AUTH_BASE_URL — or the
+  // allow-list — in production.
+  const headers = request.headers
+  const host = headers.get('x-forwarded-host') || headers.get('host') || ''
+  const allowed = (process.env.AGENT_AUTH_ALLOWED_HOSTS || '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+
+  if (allowed.length > 0) {
+    const canonical = host && allowed.includes(host) ? host : allowed[0]
+    return `https://${canonical}`
+  }
+  if (host) {
+    const proto =
+      headers.get('x-forwarded-proto') || (host.startsWith('localhost') ? 'http' : 'https')
+    return `${proto}://${host}`
+  }
+  // Last resort: derive from the request URL itself.
+  return new URL(request.url).origin
+}
+
+// Discovery + endpoint URLs, all derived from the base origin.
+export const issuerFor = (base: string) => base
+export const resourceFor = (base: string) => `${base}/`
+export const prmUrl = (base: string) => `${base}/.well-known/oauth-protected-resource`
+export const asMetadataUrl = (base: string) => `${base}/.well-known/oauth-authorization-server`
+export const authMdUrl = (base: string) => `${base}/auth.md`
+// Endpoint paths (CLAIM_PATH is also returned verbatim as the relative `claim_url`).
+export const IDENTITY_PATH = '/api/agent/identity'
+export const CLAIM_PATH = '/api/agent/identity/claim'
+export const identityEndpoint = (base: string) => `${base}${IDENTITY_PATH}`
+export const claimEndpoint = (base: string) => `${base}${CLAIM_PATH}`
+export const tokenEndpoint = (base: string) => `${base}/api/oauth2/token`
+export const revocationEndpoint = (base: string) => `${base}/api/oauth2/revoke`
+// Human-facing claim page (the verification_uri points here, through sign-in if needed).
+export const claimPagePath = (claimAttemptToken: string) =>
+  `/agent/claim?claim_attempt_token=${encodeURIComponent(claimAttemptToken)}`
+export const verificationUri = (base: string, claimAttemptToken: string) =>
+  `${base}${claimPagePath(claimAttemptToken)}`
+
+/**
+ * The HMAC secret used to sign + verify the service identity_assertion (HS256).
+ * Since this service is the only signer and verifier, a symmetric secret is sufficient
+ * and avoids the JWKS machinery the agent-verified flow would require.
+ */
+export function getJwtSecret(): string {
+  const secret = process.env.AGENT_AUTH_JWT_SECRET
+  if (!secret || secret.length < 16) {
+    throw new Error(
+      'AGENT_AUTH_JWT_SECRET is not configured (set a random string of at least 16 characters)'
+    )
+  }
+  return secret
+}

--- a/src/lib/agent-auth/resource.ts
+++ b/src/lib/agent-auth/resource.ts
@@ -1,0 +1,130 @@
+/**
+ * Resource-server authentication for VineSight API routes. Lets a route accept EITHER a
+ * normal browser cookie session OR an agent-issued bearer access_token, returning the
+ * resolved user id plus a Supabase client to query with.
+ *
+ *   const auth = await authenticateResourceRequest(request, 'farms.read')
+ *   if (!auth.ok) return auth.response
+ *   const { data } = await auth.db.from('farms').select('*').eq('user_id', auth.userId)
+ *
+ * Cookie sessions get the RLS-scoped server client (unchanged behavior); agent tokens get
+ * the service-role client, so callers MUST filter agent queries by `auth.userId` explicitly.
+ * On failure it returns a ready 401/403 carrying a WWW-Authenticate challenge that points
+ * agents at the Protected Resource Metadata for discovery.
+ */
+
+import { NextResponse } from 'next/server'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { createServerSupabaseClient } from '@/lib/auth-utils'
+import { getSupabaseAdmin } from '@/lib/supabase-admin'
+import { getBaseUrl, prmUrl } from './config'
+import { getAccessTokenByHash } from './store'
+import { sha256Hex } from './tokens'
+
+export type ResourceAuth =
+  | { ok: true; userId: string; scopes: string[]; viaAgent: boolean; db: SupabaseClient }
+  | { ok: false; response: NextResponse }
+
+function bearerChallenge(
+  base: string,
+  opts: { error?: string; description?: string; scope?: string } = {}
+): string {
+  const parts: string[] = []
+  if (opts.error) parts.push(`error="${opts.error}"`)
+  if (opts.description) parts.push(`error_description="${opts.description}"`)
+  if (opts.scope) parts.push(`scope="${opts.scope}"`)
+  parts.push(`resource_metadata="${prmUrl(base)}"`)
+  return `Bearer ${parts.join(', ')}`
+}
+
+function challengeResponse(
+  status: number,
+  body: Record<string, unknown>,
+  base: string,
+  challenge: { error?: string; description?: string; scope?: string }
+): { ok: false; response: NextResponse } {
+  return {
+    ok: false,
+    response: NextResponse.json(body, {
+      status,
+      headers: {
+        'WWW-Authenticate': bearerChallenge(base, challenge),
+        'Cache-Control': 'no-store'
+      }
+    })
+  }
+}
+
+export async function authenticateResourceRequest(
+  request: Request,
+  requiredScope: string
+): Promise<ResourceAuth> {
+  const base = getBaseUrl(request)
+  const authorization = request.headers.get('authorization') || ''
+
+  // --- Agent bearer token path ---
+  if (authorization.toLowerCase().startsWith('bearer ')) {
+    const token = authorization.slice(7).trim()
+    const row = token ? await getAccessTokenByHash(sha256Hex(token)) : null
+
+    const invalidToken = (description: string) =>
+      challengeResponse(401, { error: 'invalid_token', error_description: description }, base, {
+        error: 'invalid_token',
+        description
+      })
+
+    if (!row) return invalidToken('The access token is invalid')
+    if (row.revoked_at) return invalidToken('The access token has been revoked')
+    if (new Date(row.expires_at).getTime() <= Date.now()) {
+      return invalidToken('The access token has expired')
+    }
+    if (!row.user_id) {
+      return challengeResponse(
+        403,
+        {
+          error: 'insufficient_scope',
+          error_description: 'This token is not yet bound to a user (unclaimed registration)'
+        },
+        base,
+        { error: 'insufficient_scope', scope: requiredScope }
+      )
+    }
+    if (!row.scopes.includes(requiredScope)) {
+      return challengeResponse(
+        403,
+        {
+          error: 'insufficient_scope',
+          error_description: `Missing required scope: ${requiredScope}`
+        },
+        base,
+        { error: 'insufficient_scope', scope: requiredScope }
+      )
+    }
+
+    return {
+      ok: true,
+      userId: row.user_id,
+      scopes: row.scopes,
+      viaAgent: true,
+      db: getSupabaseAdmin() as unknown as SupabaseClient
+    }
+  }
+
+  // --- Browser cookie session path (unchanged behavior for existing clients) ---
+  const supabase = await createServerSupabaseClient()
+  const {
+    data: { user }
+  } = await supabase.auth.getUser()
+  if (user) {
+    return {
+      ok: true,
+      userId: user.id,
+      scopes: ['*'],
+      viaAgent: false,
+      db: supabase as unknown as SupabaseClient
+    }
+  }
+
+  // Neither credential — 401 with a discovery pointer for agents (browsers ignore it).
+  return challengeResponse(401, { error: 'Authentication required' }, base, {})
+}

--- a/src/lib/agent-auth/responses.ts
+++ b/src/lib/agent-auth/responses.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared request/response helpers for the agent-auth endpoints. OAuth/token responses must not
+ * be cached, and errors follow the `{ error, error_description }` shape from the spec.
+ */
+
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { SecurityService } from '@/lib/security-service'
+import { globalRateLimiter } from '@/lib/validation'
+
+export function jsonNoStore(
+  body: unknown,
+  init: { status?: number; headers?: Record<string, string> } = {}
+): NextResponse {
+  return NextResponse.json(body, {
+    status: init.status ?? 200,
+    headers: { 'Cache-Control': 'no-store', ...(init.headers ?? {}) }
+  })
+}
+
+export function oauthError(
+  error: string,
+  opts: { description?: string; status?: number; headers?: Record<string, string> } = {}
+): NextResponse {
+  return jsonNoStore(
+    { error, ...(opts.description ? { error_description: opts.description } : {}) },
+    { status: opts.status ?? 400, headers: opts.headers }
+  )
+}
+
+/** Best-effort client IP. Delegates to the shared SecurityService helper to avoid drift. */
+export function getClientIp(request: Request): string {
+  return SecurityService.getClientIP(request as unknown as NextRequest)
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+/** Loose email validation shared by the registration + claim endpoints. */
+export function isEmail(value: unknown): value is string {
+  return typeof value === 'string' && value.length <= 254 && EMAIL_RE.test(value)
+}
+
+/** Enforce the in-process per-IP rate limit; returns a ready 429, or null when allowed. */
+export function checkRateLimit(request: Request, key: string): NextResponse | null {
+  const result = globalRateLimiter.checkLimit(`${key}-${getClientIp(request)}`)
+  if (result.allowed) return null
+  return oauthError('rate_limited', { description: result.reason, status: 429 })
+}
+
+/** Parse a JSON body, enforcing content-type. Returns a ready 400 response on failure. */
+export async function readJsonBody(
+  request: Request
+): Promise<{ ok: true; body: any } | { ok: false; response: NextResponse }> {
+  if (!(request.headers.get('content-type') || '').includes('application/json')) {
+    return {
+      ok: false,
+      response: oauthError('invalid_request', { description: 'Expected application/json' })
+    }
+  }
+  try {
+    return { ok: true, body: await request.json() }
+  } catch {
+    return {
+      ok: false,
+      response: oauthError('invalid_request', { description: 'Invalid JSON payload' })
+    }
+  }
+}
+
+/** Parse an application/x-www-form-urlencoded body. */
+export async function readFormBody(request: Request): Promise<URLSearchParams> {
+  return new URLSearchParams(await request.text())
+}

--- a/src/lib/agent-auth/store.ts
+++ b/src/lib/agent-auth/store.ts
@@ -1,0 +1,272 @@
+/**
+ * Data-access layer for the agent-auth tables. Everything here runs server-side with the
+ * Supabase service-role client (RLS-bypassing); the tables are otherwise deny-all.
+ *
+ * The agent-auth tables are not part of the generated `Database` types, so we use an
+ * untyped service client and keep the row shapes typed here instead.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { getSupabaseAdmin } from '@/lib/supabase-admin'
+import { randomId } from './tokens'
+
+function admin(): SupabaseClient {
+  return getSupabaseAdmin() as unknown as SupabaseClient
+}
+
+const nowIso = () => new Date().toISOString()
+export const inSeconds = (seconds: number) => new Date(Date.now() + seconds * 1000).toISOString()
+
+export type RegistrationType = 'anonymous' | 'service_auth'
+export type RegistrationStatus = 'unclaimed' | 'claimed' | 'expired' | 'revoked'
+export type ClaimAttemptStatus = 'initiated' | 'confirmed' | 'expired'
+
+export interface AgentRegistration {
+  id: string
+  registration_type: RegistrationType
+  status: RegistrationStatus
+  claim_token_hash: string
+  claim_email: string | null
+  claimed_by_user_id: string | null
+  agent_label: string | null
+  client_ip: string | null
+  assertion_expires_at: string
+  expires_at: string
+  claimed_at: string | null
+  revoked_at: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface AgentClaimAttempt {
+  id: string
+  registration_id: string
+  claim_attempt_token_hash: string
+  user_code_hash: string
+  status: ClaimAttemptStatus
+  attempts: number
+  claimed_by_user_id: string | null
+  client_ip: string | null
+  expires_at: string
+  confirmed_at: string | null
+  created_at: string
+}
+
+export interface AgentAccessToken {
+  id: string
+  registration_id: string
+  user_id: string | null
+  token_hash: string
+  scopes: string[]
+  client_ip: string | null
+  expires_at: string
+  revoked_at: string | null
+  created_at: string
+}
+
+// --- Registrations -----------------------------------------------------------
+
+export async function createRegistration(input: {
+  registrationType: RegistrationType
+  claimTokenHash: string
+  assertionExpiresAt: string
+  expiresAt: string
+  claimEmail?: string | null
+  agentLabel?: string | null
+  clientIp?: string | null
+}): Promise<AgentRegistration> {
+  const row = {
+    id: randomId('reg'),
+    registration_type: input.registrationType,
+    status: 'unclaimed' as RegistrationStatus,
+    claim_token_hash: input.claimTokenHash,
+    claim_email: input.claimEmail ?? null,
+    agent_label: input.agentLabel ?? null,
+    client_ip: input.clientIp ?? null,
+    assertion_expires_at: input.assertionExpiresAt,
+    expires_at: input.expiresAt
+  }
+  const { data, error } = await admin().from('agent_registrations').insert(row).select().single()
+  if (error) throw error
+  return data as AgentRegistration
+}
+
+export async function getRegistrationById(id: string): Promise<AgentRegistration | null> {
+  const { data, error } = await admin()
+    .from('agent_registrations')
+    .select('*')
+    .eq('id', id)
+    .maybeSingle()
+  if (error) throw error
+  return (data as AgentRegistration) ?? null
+}
+
+export async function getRegistrationByClaimTokenHash(
+  hash: string
+): Promise<AgentRegistration | null> {
+  const { data, error } = await admin()
+    .from('agent_registrations')
+    .select('*')
+    .eq('claim_token_hash', hash)
+    .maybeSingle()
+  if (error) throw error
+  return (data as AgentRegistration) ?? null
+}
+
+export async function updateRegistration(
+  id: string,
+  patch: Partial<AgentRegistration>
+): Promise<void> {
+  const { error } = await admin()
+    .from('agent_registrations')
+    .update({ ...patch, updated_at: nowIso() })
+    .eq('id', id)
+  if (error) throw error
+}
+
+/**
+ * True once the registration can no longer mint usable credentials.
+ *
+ * `expires_at` is the deadline to COMPLETE a claim, so it only gates registrations that are
+ * still `unclaimed`; once claimed, the registration lives until `assertion_expires_at` (its
+ * hard outer bound). Without this split a claimed agent would wrongly stop working at the
+ * 7-day claim deadline even though its identity_assertion is valid for 30 days; the
+ * assertion_expires_at check is what finally bounds a claimed registration (and stops the
+ * claim_token from minting tokens forever).
+ */
+export function isRegistrationExpired(reg: AgentRegistration): boolean {
+  if (reg.status === 'revoked' || reg.status === 'expired') return true
+  const now = Date.now()
+  if (reg.status === 'unclaimed' && new Date(reg.expires_at).getTime() <= now) return true
+  if (new Date(reg.assertion_expires_at).getTime() <= now) return true
+  return false
+}
+
+// --- Claim attempts ----------------------------------------------------------
+
+export async function expireActiveAttempts(registrationId: string): Promise<void> {
+  await admin()
+    .from('agent_claim_attempts')
+    .update({ status: 'expired' })
+    .eq('registration_id', registrationId)
+    .eq('status', 'initiated')
+}
+
+export async function createClaimAttempt(input: {
+  registrationId: string
+  claimAttemptTokenHash: string
+  userCodeHash: string
+  expiresAt: string
+  clientIp?: string | null
+}): Promise<AgentClaimAttempt> {
+  const row = {
+    id: randomId('cla'),
+    registration_id: input.registrationId,
+    claim_attempt_token_hash: input.claimAttemptTokenHash,
+    user_code_hash: input.userCodeHash,
+    status: 'initiated' as ClaimAttemptStatus,
+    attempts: 0,
+    client_ip: input.clientIp ?? null,
+    expires_at: input.expiresAt
+  }
+  const { data, error } = await admin().from('agent_claim_attempts').insert(row).select().single()
+  if (error) throw error
+  return data as AgentClaimAttempt
+}
+
+export async function getClaimAttemptByTokenHash(hash: string): Promise<AgentClaimAttempt | null> {
+  const { data, error } = await admin()
+    .from('agent_claim_attempts')
+    .select('*')
+    .eq('claim_attempt_token_hash', hash)
+    .maybeSingle()
+  if (error) throw error
+  return (data as AgentClaimAttempt) ?? null
+}
+
+export async function updateClaimAttempt(
+  id: string,
+  patch: Partial<AgentClaimAttempt>
+): Promise<void> {
+  const { error } = await admin().from('agent_claim_attempts').update(patch).eq('id', id)
+  if (error) throw error
+}
+
+// --- Access tokens -----------------------------------------------------------
+
+export async function createAccessToken(input: {
+  registrationId: string
+  userId: string | null
+  tokenHash: string
+  scopes: string[]
+  expiresAt: string
+  clientIp?: string | null
+}): Promise<AgentAccessToken> {
+  const row = {
+    id: randomId('tok'),
+    registration_id: input.registrationId,
+    user_id: input.userId,
+    token_hash: input.tokenHash,
+    scopes: input.scopes,
+    client_ip: input.clientIp ?? null,
+    expires_at: input.expiresAt
+  }
+  const { data, error } = await admin().from('agent_access_tokens').insert(row).select().single()
+  if (error) throw error
+  return data as AgentAccessToken
+}
+
+export async function getAccessTokenByHash(hash: string): Promise<AgentAccessToken | null> {
+  const { data, error } = await admin()
+    .from('agent_access_tokens')
+    .select('*')
+    .eq('token_hash', hash)
+    .maybeSingle()
+  if (error) throw error
+  return (data as AgentAccessToken) ?? null
+}
+
+export async function revokeAccessTokenByHash(hash: string): Promise<void> {
+  await admin()
+    .from('agent_access_tokens')
+    .update({ revoked_at: nowIso() })
+    .eq('token_hash', hash)
+    .is('revoked_at', null)
+}
+
+/** Revoke any still-live tokens minted before a claim (the pre-claim, user-less tokens). */
+export async function revokePreClaimTokens(registrationId: string): Promise<void> {
+  await admin()
+    .from('agent_access_tokens')
+    .update({ revoked_at: nowIso() })
+    .eq('registration_id', registrationId)
+    .is('user_id', null)
+    .is('revoked_at', null)
+}
+
+// --- Audit -------------------------------------------------------------------
+
+export async function recordEvent(
+  event: string,
+  opts: {
+    registrationId?: string | null
+    userId?: string | null
+    metadata?: Record<string, unknown>
+  } = {}
+): Promise<void> {
+  try {
+    await admin()
+      .from('agent_auth_events')
+      .insert({
+        event,
+        registration_id: opts.registrationId ?? null,
+        user_id: opts.userId ?? null,
+        metadata: opts.metadata ?? null
+      })
+  } catch (error) {
+    // Audit logging must never break the request flow.
+    if (process.env.NODE_ENV === 'development') {
+      console.error('[agent-auth] failed to record event', event, error)
+    }
+  }
+}

--- a/src/lib/agent-auth/tokens.ts
+++ b/src/lib/agent-auth/tokens.ts
@@ -1,0 +1,87 @@
+/**
+ * Cryptographic helpers for the agent-auth flow: prefixed CSPRNG identifiers/secrets,
+ * SHA-256 hashing for at-rest bearer secrets, constant-time comparison, the 6-digit
+ * user_code, and a minimal HS256 JWT signer/verifier for the identity_assertion.
+ *
+ * The JWT is a standard, compact HS256 token built on Node's `crypto`. We only ever sign
+ * and verify our own assertions with a symmetric secret, so no external JWT library or
+ * JWKS resolution is needed.
+ */
+
+import crypto from 'crypto'
+
+/** A non-secret, prefixed identifier, e.g. reg_<base64url>. */
+export function randomId(prefix: string, bytes = 16): string {
+  return `${prefix}_${crypto.randomBytes(bytes).toString('base64url')}`
+}
+
+/** A high-entropy bearer secret, e.g. clm_<base64url>. Returned to the caller exactly once. */
+export function randomSecret(prefix: string, bytes = 24): string {
+  return `${prefix}_${crypto.randomBytes(bytes).toString('base64url')}`
+}
+
+export function sha256Hex(value: string): string {
+  return crypto.createHash('sha256').update(value).digest('hex')
+}
+
+/** Constant-time comparison of two equal-purpose strings (returns false on length mismatch). */
+export function timingSafeEqual(a: string, b: string): boolean {
+  const bufferA = Buffer.from(a)
+  const bufferB = Buffer.from(b)
+  if (bufferA.length !== bufferB.length) return false
+  return crypto.timingSafeEqual(bufferA, bufferB)
+}
+
+/** A CSPRNG 6-digit numeric code (RFC 8628 user_code), zero-padded. */
+export function generateUserCode(): string {
+  return crypto.randomInt(0, 1_000_000).toString().padStart(6, '0')
+}
+
+// --- Minimal HS256 JWT -------------------------------------------------------
+
+function b64url(input: string | Buffer): string {
+  return Buffer.from(input).toString('base64url')
+}
+
+export interface JwtPayload {
+  [claim: string]: unknown
+}
+
+export function signJwt(payload: JwtPayload, secret: string, typ = 'JWT'): string {
+  const header = b64url(JSON.stringify({ alg: 'HS256', typ }))
+  const body = b64url(JSON.stringify(payload))
+  const signingInput = `${header}.${body}`
+  const signature = crypto.createHmac('sha256', secret).update(signingInput).digest('base64url')
+  return `${signingInput}.${signature}`
+}
+
+export class JwtError extends Error {}
+
+/**
+ * Verifies an HS256 JWT signature and the exp/nbf time bounds, returning the decoded
+ * payload. Throws JwtError on any failure. Caller is responsible for iss/aud/typ checks.
+ */
+export function verifyJwt(token: string, secret: string): JwtPayload {
+  const parts = token.split('.')
+  if (parts.length !== 3) throw new JwtError('Malformed token')
+  const [header, body, signature] = parts
+
+  const expected = crypto
+    .createHmac('sha256', secret)
+    .update(`${header}.${body}`)
+    .digest('base64url')
+  if (!timingSafeEqual(signature, expected)) throw new JwtError('Invalid signature')
+
+  let payload: JwtPayload
+  try {
+    payload = JSON.parse(Buffer.from(body, 'base64url').toString('utf8'))
+  } catch {
+    throw new JwtError('Invalid payload')
+  }
+
+  const now = Math.floor(Date.now() / 1000)
+  if (typeof payload.exp === 'number' && now >= payload.exp) throw new JwtError('Token expired')
+  if (typeof payload.nbf === 'number' && now < payload.nbf)
+    throw new JwtError('Token not yet valid')
+  return payload
+}

--- a/supabase/migrations/202606140001_agent_auth.sql
+++ b/supabase/migrations/202606140001_agent_auth.sql
@@ -1,0 +1,116 @@
+-- auth.md agent registration (user-claimed flow).
+-- Implements the WorkOS auth.md "user claimed" flow so AI agents can register on behalf
+-- of a VineSight user and obtain scoped, revocable bearer access tokens.
+--
+-- Trust model: every row here either stores a SHA-256 hash of a bearer secret
+-- (claim tokens, user codes, access tokens) or agent registration state. None of it is
+-- ever read by the browser. RLS is enabled with NO policies so the anon/authenticated
+-- client roles are denied by default; all access goes through server-side code using the
+-- service-role key (which bypasses RLS). See src/lib/agent-auth/store.ts.
+
+-- ---------------------------------------------------------------------------
+-- agent_registrations: one row per agent that has registered with the service.
+-- ---------------------------------------------------------------------------
+create table if not exists public.agent_registrations (
+  id text primary key,                          -- e.g. reg_<base62>
+  registration_type text not null
+    check (registration_type in ('anonymous', 'service_auth')),
+  status text not null default 'unclaimed'
+    check (status in ('unclaimed', 'claimed', 'expired', 'revoked')),
+  claim_token_hash text not null,               -- sha256 of the long-lived claim_token
+  claim_email text,                             -- email that must match the claiming user
+  claimed_by_user_id uuid references auth.users(id) on delete cascade,
+  agent_label text,                             -- best-effort User-Agent capture
+  client_ip text,
+  assertion_expires_at timestamptz not null,    -- outer bound for re-exchangeable assertions
+  expires_at timestamptz not null,              -- unclaimed registrations expire at this time
+  claimed_at timestamptz,
+  revoked_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create unique index if not exists idx_agent_registrations_claim_token
+  on public.agent_registrations (claim_token_hash);
+create index if not exists idx_agent_registrations_status
+  on public.agent_registrations (status);
+create index if not exists idx_agent_registrations_claimed_by
+  on public.agent_registrations (claimed_by_user_id);
+
+-- ---------------------------------------------------------------------------
+-- agent_claim_attempts: the RFC 8628-shaped claim ceremony material. A fresh
+-- attempt is minted each time the user code is (re)issued; older attempts for the
+-- same registration are marked 'expired' so only the latest verification_uri works.
+-- ---------------------------------------------------------------------------
+create table if not exists public.agent_claim_attempts (
+  id text primary key,                          -- e.g. cla_<base62>
+  registration_id text not null
+    references public.agent_registrations(id) on delete cascade,
+  claim_attempt_token_hash text not null,       -- sha256 of the token embedded in verification_uri
+  user_code_hash text not null,                 -- sha256 of the 6-digit user_code
+  status text not null default 'initiated'
+    check (status in ('initiated', 'confirmed', 'expired')),
+  attempts integer not null default 0,          -- user_code guesses, for lockout
+  claimed_by_user_id uuid references auth.users(id) on delete set null,
+  client_ip text,
+  expires_at timestamptz not null,
+  confirmed_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create unique index if not exists idx_agent_claim_attempts_token
+  on public.agent_claim_attempts (claim_attempt_token_hash);
+create index if not exists idx_agent_claim_attempts_registration
+  on public.agent_claim_attempts (registration_id);
+
+-- ---------------------------------------------------------------------------
+-- agent_access_tokens: opaque bearer tokens minted at /oauth2/token. The resource
+-- server (src/lib/agent-auth/resource.ts) authenticates a request by hashing the
+-- presented bearer and looking it up here. Revocation just stamps revoked_at.
+-- ---------------------------------------------------------------------------
+create table if not exists public.agent_access_tokens (
+  id text primary key,                          -- e.g. tok_<base62>
+  registration_id text not null
+    references public.agent_registrations(id) on delete cascade,
+  user_id uuid references auth.users(id) on delete cascade,  -- null while pre-claim
+  token_hash text not null,                     -- sha256 of the opaque access_token
+  scopes text[] not null default '{}',
+  client_ip text,
+  expires_at timestamptz not null,
+  revoked_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create unique index if not exists idx_agent_access_tokens_hash
+  on public.agent_access_tokens (token_hash);
+create index if not exists idx_agent_access_tokens_registration
+  on public.agent_access_tokens (registration_id);
+create index if not exists idx_agent_access_tokens_user
+  on public.agent_access_tokens (user_id);
+
+-- ---------------------------------------------------------------------------
+-- agent_auth_events: lightweight audit trail for every state change, as the
+-- auth.md "For apps" guide recommends.
+-- ---------------------------------------------------------------------------
+create table if not exists public.agent_auth_events (
+  id bigint generated always as identity primary key,
+  registration_id text,
+  user_id uuid,
+  event text not null,                          -- registration.created, claim.confirmed, token.issued, ...
+  metadata jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_agent_auth_events_registration
+  on public.agent_auth_events (registration_id);
+create index if not exists idx_agent_auth_events_event
+  on public.agent_auth_events (event);
+
+-- ---------------------------------------------------------------------------
+-- Row Level Security: deny-all by default. Only the service-role key may touch
+-- these tables (it bypasses RLS). We intentionally create no policies.
+-- ---------------------------------------------------------------------------
+alter table public.agent_registrations enable row level security;
+alter table public.agent_claim_attempts enable row level security;
+alter table public.agent_access_tokens enable row level security;
+alter table public.agent_auth_events enable row level security;


### PR DESCRIPTION
## What

Implements the [WorkOS **auth.md**](https://workos.com/auth-md/docs) **user-claimed** flow so AI agents can register on behalf of a VineSight user and obtain scoped, revocable bearer tokens. The authorization server and resource server are co-located on the app origin (no separate AS host).

The agent-verified / ID-JAG path is intentionally **not** implemented — `identity_types_supported` advertises only `anonymous` and `service_auth`.

## How it works

1. **Discover** — `/auth.md` (prose) + `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server` (with the `agent_auth` block). Served via `next.config` rewrites so the origin is computed per-request.
2. **Register** — `POST /api/agent/identity` with `{"type":"anonymous"}` (immediate pre-claim assertion) or `{"type":"service_auth","login_hint":"…"}` (claim required first).
3. **Claim** — the user opens the `verification_uri`, signs in, and types the 6-digit code on `/agent/claim`; the agent polls `POST /api/oauth2/token` (claim grant) until it flips from `authorization_pending` to an `access_token` + `identity_assertion`.
4. **Use / refresh / revoke** — `Authorization: Bearer <token>` on the API; re-exchange the assertion via the jwt-bearer grant (no refresh token); `POST /api/oauth2/revoke` (RFC 7009).

Bearer auth is wired into `GET /api/farms` (`farms.read`) and `GET /api/tasks` (`tasks.read`) **alongside** the existing cookie session — no change for browser clients.

## Security / design

- New tables (`agent_registrations`, `agent_claim_attempts`, `agent_access_tokens`, `agent_auth_events`) behind **deny-all RLS** — only the service role touches them.
- Claim tokens, user codes, and access tokens are stored as **SHA-256** (plaintext returned once); the `identity_assertion` is a service-signed **HS256 JWT** built on Node `crypto` (no new dependency).
- Constant-time code check with a 5-try lockout; same-account binding (claim email vs signed-in user); pre-claim tokens revoked on claim; a registration's lifetime is bounded by `assertion_expires_at`.
- `getBaseUrl` host-poisoning guard via optional `AGENT_AUTH_ALLOWED_HOSTS`; `AGENT_AUTH_BASE_URL` recommended in production.

## ⚠️ Required to deploy

1. **Run the migration** `supabase/migrations/202606140001_agent_auth.sql`.
2. Set **`AGENT_AUTH_JWT_SECRET`** (random, ≥16 chars) and, in production, **`AGENT_AUTH_BASE_URL`**.
3. Ensure the Supabase Auth **redirect allow-list** permits `/auth/callback` with a query string (used by the claim sign-in round-trip).

## Verification

- `tsc --noEmit` clean for all new/changed files; `eslint` reports 0 errors.
- Hand-rolled JWT + crypto unit-tested (sign/verify/tamper/expiry).
- Live dev-server probe: discovery docs, `/auth.md`, validation paths, and the `WWW-Authenticate` discovery challenge on `GET /api/farms` all return as expected.
- Self-reviewed (max-effort pass): fixed claimed-registration expiry, `/auth.md` middleware routing, DB-error masking in getters, host-header trust, and the `next` open-redirect guard.

## Follow-ups (not in this PR)

- Double-claim is not yet an atomic compare-and-set (low severity).
- A "Connected agents" settings screen (list + revoke) for end users.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements WorkOS `auth.md` user-claimed agent registration so agents can act on a user’s behalf with scoped, revocable bearer tokens. Adds bearer auth to `GET /api/farms` and `GET /api/tasks` alongside existing cookie sessions.

- **New Features**
  - Discovery via rewrites: `/auth.md`, `/.well-known/oauth-protected-resource`, and `/.well-known/oauth-authorization-server` (with `agent_auth`).
  - Registration: `POST /api/agent/identity` (`anonymous` or `service_auth`) and `POST /api/agent/identity/claim` (anonymous only).
  - Tokens: `POST /api/oauth2/token` (JWT-bearer exchange and claim polling) and `POST /api/oauth2/revoke` (RFC 7009).
  - Claim UI: `/agent/claim` for code entry after sign-in; API routes now accept bearer tokens with `farms.read` and `tasks.read`.

- **Migration**
  - Run `supabase/migrations/202606140001_agent_auth.sql`.
  - Set `AGENT_AUTH_JWT_SECRET` (required) and `AGENT_AUTH_BASE_URL` in production; optionally `AGENT_AUTH_ALLOWED_HOSTS` when deriving origin from `Host`.
  - Allow `/auth/callback` with a query string in the Supabase Auth redirect allow-list.

<sup>Written for commit 75d386a79059969d115b64c4e803c5cdb08c2b31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ashish921998/Vinesight/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added agent registration and authentication system for third-party integrations.
  * Implemented OAuth2 token issuance and revocation endpoints for authorized agents.
  * Added agent claim verification flow with email confirmation.
  * Improved API authentication to support both browser sessions and agent bearer tokens.
  * Published standard OAuth discovery metadata for agent integration.

* **Documentation**
  * Added agent authentication setup and design guide.

* **Chores**
  * Added database schema for agent registrations, claim attempts, and access token management.
  * Enhanced auth routing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->