### PR TITLE
refactor(auth): extract auth logic into DI, vitest-tested src/lib/auth modules

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -97,6 +97,7 @@
         "supabase": "^2.70.5",
         "tailwindcss": "^4.1.18",
         "typescript": "^5.9.3",
+        "vitest": "^4.1.1",
       },
     },
   },
@@ -695,6 +696,38 @@
 
     "@reduxjs/toolkit": ["@reduxjs/toolkit@2.10.1", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^10.2.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" } }, "sha512-/U17EXQ9Do9Yx4DlNGU6eVNfZvFJfYpUtRRdLf19PbPjdWBxNlxGZXywQZ1p1Nz8nMkWplTI7iD/23m07nolDA=="],
 
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.3", "", { "os": "android", "cpu": "arm64" }, "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.3", "", { "os": "linux", "cpu": "arm" }, "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.3", "", { "os": "none", "cpu": "arm64" }, "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.3", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
     "@rollup/plugin-commonjs": ["@rollup/plugin-commonjs@28.0.1", "", { "dependencies": { "@rollup/pluginutils": "^5.0.1", "commondir": "^1.0.1", "estree-walker": "^2.0.2", "fdir": "^6.2.0", "is-reference": "1.2.1", "magic-string": "^0.30.3", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^2.68.0||^3.0.0||^4.0.0" } }, "sha512-+tNWdlWKbpB3WgBN7ijjYkq9X5uhjmcvyjEght4NmH5fAU++zfQzAJ6wumLS+dNcvwEZhKx2Z+skY8m7v0wGSA=="],
 
     "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" } }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
@@ -817,7 +850,7 @@
 
     "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
-    "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
@@ -897,6 +930,8 @@
 
     "@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
 
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
     "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
@@ -964,6 +999,8 @@
     "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
 
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/eslint": ["@types/eslint@9.6.1", "", { "dependencies": { "@types/estree": "*", "@types/json-schema": "*" } }, "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag=="],
 
@@ -1095,6 +1132,20 @@
 
     "@vercel/oidc": ["@vercel/oidc@3.0.5", "", {}, "sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw=="],
 
+    "@vitest/expect": ["@vitest/expect@4.1.9", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.9", "", { "dependencies": { "@vitest/spy": "4.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.9", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.9", "", { "dependencies": { "@vitest/utils": "4.1.9", "pathe": "^2.0.3" } }, "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "@vitest/utils": "4.1.9", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.9", "", {}, "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA=="],
+
     "@webassemblyjs/ast": ["@webassemblyjs/ast@1.14.1", "", { "dependencies": { "@webassemblyjs/helper-numbers": "1.13.2", "@webassemblyjs/helper-wasm-bytecode": "1.13.2" } }, "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ=="],
 
     "@webassemblyjs/floating-point-hex-parser": ["@webassemblyjs/floating-point-hex-parser@1.13.2", "", {}, "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA=="],
@@ -1187,6 +1238,8 @@
 
     "arraybuffer.prototype.slice": ["arraybuffer.prototype.slice@1.0.4", "", { "dependencies": { "array-buffer-byte-length": "^1.0.1", "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "is-array-buffer": "^3.0.4" } }, "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ=="],
 
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
     "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
 
     "ast-types-flow": ["ast-types-flow@0.0.8", "", {}, "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ=="],
@@ -1244,6 +1297,8 @@
     "canvg": ["canvg@3.0.11", "", { "dependencies": { "@babel/runtime": "^7.12.5", "@types/raf": "^3.4.0", "core-js": "^3.8.3", "raf": "^3.4.1", "regenerator-runtime": "^0.13.7", "rgbcolor": "^1.0.1", "stackblur-canvas": "^2.0.0", "svg-pathdata": "^6.0.3" } }, "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -1507,7 +1562,7 @@
 
     "es-iterator-helpers": ["es-iterator-helpers@1.2.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-abstract": "^1.23.6", "es-errors": "^1.3.0", "es-set-tostringtag": "^2.0.3", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.6", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "internal-slot": "^1.1.0", "iterator.prototype": "^1.1.4", "safe-array-concat": "^1.1.3" } }, "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w=="],
 
-    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+    "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
@@ -1565,7 +1620,7 @@
 
     "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
 
-    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
@@ -1582,6 +1637,8 @@
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
     "execa": ["execa@9.6.0", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-jpWzZ1ZhwUmeWRhS7Qv3mhpOhLfwI+uAX4e5fOcXqwMR7EcJ0pj2kV1CVzHVMX/LphnKWD3LObjZCoJ71lKpHw=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "express": ["express@5.1.0", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.0", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA=="],
 
@@ -2213,6 +2270,8 @@
 
     "object.values": ["object.values@1.2.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA=="],
 
+    "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
+
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
@@ -2471,6 +2530,8 @@
 
     "robust-predicates": ["robust-predicates@3.0.2", "", {}, "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="],
 
+    "rolldown": ["rolldown@1.0.3", "", { "dependencies": { "@oxc-project/types": "=0.133.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.3", "@rolldown/binding-darwin-arm64": "1.0.3", "@rolldown/binding-darwin-x64": "1.0.3", "@rolldown/binding-freebsd-x64": "1.0.3", "@rolldown/binding-linux-arm-gnueabihf": "1.0.3", "@rolldown/binding-linux-arm64-gnu": "1.0.3", "@rolldown/binding-linux-arm64-musl": "1.0.3", "@rolldown/binding-linux-ppc64-gnu": "1.0.3", "@rolldown/binding-linux-s390x-gnu": "1.0.3", "@rolldown/binding-linux-x64-gnu": "1.0.3", "@rolldown/binding-linux-x64-musl": "1.0.3", "@rolldown/binding-openharmony-arm64": "1.0.3", "@rolldown/binding-wasm32-wasi": "1.0.3", "@rolldown/binding-win32-arm64-msvc": "1.0.3", "@rolldown/binding-win32-x64-msvc": "1.0.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g=="],
+
     "rollup": ["rollup@4.52.5", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.52.5", "@rollup/rollup-android-arm64": "4.52.5", "@rollup/rollup-darwin-arm64": "4.52.5", "@rollup/rollup-darwin-x64": "4.52.5", "@rollup/rollup-freebsd-arm64": "4.52.5", "@rollup/rollup-freebsd-x64": "4.52.5", "@rollup/rollup-linux-arm-gnueabihf": "4.52.5", "@rollup/rollup-linux-arm-musleabihf": "4.52.5", "@rollup/rollup-linux-arm64-gnu": "4.52.5", "@rollup/rollup-linux-arm64-musl": "4.52.5", "@rollup/rollup-linux-loong64-gnu": "4.52.5", "@rollup/rollup-linux-ppc64-gnu": "4.52.5", "@rollup/rollup-linux-riscv64-gnu": "4.52.5", "@rollup/rollup-linux-riscv64-musl": "4.52.5", "@rollup/rollup-linux-s390x-gnu": "4.52.5", "@rollup/rollup-linux-x64-gnu": "4.52.5", "@rollup/rollup-linux-x64-musl": "4.52.5", "@rollup/rollup-openharmony-arm64": "4.52.5", "@rollup/rollup-win32-arm64-msvc": "4.52.5", "@rollup/rollup-win32-ia32-msvc": "4.52.5", "@rollup/rollup-win32-x64-gnu": "4.52.5", "@rollup/rollup-win32-x64-msvc": "4.52.5", "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw=="],
 
     "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
@@ -2535,6 +2596,8 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
@@ -2553,11 +2616,15 @@
 
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
 
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
     "stackblur-canvas": ["stackblur-canvas@2.7.0", "", {}, "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ=="],
 
     "stacktrace-parser": ["stacktrace-parser@0.1.11", "", { "dependencies": { "type-fest": "^0.7.1" } }, "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
     "stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
 
@@ -2651,9 +2718,13 @@
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
-    "tinyexec": ["tinyexec@1.0.1", "", {}, "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw=="],
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "tldts": ["tldts@7.0.16", "", { "dependencies": { "tldts-core": "^7.0.16" }, "bin": "bin/cli.js" }, "sha512-5bdPHSwbKTeHmXrgecID4Ljff8rQjv7g8zKQPkCozRo2HWWni+p310FSn5ImI+9kWw9kK4lzOB5q/a6iv0IJsw=="],
 
@@ -2767,6 +2838,10 @@
 
     "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
 
+    "vite": ["vite@8.0.16", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw=="],
+
+    "vitest": ["vitest@4.1.9", "", { "dependencies": { "@vitest/expect": "4.1.9", "@vitest/mocker": "4.1.9", "@vitest/pretty-format": "4.1.9", "@vitest/runner": "4.1.9", "@vitest/snapshot": "4.1.9", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.9", "@vitest/browser-preview": "4.1.9", "@vitest/browser-webdriverio": "4.1.9", "@vitest/coverage-istanbul": "4.1.9", "@vitest/coverage-v8": "4.1.9", "@vitest/ui": "4.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ=="],
+
     "void-elements": ["void-elements@3.1.0", "", {}, "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w=="],
 
     "vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
@@ -2811,6 +2886,8 @@
 
     "which-typed-array": ["which-typed-array@1.1.19", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw=="],
 
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
@@ -2852,6 +2929,12 @@
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@ai-sdk/anthropic/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.18", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ypv1xXMsgGcNKUP+hglKqtdDuMg68nWHucPPAhIENrbFAI+xCHiqPVN8Zllxyv1TNZwGWUghPxJXU+Mqps0YRQ=="],
+
+    "@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
+
+    "@antfu/install-pkg/tinyexec": ["tinyexec@1.0.1", "", {}, "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw=="],
+
+    "@antfu/ni/tinyexec": ["tinyexec@1.0.1", "", {}, "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw=="],
 
     "@babel/core/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
@@ -3027,7 +3110,17 @@
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
+    "@reduxjs/toolkit/@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
+
+    "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
+
+    "@rollup/plugin-commonjs/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
     "@rollup/plugin-commonjs/magic-string": ["magic-string@0.30.19", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw=="],
+
+    "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "@sentry-internal/server-utils/@sentry/core": ["@sentry/core@10.57.0", "", {}, "sha512-kntItTA2kiT0YpL7encXaF6mkdZMB+y48lwj8w1wkfBpfJAC7sifdgrzLQZqmsqVNE3crg9VfufaAGA+78uFMg=="],
 
@@ -3257,6 +3350,8 @@
 
     "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
+    "rolldown/@oxc-project/types": ["@oxc-project/types@0.133.0", "", {}, "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA=="],
+
     "router/path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
     "schema-utils/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
@@ -3287,6 +3382,16 @@
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
+    "vite/lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "vite/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "vite/postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
+    "vite/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "webpack/es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
     "webpack/eslint-scope": ["eslint-scope@5.1.1", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^4.1.1" } }, "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw=="],
 
     "webpack/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
@@ -3300,6 +3405,8 @@
     "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "@ai-sdk/anthropic/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
 
     "@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.27.1", "", {}, "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow=="],
 
@@ -3473,6 +3580,8 @@
 
     "@prisma/instrumentation/@opentelemetry/instrumentation/import-in-the-middle": ["import-in-the-middle@2.0.0", "", { "dependencies": { "acorn": "^8.14.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^1.2.2", "module-details-from-path": "^1.0.3" } }, "sha512-yNZhyQYqXpkT0AKq3F3KLasUSK4fHvebNH5hOsKQw2dhGSALvQ4U0BqUc5suziKvydO5u5hgN2hy1RJaho8U5A=="],
 
+    "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
+
     "@sentry/cli/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "@sentry/nextjs/@sentry/node/@opentelemetry/core": ["@opentelemetry/core@2.2.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw=="],
@@ -3554,6 +3663,30 @@
     "schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "vite/lightningcss/lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "vite/lightningcss/lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "vite/lightningcss/lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "vite/lightningcss/lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "vite/lightningcss/lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "vite/lightningcss/lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "vite/lightningcss/lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "vite/lightningcss/lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "vite/lightningcss/lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "vite/lightningcss/lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "vite/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "vite/postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
     "webpack/eslint-scope/estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
 

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "shadcn": "^3.6.2",
     "supabase": "^2.70.5",
     "tailwindcss": "^4.1.18",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "format": "prettier --write .",
     "perf": "npm run build && npm run start",
     "size": "npm run build && du -sh .next/static",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "prepare": "husky || true",
     "postinstall": "[ -n \"$CI\" ] || husky install || true",

--- a/src/app/consultant/farmers/[farmerId]/page.tsx
+++ b/src/app/consultant/farmers/[farmerId]/page.tsx
@@ -95,6 +95,13 @@ export default function FarmerProfilePage() {
       setFarmer(profile)
       setFarms(farmsData)
       setVisits(visitsData)
+      posthog.capture('consultant_farmer_profile_viewed', {
+        farmer_id: farmerId,
+        org_id: currentAccess.organizationId,
+        role: currentAccess.role,
+        farm_count: farmsData.length,
+        visit_count: visitsData.length
+      })
     } catch (error) {
       console.error('Failed to load farmer profile:', error)
       posthog.captureException(error, { context: 'loadFarmerProfile', farmerId })

--- a/src/app/consultant/farmers/page.tsx
+++ b/src/app/consultant/farmers/page.tsx
@@ -52,6 +52,11 @@ export default function FarmerDirectoryPage() {
       setAccess(currentAccess)
       const data = await getFarmerClients(currentAccess)
       setFarmers(data)
+      posthog.capture('consultant_farmer_list_viewed', {
+        org_id: currentAccess.organizationId,
+        role: currentAccess.role,
+        farmer_count: data.length
+      })
     } catch (error) {
       console.error('Failed to load farmers:', error)
       posthog.captureException(error, { context: 'getFarmerClients' })

--- a/src/app/consultant/layout.tsx
+++ b/src/app/consultant/layout.tsx
@@ -20,6 +20,7 @@ import {
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { ConsultantAccess, getConsultantAccess, roleLabels } from '@/lib/consultant-access'
+import posthog from 'posthog-js'
 import { toast } from 'sonner'
 
 interface ConsultantLayoutProps {
@@ -90,6 +91,11 @@ export default function ConsultantLayout({ children }: ConsultantLayoutProps) {
 
         setAccess(access)
         setAccessState('ok')
+        posthog.identify(access.userId, {
+          role: access.role,
+          org_id: access.organizationId,
+          can_view_all_farmers: access.canViewAllFarmers
+        })
       } catch (error) {
         console.error('Access check failed:', error)
         toast.error('Unable to verify consultant access. Please try again.')

--- a/src/app/consultant/team/page.tsx
+++ b/src/app/consultant/team/page.tsx
@@ -34,6 +34,7 @@ import {
 import { toast } from 'sonner'
 import { Loader2, UserPlus, Users, Mail, Copy, Trash2, Clock } from 'lucide-react'
 import { getConsultantAccess, roleLabels, type ConsultantAccess } from '@/lib/consultant-access'
+import posthog from 'posthog-js'
 import {
   listOrgMembers,
   listPendingInvites,
@@ -97,6 +98,11 @@ export default function TeamSettingsPage() {
       const orgId = currentAccess.organizationId
       const memberRows = await listOrgMembers(orgId)
       setMembers(memberRows)
+      posthog.capture('consultant_team_viewed', {
+        org_id: orgId,
+        role: currentAccess.role,
+        member_count: memberRows.length
+      })
 
       if (currentAccess.canViewAllFarmers) {
         const inviteRows = await listPendingInvites(orgId)

--- a/src/app/consultant/triage/page.tsx
+++ b/src/app/consultant/triage/page.tsx
@@ -25,6 +25,7 @@ import {
 import { toast } from 'sonner'
 import { Search, Loader2, ClipboardList, ChevronRight, FlaskConical } from 'lucide-react'
 import { getConsultantAccess, type ConsultantAccess } from '@/lib/consultant-access'
+import posthog from 'posthog-js'
 import {
   getTriageItems,
   getTriageItem,
@@ -122,6 +123,11 @@ export default function TriagePage() {
       setAccess(currentAccess)
       const data = await getTriageItems(currentAccess)
       setItems(data)
+      posthog.capture('consultant_triage_viewed', {
+        org_id: currentAccess.organizationId,
+        role: currentAccess.role,
+        item_count: data.length
+      })
     } catch (error) {
       console.error('Failed to load triage:', error)
       toast.error('Failed to load triage queue')
@@ -224,6 +230,11 @@ export default function TriagePage() {
             : it
         )
       )
+      posthog.capture('consultant_triage_item_actioned', {
+        status: formStatus,
+        severity: formSeverity === 'none' ? null : formSeverity,
+        has_recommendation: formRecommendation.trim().length > 0
+      })
       toast.success('Triage updated')
       closeDetail()
     } catch (error) {

--- a/src/app/consultant/triage/page.tsx
+++ b/src/app/consultant/triage/page.tsx
@@ -230,10 +230,12 @@ export default function TriagePage() {
             : it
         )
       )
+      // Report what the backend actually persisted (it may normalize/transform the form
+      // input), consistent with the list merge above — not the raw form state.
       posthog.capture('consultant_triage_item_actioned', {
-        status: formStatus,
-        severity: formSeverity === 'none' ? null : formSeverity,
-        has_recommendation: formRecommendation.trim().length > 0
+        status: updated.status,
+        severity: updated.severity,
+        has_recommendation: Boolean(updated.recommendation)
       })
       toast.success('Triage updated')
       closeDetail()

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -156,6 +156,10 @@ export default function LandingPage() {
     if (!loading && user) {
       const lastRoute = getLastRoute()
       const targetRoute = lastRoute || '/dashboard'
+      // Redirect stays client-side by design (localStorage last-route + middleware redirect-loop
+      // avoidance — see the render-gate note below); the flash this rule warns about is already
+      // prevented by that gate.
+      // react-doctor-disable-next-line react-doctor/nextjs-no-client-side-redirect, nextjs-no-client-side-redirect -- justified above
       router.replace(targetRoute)
     }
   }, [loading, user, router])

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,7 @@ import {
   ClipboardList,
   Handshake,
   Languages,
+  Loader2,
   ShieldCheck,
   Sprout,
   XCircle
@@ -158,6 +159,22 @@ export default function LandingPage() {
       router.replace(targetRoute)
     }
   }, [loading, user, router])
+
+  // Authenticated visitors are being redirected to their module home by the effect
+  // above. Don't paint the marketing page in that window, or it flashes before the
+  // redirect lands. This stays client-side on purpose: the target comes from
+  // localStorage (getLastRoute), and middleware deliberately leaves the homepage
+  // redirect to the client to avoid dashboard redirect loops (see middleware.ts).
+  if (!loading && user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="flex items-center gap-2">
+          <Loader2 className="h-6 w-6 animate-spin" />
+          <span>Loading...</span>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="min-h-screen bg-background text-foreground">

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -1,9 +1,8 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { LoginButton } from './LoginButton'
-import { Loader2, Lock } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { Loader2 } from 'lucide-react'
 import { useSupabaseAuth } from '@/hooks/useSupabaseAuth'
 
 interface ProtectedRouteProps {
@@ -13,6 +12,7 @@ interface ProtectedRouteProps {
 
 export function ProtectedRoute({ children, fallback }: ProtectedRouteProps) {
   const { user, loading } = useSupabaseAuth()
+  const router = useRouter()
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
@@ -26,8 +26,20 @@ export function ProtectedRoute({ children, fallback }: ProtectedRouteProps) {
     (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1')
   const bypassAuth = isDevelopment && isLocalhost && process.env.NEXT_PUBLIC_BYPASS_AUTH === 'true'
 
-  // Show loading until component is mounted and auth check is complete
-  if (!mounted || (loading && !bypassAuth)) {
+  // Once we know the user is unauthenticated, send them to the full login page
+  // (email/password, phone OTP, and Google) rather than a Google-only fallback.
+  // Preserve the page they wanted via ?redirect= so they return after signing in.
+  const shouldRedirect = mounted && !loading && !user && !bypassAuth && !fallback
+
+  useEffect(() => {
+    if (!shouldRedirect) return
+    const returnTo = window.location.pathname + window.location.search
+    router.replace(`/login?redirect=${encodeURIComponent(returnTo)}`)
+  }, [shouldRedirect, router])
+
+  // Show loading until component is mounted, auth check is complete, or while
+  // the redirect to /login is in flight.
+  if (!mounted || (loading && !bypassAuth) || shouldRedirect) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="flex items-center gap-2">
@@ -39,28 +51,8 @@ export function ProtectedRoute({ children, fallback }: ProtectedRouteProps) {
   }
 
   if (!user && !bypassAuth) {
-    if (fallback) {
-      return <>{fallback}</>
-    }
-
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-background">
-        <Card className="w-full max-w-md">
-          <CardHeader className="text-center">
-            <div className="flex justify-center mb-4">
-              <Lock className="h-12 w-12 text-primary" />
-            </div>
-            <CardTitle className="text-xl">Authentication Required</CardTitle>
-          </CardHeader>
-          <CardContent className="text-center space-y-4">
-            <p className="text-muted-foreground">
-              You need to sign in to access this page. Please use Google to continue.
-            </p>
-            <LoginButton className="w-full">Sign in to continue</LoginButton>
-          </CardContent>
-        </Card>
-      </div>
-    )
+    // A caller-supplied fallback takes precedence over the login redirect.
+    return <>{fallback}</>
   }
 
   return <>{children}</>

--- a/src/components/consultant/InviteFarmerDialog.tsx
+++ b/src/components/consultant/InviteFarmerDialog.tsx
@@ -82,9 +82,13 @@ export function InviteFarmerDialog({ organizationId, trigger }: InviteFarmerDial
       })
       posthog.capture('consultant_farmer_invite_created', { organization_id: organizationId })
     } catch (err) {
+      // Don't forward raw error text to analytics: server messages can carry the invitee's
+      // phone number (PII) and are unbounded/high-cardinality. Send a bounded category instead.
+      const reason =
+        err instanceof TypeError ? 'network_error' : err instanceof Error ? 'api_error' : 'unknown'
       posthog.capture('consultant_farmer_invite_failed', {
         organization_id: organizationId,
-        reason: err instanceof Error ? err.message : 'unknown'
+        reason
       })
       toast.error(err instanceof Error ? err.message : 'Failed to create invite')
     } finally {

--- a/src/components/consultant/InviteFarmerDialog.tsx
+++ b/src/components/consultant/InviteFarmerDialog.tsx
@@ -15,6 +15,7 @@ import { Label } from '@/components/ui/label'
 import { toast } from 'sonner'
 import { UserPlus, Copy, Check, MessageCircle, Send, Loader2, RefreshCw } from 'lucide-react'
 import { normalizePhone } from '@/lib/phone'
+import posthog from 'posthog-js'
 
 interface InviteResult {
   inviteUrl: string
@@ -79,7 +80,12 @@ export function InviteFarmerDialog({ organizationId, trigger }: InviteFarmerDial
         organizationName: data.organizationName,
         e164: normalized.e164
       })
+      posthog.capture('consultant_farmer_invite_created', { organization_id: organizationId })
     } catch (err) {
+      posthog.capture('consultant_farmer_invite_failed', {
+        organization_id: organizationId,
+        reason: err instanceof Error ? err.message : 'unknown'
+      })
       toast.error(err instanceof Error ? err.message : 'Failed to create invite')
     } finally {
       setSubmitting(false)
@@ -91,6 +97,10 @@ export function InviteFarmerDialog({ organizationId, trigger }: InviteFarmerDial
     try {
       await navigator.clipboard.writeText(result.inviteUrl)
       setCopied(true)
+      posthog.capture('consultant_invite_shared', {
+        organization_id: organizationId,
+        channel: 'copy'
+      })
       toast.success('Invite link copied')
       setTimeout(() => setCopied(false), 2000)
     } catch {
@@ -174,13 +184,31 @@ export function InviteFarmerDialog({ organizationId, trigger }: InviteFarmerDial
                 {copied ? 'Copied' : 'Copy'}
               </Button>
               <Button asChild variant="outline" className="gap-2">
-                <a href={waHref} target="_blank" rel="noopener noreferrer">
+                <a
+                  href={waHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() =>
+                    posthog.capture('consultant_invite_shared', {
+                      organization_id: organizationId,
+                      channel: 'whatsapp'
+                    })
+                  }
+                >
                   <MessageCircle className="h-4 w-4 text-green-600" />
                   WhatsApp
                 </a>
               </Button>
               <Button asChild variant="outline" className="gap-2">
-                <a href={smsHref}>
+                <a
+                  href={smsHref}
+                  onClick={() =>
+                    posthog.capture('consultant_invite_shared', {
+                      organization_id: organizationId,
+                      channel: 'sms'
+                    })
+                  }
+                >
                   <Send className="h-4 w-4" />
                   SMS
                 </a>

--- a/src/components/consultant/PaidToggleButton.tsx
+++ b/src/components/consultant/PaidToggleButton.tsx
@@ -41,7 +41,7 @@ export function PaidToggleButton({
       const confirmed = await setClientPaymentStatus(clientRecordId, next)
       setPaid(confirmed)
       onChange?.(confirmed)
-      posthog.capture('client_payment_status_toggled', {
+      posthog.capture('consultant_client_payment_toggled', {
         client_record_id: clientRecordId,
         is_paid: confirmed
       })

--- a/src/components/consultant/RecordVisitDialog.tsx
+++ b/src/components/consultant/RecordVisitDialog.tsx
@@ -94,6 +94,7 @@ export function RecordVisitDialog({ access, farmerId, farms, onRecorded }: Recor
     if (next) {
       reset()
       loadRecommendations()
+      posthog.capture('consultant_visit_started', { farmer_id: farmerId })
     }
   }
 

--- a/src/hooks/useSupabaseAuth.ts
+++ b/src/hooks/useSupabaseAuth.ts
@@ -9,6 +9,7 @@ import posthog from 'posthog-js'
 import {
   type AuthState,
   type ResetPasswordParams,
+  type ResendVerificationEmailParams,
   type SendPhoneOtpParams,
   type SignInWithEmailParams,
   type SignInWithGoogleParams,
@@ -151,7 +152,7 @@ export function useSupabaseAuth() {
     return applyResult(result, 'keepUser', setAuthState)
   }
 
-  const resendVerificationEmail = async (params: ResetPasswordParams) => {
+  const resendVerificationEmail = async (params: ResendVerificationEmailParams) => {
     setAuthState((prev) => ({ ...prev, loading: true, error: null }))
     const result = await performResendVerificationEmail(params, {
       supabase: createClient(),

--- a/src/hooks/useSupabaseAuth.ts
+++ b/src/hooks/useSupabaseAuth.ts
@@ -4,127 +4,60 @@ import { useState, useEffect, useCallback } from 'react'
 import { createClient } from '@/lib/supabase'
 import { User } from '@supabase/supabase-js'
 import { toast } from 'sonner'
-import { VALIDATION } from '@/lib/constants'
 import { clearLastRoute } from '@/lib/route-persistence'
 import posthog from 'posthog-js'
+import {
+  type AuthState,
+  type ResetPasswordParams,
+  type SendPhoneOtpParams,
+  type SignInWithEmailParams,
+  type SignInWithGoogleParams,
+  type SignUpWithEmailParams,
+  type VerifyOtpParams,
+  type VerifyPhoneOtpParams,
+  reduceAuthStateChange,
+  resolveInitialUser,
+  signInWithEmail as performSignInWithEmail,
+  signInWithGoogle as performSignInWithGoogle,
+  resendVerificationEmail as performResendVerificationEmail,
+  resetPassword as performResetPassword,
+  sendPhoneOtp as performSendPhoneOtp,
+  signOut as performSignOut,
+  signUpWithEmail as performSignUpWithEmail,
+  verifyOtp as performVerifyOtp,
+  verifyPhoneOtp as performVerifyPhoneOtp
+} from '@/lib/auth'
 
-interface AuthState {
-  user: User | null
-  loading: boolean
-  error: string | null
-}
-
-interface SignInWithEmailParams {
-  email: string
-  password: string
-}
-
-interface SignUpWithEmailParams {
-  email: string
-  password: string
-  confirmPassword?: string
-  firstName?: string
-  lastName?: string
-}
-
-interface ResetPasswordParams {
-  email: string
-}
-
-interface VerifyOtpParams {
-  email: string
-  token: string
-  otpType?: 'email' | 'recovery' | 'invite' | 'email_change'
-}
-
-interface SendPhoneOtpParams {
-  phone: string // E.164, e.g. +919876543210
-  firstName?: string
-  lastName?: string
-  // Defaults to true so the invite flow still creates the farmer account. The
-  // login page passes false so an unknown number can't silently create an
-  // orphaned account with no profile/org.
-  shouldCreateUser?: boolean
-}
-
-interface VerifyPhoneOtpParams {
-  phone: string // E.164
-  token: string
-}
-
-interface SignInWithGoogleParams {
-  redirectTo?: string
-}
-
-interface SanitizedNameResult {
-  isValid: boolean
-  value?: string
-  error?: string
-}
+type AuthOperationResult = { success: true; user?: User | null } | { success: false; error: string }
+type ApplyMode = 'setUser' | 'keepUser' | 'resetUser'
 
 /**
- * Sanitizes and validates a name field
- * - Returns valid for undefined (optional parameter)
- * - Trims whitespace
- * - Removes control characters and newlines
- * - Collapses repeated spaces
- * - Enforces max length of 50 characters
+ * Maps an auth-operation result onto React state. The extracted operations own
+ * the Supabase calls, validation, toasts, and PostHog events; this thin glue
+ * owns only the loading/error/user state transitions, derived from the result
+ * shape — preserving the exact behavior of the pre-extraction hook.
  */
-function sanitizeAndValidateName(name: string | undefined, fieldName: string): SanitizedNameResult {
-  // Return valid if name is undefined (optional parameter)
-  if (name === undefined) {
-    return {
-      isValid: true
-    }
+function applyResult<T extends AuthOperationResult>(
+  result: T,
+  mode: ApplyMode,
+  setAuthState: (updater: (prev: AuthState) => AuthState) => void
+): T {
+  if (!result.success) {
+    const error = result.error
+    setAuthState((prev) => ({ ...prev, error, loading: false }))
+    return result
   }
 
-  // Trim whitespace
-  let sanitized = name.trim()
-
-  // Check if empty after trimming
-  if (!sanitized) {
-    return {
-      isValid: false,
-      error: `${fieldName} cannot be empty or contain only whitespace`
-    }
+  if (mode === 'resetUser') {
+    setAuthState(() => ({ user: null, loading: false, error: null }))
+  } else if (mode === 'setUser') {
+    const user = result.user ?? null
+    setAuthState((prev) => ({ ...prev, user, loading: false }))
+  } else {
+    setAuthState((prev) => ({ ...prev, loading: false }))
   }
 
-  // Remove control characters and newlines (ASCII 0-31 and 127)
-  // Using character-code filter instead of regex to avoid lint warnings
-  sanitized = sanitized
-    .split('')
-    .filter((char) => {
-      const code = char.charCodeAt(0)
-      return code >= 32 && code !== 127
-    })
-    .join('')
-
-  // Collapse repeated spaces into single space
-  sanitized = sanitized.replace(/\s+/g, ' ')
-
-  // Trim again after sanitization
-  sanitized = sanitized.trim()
-
-  // Check if empty after full sanitization
-  if (!sanitized) {
-    return {
-      isValid: false,
-      error: `${fieldName} contains only invalid characters`
-    }
-  }
-
-  // Check length and truncate if necessary
-  if (sanitized.length > VALIDATION.MAX_NAME_LENGTH) {
-    return {
-      isValid: false,
-      error: `${fieldName} must not exceed ${VALIDATION.MAX_NAME_LENGTH} characters (currently ${sanitized.length} characters)`
-    }
-  }
-
-  return {
-    isValid: true,
-    value: sanitized
-  }
+  return result
 }
 
 export function useSupabaseAuth() {
@@ -137,34 +70,14 @@ export function useSupabaseAuth() {
   useEffect(() => {
     const supabase = createClient()
 
-    // Get initial user - use getUser() for secure verification
     const getInitialUser = async () => {
       try {
-        const {
-          data: { user },
-          error
-        } = await supabase.auth.getUser()
-
+        const { user, error } = await resolveInitialUser({ supabase, posthog })
         if (error) {
-          // "Auth session missing!" means no session exists - this is expected when not logged in
-          // Don't treat this as an error, just set user to null
-          if (
-            error.message === 'Auth session missing!' ||
-            error.name === 'AuthSessionMissingError'
-          ) {
-            setAuthState((prev) => ({ ...prev, user: null }))
-          } else {
-            console.error('Auth error:', error.message, error.name)
-            setAuthState((prev) => ({ ...prev, error: error.message }))
-          }
+          setAuthState((prev) => ({ ...prev, error }))
         } else {
-          setAuthState((prev) => ({ ...prev, user: user ?? null }))
+          setAuthState((prev) => ({ ...prev, user }))
         }
-      } catch (err) {
-        setAuthState((prev) => ({
-          ...prev,
-          error: err instanceof Error ? err.message : 'An unexpected error occurred'
-        }))
       } finally {
         setAuthState((prev) => ({ ...prev, loading: false }))
       }
@@ -176,25 +89,11 @@ export function useSupabaseAuth() {
     } = supabase.auth.onAuthStateChange((event, session) => {
       // Only update the user state, don't change loading state here
       // to avoid interfering with the loading states from auth operations
-      const sessionUser = session?.user ?? null
+      const { user } = reduceAuthStateChange(event, session, { posthog })
       setAuthState((prev) => ({
         ...prev,
-        user: sessionUser
+        user
       }))
-
-      // Keep PostHog's distinct_id in sync with the authenticated user so every
-      // event is attributed to a stable unique identifier across all entry
-      // paths — email login, Google OAuth, and session restore — not just the
-      // signup OTP flow. The id guard avoids redundant identify calls (this
-      // listener runs once per mounted hook instance). Reset on sign-out so the
-      // next user on a shared browser doesn't inherit this identity.
-      if (sessionUser) {
-        if (posthog.get_distinct_id() !== sessionUser.id) {
-          posthog.identify(sessionUser.id, { email: sessionUser.email })
-        }
-      } else if (event === 'SIGNED_OUT') {
-        posthog.reset()
-      }
     })
 
     getInitialUser()
@@ -204,395 +103,78 @@ export function useSupabaseAuth() {
     }
   }, [])
 
-  const signInWithEmail = async ({ email, password }: SignInWithEmailParams) => {
+  const signInWithEmail = async (params: SignInWithEmailParams) => {
     setAuthState((prev) => ({ ...prev, loading: true, error: null }))
-
-    try {
-      const supabase = createClient()
-      const { data, error } = await supabase.auth.signInWithPassword({
-        email,
-        password
-      })
-
-      if (error) {
-        setAuthState((prev) => ({ ...prev, error: error.message, loading: false }))
-        toast.error(`Login failed: ${error.message}`)
-        return { success: false, error: error.message }
-      }
-
-      setAuthState((prev) => ({
-        ...prev,
-        user: data.user ?? null,
-        loading: false
-      }))
-
-      toast.success('Login successful!')
-      return { success: true, user: data.user }
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'An unexpected error occurred'
-      setAuthState((prev) => ({ ...prev, error: errorMessage, loading: false }))
-      toast.error(`Login failed: ${errorMessage}`)
-      return { success: false, error: errorMessage }
-    }
+    const result = await performSignInWithEmail(params, {
+      supabase: createClient(),
+      toast,
+      posthog
+    })
+    return applyResult(result, 'setUser', setAuthState)
   }
 
-  const signUpWithEmail = async ({
-    email,
-    password,
-    confirmPassword,
-    firstName,
-    lastName
-  }: SignUpWithEmailParams) => {
+  const signUpWithEmail = async (params: SignUpWithEmailParams) => {
     setAuthState((prev) => ({ ...prev, loading: true, error: null }))
-
-    // Validate password confirmation if provided
-    if (confirmPassword && password !== confirmPassword) {
-      const error = 'Passwords do not match'
-      setAuthState((prev) => ({ ...prev, error, loading: false }))
-      return { success: false, error }
-    }
-
-    // Validate and sanitize name fields
-    const userMetadata: Record<string, string> = {}
-
-    const firstNameResult = sanitizeAndValidateName(firstName, 'First name')
-    if (!firstNameResult.isValid) {
-      const error = firstNameResult.error || 'Invalid first name'
-      setAuthState((prev) => ({ ...prev, error, loading: false }))
-      toast.error(error)
-      return { success: false, error }
-    }
-    if (firstNameResult.value) {
-      userMetadata.first_name = firstNameResult.value
-    }
-
-    const lastNameResult = sanitizeAndValidateName(lastName, 'Last name')
-    if (!lastNameResult.isValid) {
-      const error = lastNameResult.error || 'Invalid last name'
-      setAuthState((prev) => ({ ...prev, error, loading: false }))
-      toast.error(error)
-      return { success: false, error }
-    }
-    if (lastNameResult.value) {
-      userMetadata.last_name = lastNameResult.value
-    }
-
-    // Create full_name field for UI display
-    if (userMetadata.first_name && userMetadata.last_name) {
-      userMetadata.full_name = `${userMetadata.first_name} ${userMetadata.last_name}`
-    } else if (userMetadata.first_name) {
-      userMetadata.full_name = userMetadata.first_name
-    } else if (userMetadata.last_name) {
-      userMetadata.full_name = userMetadata.last_name
-    }
-
-    try {
-      const supabase = createClient()
-
-      const { data, error } = await supabase.auth.signUp({
-        email: email.toLowerCase(),
-        password,
-        options: {
-          emailRedirectTo: `${window.location.origin}/auth/callback`,
-          data: userMetadata
-        }
-      })
-
-      if (error) {
-        setAuthState((prev) => ({ ...prev, error: error.message, loading: false }))
-        toast.error(`Sign up failed: ${error.message}`)
-        return { success: false, error: error.message }
-      }
-
-      setAuthState((prev) => ({
-        ...prev,
-        user: data.user ?? null,
-        loading: false
-      }))
-
-      const needsOtpVerification = !data.user?.email_confirmed_at
-      if (needsOtpVerification) {
-        toast.success('Account created! Please check your email for the verification code.')
-      } else {
-        toast.success('Account created successfully!')
-      }
-
-      return {
-        success: true,
-        user: data.user,
-        needsOtpVerification
-      }
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'An unexpected error occurred'
-      setAuthState((prev) => ({ ...prev, error: errorMessage, loading: false }))
-      toast.error(`Sign up failed: ${errorMessage}`)
-      return { success: false, error: errorMessage }
-    }
+    const result = await performSignUpWithEmail(params, {
+      supabase: createClient(),
+      toast,
+      posthog
+    })
+    return applyResult(result, 'setUser', setAuthState)
   }
 
-  const verifyOtp = async ({ email, token, otpType = 'email' }: VerifyOtpParams) => {
+  const verifyOtp = async (params: VerifyOtpParams) => {
     setAuthState((prev) => ({ ...prev, loading: true, error: null }))
-
-    try {
-      const supabase = createClient()
-
-      const { data, error } = await supabase.auth.verifyOtp({
-        email,
-        token,
-        type: otpType
-      })
-
-      if (error) {
-        setAuthState((prev) => ({ ...prev, error: error.message, loading: false }))
-        toast.error(`Verification failed: ${error.message}`)
-        return { success: false, error: error.message }
-      }
-
-      setAuthState((prev) => ({
-        ...prev,
-        user: data.user ?? null,
-        loading: false
-      }))
-
-      toast.success('Email verified successfully!')
-
-      // 'email' is the only otpType this app ever passes here (verify-otp page is signup-only).
-      if (otpType === 'email') {
-        posthog.identify(data.user?.id, { email: data.user?.email })
-        posthog.capture('New user created', {
-          user_id: data.user?.id,
-          timestamp: new Date().toISOString()
-        })
-      }
-
-      return { success: true, user: data.user }
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'An unexpected error occurred'
-      setAuthState((prev) => ({ ...prev, error: errorMessage, loading: false }))
-      toast.error(`Verification failed: ${errorMessage}`)
-      return { success: false, error: errorMessage }
-    }
+    const result = await performVerifyOtp(params, { supabase: createClient(), toast, posthog })
+    return applyResult(result, 'setUser', setAuthState)
   }
 
-  // Sends an SMS OTP to the given phone, creating the account if it doesn't exist. Names are
-  // attached as user metadata here because Supabase only applies it at user-creation time
-  // (this call) — the same full_name the handle_new_user trigger reads into profiles.
-  const sendPhoneOtp = async ({
-    phone,
-    firstName,
-    lastName,
-    shouldCreateUser = true
-  }: SendPhoneOtpParams) => {
+  const sendPhoneOtp = async (params: SendPhoneOtpParams) => {
     setAuthState((prev) => ({ ...prev, loading: true, error: null }))
-
-    const userMetadata: Record<string, string> = {}
-
-    const firstNameResult = sanitizeAndValidateName(firstName, 'First name')
-    if (!firstNameResult.isValid) {
-      const error = firstNameResult.error || 'Invalid first name'
-      setAuthState((prev) => ({ ...prev, error, loading: false }))
-      toast.error(error)
-      return { success: false, error }
-    }
-    if (firstNameResult.value) userMetadata.first_name = firstNameResult.value
-
-    const lastNameResult = sanitizeAndValidateName(lastName, 'Last name')
-    if (!lastNameResult.isValid) {
-      const error = lastNameResult.error || 'Invalid last name'
-      setAuthState((prev) => ({ ...prev, error, loading: false }))
-      toast.error(error)
-      return { success: false, error }
-    }
-    if (lastNameResult.value) userMetadata.last_name = lastNameResult.value
-
-    if (userMetadata.first_name && userMetadata.last_name) {
-      userMetadata.full_name = `${userMetadata.first_name} ${userMetadata.last_name}`
-    } else if (userMetadata.first_name) {
-      userMetadata.full_name = userMetadata.first_name
-    } else if (userMetadata.last_name) {
-      userMetadata.full_name = userMetadata.last_name
-    }
-
-    try {
-      const supabase = createClient()
-      const { error } = await supabase.auth.signInWithOtp({
-        phone,
-        options: { channel: 'sms', shouldCreateUser, data: userMetadata }
-      })
-
-      if (error) {
-        setAuthState((prev) => ({ ...prev, error: error.message, loading: false }))
-        toast.error(`Couldn't send code: ${error.message}`)
-        return { success: false, error: error.message }
-      }
-
-      setAuthState((prev) => ({ ...prev, loading: false }))
-      toast.success('Verification code sent')
-      return { success: true }
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'An unexpected error occurred'
-      setAuthState((prev) => ({ ...prev, error: errorMessage, loading: false }))
-      toast.error(`Couldn't send code: ${errorMessage}`)
-      return { success: false, error: errorMessage }
-    }
+    const result = await performSendPhoneOtp(params, { supabase: createClient(), toast, posthog })
+    return applyResult(result, 'keepUser', setAuthState)
   }
 
-  // Verifies the SMS OTP. On success the user has a confirmed phone and an active session
-  // (cookie-based), which the invite/accept route reads to prove phone ownership.
-  const verifyPhoneOtp = async ({ phone, token }: VerifyPhoneOtpParams) => {
+  const verifyPhoneOtp = async (params: VerifyPhoneOtpParams) => {
     setAuthState((prev) => ({ ...prev, loading: true, error: null }))
-
-    try {
-      const supabase = createClient()
-      const { data, error } = await supabase.auth.verifyOtp({ phone, token, type: 'sms' })
-
-      if (error) {
-        setAuthState((prev) => ({ ...prev, error: error.message, loading: false }))
-        toast.error(`Verification failed: ${error.message}`)
-        return { success: false, error: error.message }
-      }
-
-      setAuthState((prev) => ({ ...prev, user: data.user ?? null, loading: false }))
-      toast.success('Phone verified')
-
-      // Phone-OTP verify is the acquisition funnel for the consultant-invite feature: identify the
-      // farmer and fire 'New user created' for genuinely new accounts (created within the last
-      // couple of minutes), mirroring the email verify path. PII (phone) stays in identify(),
-      // never in the capture event. TODO: email + phone both identify per-flow, but the documented
-      // convention is to identify once at the onAuthStateChange chokepoint; consolidate later.
-      if (data.user) {
-        posthog.identify(data.user.id, { phone: data.user.phone })
-        const createdMs = data.user.created_at ? new Date(data.user.created_at).getTime() : 0
-        if (createdMs && Date.now() - createdMs < 2 * 60 * 1000) {
-          posthog.capture('New user created', {
-            user_id: data.user.id,
-            timestamp: new Date().toISOString()
-          })
-        }
-      }
-
-      return { success: true, user: data.user }
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'An unexpected error occurred'
-      setAuthState((prev) => ({ ...prev, error: errorMessage, loading: false }))
-      toast.error(`Verification failed: ${errorMessage}`)
-      return { success: false, error: errorMessage }
-    }
+    const result = await performVerifyPhoneOtp(params, { supabase: createClient(), toast, posthog })
+    return applyResult(result, 'setUser', setAuthState)
   }
 
-  const resendVerificationEmail = async ({ email }: { email: string }) => {
+  const signInWithGoogle = async (params: SignInWithGoogleParams = {}) => {
     setAuthState((prev) => ({ ...prev, loading: true, error: null }))
-
-    try {
-      const supabase = createClient()
-
-      const { error } = await supabase.auth.resend({
-        type: 'signup',
-        email: email.toLowerCase(),
-        options: {
-          emailRedirectTo: `${window.location.origin}/auth/callback`
-        }
-      })
-
-      if (error) {
-        setAuthState((prev) => ({ ...prev, error: error.message, loading: false }))
-        return { success: false, error: error.message }
-      }
-
-      setAuthState((prev) => ({ ...prev, loading: false }))
-      return { success: true, message: 'Verification code resent successfully' }
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'An unexpected error occurred'
-      setAuthState((prev) => ({ ...prev, error: errorMessage, loading: false }))
-      return { success: false, error: errorMessage }
-    }
+    const result = await performSignInWithGoogle(params, {
+      supabase: createClient(),
+      toast,
+      posthog
+    })
+    return applyResult(result, 'keepUser', setAuthState)
   }
 
-  const resetPassword = async ({ email }: ResetPasswordParams) => {
+  const resendVerificationEmail = async (params: ResetPasswordParams) => {
     setAuthState((prev) => ({ ...prev, loading: true, error: null }))
-
-    try {
-      const supabase = createClient()
-      const { error } = await supabase.auth.resetPasswordForEmail(email, {
-        redirectTo: `${window.location.origin}/auth/reset-password`
-      })
-
-      if (error) {
-        setAuthState((prev) => ({ ...prev, error: error.message, loading: false }))
-        toast.error(`Password reset failed: ${error.message}`)
-        return { success: false, error: error.message }
-      }
-
-      setAuthState((prev) => ({ ...prev, loading: false }))
-      toast.success('Password reset email sent! Please check your inbox.')
-      return { success: true, message: 'Password reset email sent' }
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'An unexpected error occurred'
-      setAuthState((prev) => ({ ...prev, error: errorMessage, loading: false }))
-      toast.error(`Password reset failed: ${errorMessage}`)
-      return { success: false, error: errorMessage }
-    }
+    const result = await performResendVerificationEmail(params, {
+      supabase: createClient(),
+      toast,
+      posthog
+    })
+    return applyResult(result, 'keepUser', setAuthState)
   }
 
-  const signInWithGoogle = async ({
-    redirectTo = `${window.location.origin}/auth/callback`
-  }: SignInWithGoogleParams = {}) => {
+  const resetPassword = async (params: ResetPasswordParams) => {
     setAuthState((prev) => ({ ...prev, loading: true, error: null }))
-
-    try {
-      const supabase = createClient()
-      const { error } = await supabase.auth.signInWithOAuth({
-        provider: 'google',
-        options: {
-          redirectTo,
-          queryParams: {
-            access_type: 'online',
-            prompt: 'consent'
-          }
-        }
-      })
-
-      if (error) {
-        setAuthState((prev) => ({ ...prev, error: error.message, loading: false }))
-        toast.error(`Google sign in failed: ${error.message}`)
-        return { success: false, error: error.message }
-      }
-
-      // The user will be redirected to the OAuth provider
-      // We don't set the user here as they will be redirected
-      setAuthState((prev) => ({ ...prev, loading: false }))
-      return { success: true }
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'An unexpected error occurred'
-      setAuthState((prev) => ({ ...prev, error: errorMessage, loading: false }))
-      toast.error(`Google sign in failed: ${errorMessage}`)
-      return { success: false, error: errorMessage }
-    }
+    const result = await performResetPassword(params, { supabase: createClient(), toast, posthog })
+    return applyResult(result, 'keepUser', setAuthState)
   }
 
   const signOut = async () => {
     setAuthState((prev) => ({ ...prev, loading: true, error: null }))
-
-    try {
-      const supabase = createClient()
-      await supabase.auth.signOut()
-
+    const result = await performSignOut({ supabase: createClient(), toast, posthog })
+    if (result.success) {
       // Clear saved route to prevent restoring auth-protected pages
       clearLastRoute()
-
-      setAuthState((prev) => ({
-        user: null,
-        loading: false,
-        error: null
-      }))
-      toast.success('Signed out successfully')
-      return { success: true }
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'An unexpected error occurred'
-      setAuthState((prev) => ({ ...prev, error: errorMessage, loading: false }))
-      toast.error(`Sign out failed: ${errorMessage}`)
-      return { success: false, error: errorMessage }
     }
+    return applyResult(result, 'resetUser', setAuthState)
   }
 
   // Stable identity — it only calls the stable setAuthState setter — so callers can list it

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -6,26 +6,13 @@ import * as Sentry from '@sentry/nextjs'
 import { parseEnvFloat, parseEnvBoolean } from '@/lib/sentry-env-helpers'
 import { createClient } from '@/lib/supabase'
 import posthog from 'posthog-js'
+import { redactInviteToken, redactInviteTokens } from '@/lib/analytics/redact-invite-token'
 
-// The consultant-invite signup link carries a 7-day bearer token in the URL PATH
-// (/signup/invite/<token>). PostHog autocapture ($pageview $current_url) and Sentry replay would
-// otherwise ship that token to first-party analytics, leaking a live invite secret to anyone with
-// analytics read access. Redact the token segment from any captured string before it leaves the
-// browser. (Residual: browser history and server access logs still carry the URL, which is
-// inherent to magic-link invites and acceptable here; a deeper fix would move the token out of
-// the URL entirely.)
-const INVITE_TOKEN_RE = /\/signup\/invite\/[^\s/?#$]+/g
-const redactInviteToken = (value: unknown): unknown =>
-  typeof value === 'string' ? value.replace(INVITE_TOKEN_RE, '/signup/invite/[redacted]') : value
-const redactInviteTokens = (obj: Record<string, unknown> | undefined | null): void => {
-  if (!obj) return
-  for (const key of Object.keys(obj)) {
-    obj[key] = redactInviteToken(obj[key])
-  }
-}
+// Invite-token redaction (used by both the PostHog before_send and the Sentry beforeSend below)
+// lives in @/lib/analytics/redact-invite-token.
 
 // Initialize PostHog for analytics (only on the client and only if key is available)
-const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY
+const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN
 if (typeof window !== 'undefined' && posthogKey) {
   posthog.init(posthogKey, {
     api_host: '/ingest',
@@ -43,7 +30,9 @@ if (typeof window !== 'undefined' && posthogKey) {
   })
 } else if (typeof window !== 'undefined') {
   // Only warn on client-side, not during SSR/build
-  console.warn('[PostHog] NEXT_PUBLIC_POSTHOG_KEY is not set. Analytics will be disabled.')
+  console.warn(
+    '[PostHog] NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN is not set. Analytics will be disabled.'
+  )
 }
 
 // Lazy-load Supabase client for Sentry integration

--- a/src/lib/__tests__/auth-operations.test.ts
+++ b/src/lib/__tests__/auth-operations.test.ts
@@ -1,0 +1,519 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  signInWithEmail,
+  signUpWithEmail,
+  verifyOtp,
+  sendPhoneOtp,
+  verifyPhoneOtp,
+  signInWithGoogle,
+  resendVerificationEmail,
+  resetPassword,
+  signOut
+} from '../auth/auth-operations'
+import type { AuthOperationDeps, PosthogSeam, SupabaseAuthClient } from '../auth/types'
+import type { User } from '@supabase/supabase-js'
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 'user-1',
+    email: 'user@example.com',
+    app_metadata: {},
+    user_metadata: {},
+    aud: 'authenticated',
+    created_at: new Date().toISOString(),
+    ...overrides
+  } as unknown as User
+}
+
+interface DepsKit {
+  deps: AuthOperationDeps
+  supabaseAuth: Record<string, ReturnType<typeof vi.fn>>
+  toast: { success: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> }
+  posthog: PosthogSeam & {
+    identify: ReturnType<typeof vi.fn>
+    capture: ReturnType<typeof vi.fn>
+    get_distinct_id: ReturnType<typeof vi.fn>
+    reset: ReturnType<typeof vi.fn>
+  }
+}
+
+function buildDeps(auth: Record<string, any> = {}): DepsKit {
+  const supabaseAuth: Record<string, ReturnType<typeof vi.fn>> = { ...auth }
+  const success = vi.fn()
+  const error = vi.fn()
+  const toast = { success, error }
+  const identify = vi.fn()
+  const capture = vi.fn()
+  const get_distinct_id = vi.fn().mockReturnValue('anon')
+  const reset = vi.fn()
+  const posthog: DepsKit['posthog'] = { identify, capture, get_distinct_id, reset }
+  const deps: AuthOperationDeps = {
+    supabase: { auth: supabaseAuth } as unknown as SupabaseAuthClient,
+    toast,
+    posthog
+  }
+  return { deps, supabaseAuth, toast, posthog }
+}
+
+describe('signInWithEmail', () => {
+  it('succeeds, toasts success, and returns the user', async () => {
+    const user = makeUser({ id: 'u-signin' })
+    const kit = buildDeps({
+      signInWithPassword: vi.fn().mockResolvedValue({ data: { user }, error: null })
+    })
+
+    const result = await signInWithEmail({ email: 'a@b.com', password: 'pw' }, kit.deps)
+
+    expect(result).toEqual({ success: true, user })
+    expect(kit.supabaseAuth.signInWithPassword).toHaveBeenCalledWith({
+      email: 'a@b.com',
+      password: 'pw'
+    })
+    expect(kit.toast.success).toHaveBeenCalledWith('Login successful!')
+    expect(kit.toast.error).not.toHaveBeenCalled()
+  })
+
+  it('returns an error and toasts on a Supabase error', async () => {
+    const kit = buildDeps({
+      signInWithPassword: vi.fn().mockResolvedValue({
+        data: {},
+        error: { message: 'Invalid login credentials' }
+      })
+    })
+
+    const result = await signInWithEmail({ email: 'a@b.com', password: 'pw' }, kit.deps)
+
+    expect(result).toEqual({ success: false, error: 'Invalid login credentials' })
+    expect(kit.toast.error).toHaveBeenCalledWith('Login failed: Invalid login credentials')
+    expect(kit.toast.success).not.toHaveBeenCalled()
+  })
+
+  it('returns an error and toasts when the call throws', async () => {
+    const kit = buildDeps({
+      signInWithPassword: vi.fn().mockRejectedValue(new Error('network down'))
+    })
+
+    const result = await signInWithEmail({ email: 'a@b.com', password: 'pw' }, kit.deps)
+
+    expect(result).toEqual({ success: false, error: 'network down' })
+    expect(kit.toast.error).toHaveBeenCalledWith('Login failed: network down')
+  })
+})
+
+describe('signUpWithEmail', () => {
+  it('succeeds, toasts the OTP prompt, and returns needsOtpVerification=true for an unconfirmed email', async () => {
+    const user = makeUser({ email_confirmed_at: undefined as unknown as string })
+    const kit = buildDeps({ signUp: vi.fn().mockResolvedValue({ data: { user }, error: null }) })
+
+    const result = await signUpWithEmail({ email: 'A@B.com', password: 'pw' }, kit.deps)
+
+    expect(result).toEqual({ success: true, user, needsOtpVerification: true })
+    expect(kit.toast.success).toHaveBeenCalledWith(
+      'Account created! Please check your email for the verification code.'
+    )
+    expect(kit.supabaseAuth.signUp).toHaveBeenCalledWith({
+      email: 'a@b.com',
+      password: 'pw',
+      options: { emailRedirectTo: `${window.location.origin}/auth/callback`, data: {} }
+    })
+  })
+
+  it('toasts a plain success when the email is already confirmed', async () => {
+    const user = makeUser({ email_confirmed_at: '2025-01-01' as unknown as string })
+    const kit = buildDeps({ signUp: vi.fn().mockResolvedValue({ data: { user }, error: null }) })
+
+    const result = await signUpWithEmail({ email: 'a@b.com', password: 'pw' }, kit.deps)
+
+    expect(result).toEqual({ success: true, user, needsOtpVerification: false })
+    expect(kit.toast.success).toHaveBeenCalledWith('Account created successfully!')
+  })
+
+  it('gates on password confirmation mismatch without calling signUp or toasting', async () => {
+    const kit = buildDeps({ signUp: vi.fn() })
+
+    const result = await signUpWithEmail(
+      { email: 'a@b.com', password: 'pw', confirmPassword: 'different' },
+      kit.deps
+    )
+
+    expect(result).toEqual({ success: false, error: 'Passwords do not match' })
+    expect(kit.supabaseAuth.signUp).not.toHaveBeenCalled()
+    expect(kit.toast.error).not.toHaveBeenCalled()
+  })
+
+  it('gates on an invalid name, toasts the error, and does not call signUp', async () => {
+    const kit = buildDeps({ signUp: vi.fn() })
+
+    const result = await signUpWithEmail(
+      { email: 'a@b.com', password: 'pw', firstName: '   ' },
+      kit.deps
+    )
+
+    expect(result.success).toBe(false)
+    expect(kit.supabaseAuth.signUp).not.toHaveBeenCalled()
+    expect(kit.toast.error).toHaveBeenCalledTimes(1)
+    expect(kit.toast.error).toHaveBeenCalledWith(expect.stringMatching(/First name/))
+  })
+
+  it('sanitizes names and composes full_name metadata into the signUp call', async () => {
+    const user = makeUser()
+    const kit = buildDeps({ signUp: vi.fn().mockResolvedValue({ data: { user }, error: null }) })
+
+    await signUpWithEmail(
+      { email: 'a@b.com', password: 'pw', firstName: '  Ashish  Kumar ', lastName: 'Huddar' },
+      kit.deps
+    )
+
+    expect(kit.supabaseAuth.signUp).toHaveBeenCalledWith({
+      email: 'a@b.com',
+      password: 'pw',
+      options: {
+        emailRedirectTo: `${window.location.origin}/auth/callback`,
+        data: { first_name: 'Ashish Kumar', last_name: 'Huddar', full_name: 'Ashish Kumar Huddar' }
+      }
+    })
+  })
+
+  it('returns an error and toasts on a Supabase error', async () => {
+    const kit = buildDeps({
+      signUp: vi.fn().mockResolvedValue({ data: {}, error: { message: 'User already registered' } })
+    })
+
+    const result = await signUpWithEmail({ email: 'a@b.com', password: 'pw' }, kit.deps)
+
+    expect(result).toEqual({ success: false, error: 'User already registered' })
+    expect(kit.toast.error).toHaveBeenCalledWith('Sign up failed: User already registered')
+  })
+
+  it('returns an error and toasts when the call throws', async () => {
+    const kit = buildDeps({ signUp: vi.fn().mockRejectedValue(new Error('boom')) })
+
+    const result = await signUpWithEmail({ email: 'a@b.com', password: 'pw' }, kit.deps)
+
+    expect(result).toEqual({ success: false, error: 'boom' })
+    expect(kit.toast.error).toHaveBeenCalledWith('Sign up failed: boom')
+  })
+})
+
+describe('verifyOtp (email)', () => {
+  it('succeeds, toasts, and fires identify + "New user created" once for email', async () => {
+    const user = makeUser({ id: 'u-verify', email: 'a@b.com' })
+    const kit = buildDeps({ verifyOtp: vi.fn().mockResolvedValue({ data: { user }, error: null }) })
+
+    const result = await verifyOtp({ email: 'a@b.com', token: '123456' }, kit.deps)
+
+    expect(result).toEqual({ success: true, user })
+    expect(kit.toast.success).toHaveBeenCalledWith('Email verified successfully!')
+    expect(kit.posthog.identify).toHaveBeenCalledWith('u-verify', { email: 'a@b.com' })
+    expect(kit.posthog.capture).toHaveBeenCalledWith('New user created', {
+      user_id: 'u-verify',
+      timestamp: expect.any(String)
+    })
+    expect(kit.posthog.capture).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not capture "New user created" for a non-email otpType', async () => {
+    const user = makeUser()
+    const kit = buildDeps({ verifyOtp: vi.fn().mockResolvedValue({ data: { user }, error: null }) })
+
+    const result = await verifyOtp(
+      { email: 'a@b.com', token: '123456', otpType: 'recovery' },
+      kit.deps
+    )
+
+    expect(result.success).toBe(true)
+    expect(kit.posthog.capture).not.toHaveBeenCalled()
+    expect(kit.posthog.identify).not.toHaveBeenCalled()
+  })
+
+  it('returns an error and toasts on a Supabase error', async () => {
+    const kit = buildDeps({
+      verifyOtp: vi.fn().mockResolvedValue({ data: {}, error: { message: 'Token expired' } })
+    })
+
+    const result = await verifyOtp({ email: 'a@b.com', token: '123456' }, kit.deps)
+
+    expect(result).toEqual({ success: false, error: 'Token expired' })
+    expect(kit.toast.error).toHaveBeenCalledWith('Verification failed: Token expired')
+    expect(kit.posthog.capture).not.toHaveBeenCalled()
+  })
+
+  it('returns an error and toasts when the call throws', async () => {
+    const kit = buildDeps({ verifyOtp: vi.fn().mockRejectedValue(new Error('boom')) })
+
+    const result = await verifyOtp({ email: 'a@b.com', token: '123456' }, kit.deps)
+
+    expect(result).toEqual({ success: false, error: 'boom' })
+    expect(kit.toast.error).toHaveBeenCalledWith('Verification failed: boom')
+  })
+})
+
+describe('sendPhoneOtp', () => {
+  it('succeeds, toasts, and defaults shouldCreateUser to true', async () => {
+    const kit = buildDeps({ signInWithOtp: vi.fn().mockResolvedValue({ error: null }) })
+
+    const result = await sendPhoneOtp({ phone: '+919876543210' }, kit.deps)
+
+    expect(result).toEqual({ success: true })
+    expect(kit.toast.success).toHaveBeenCalledWith('Verification code sent')
+    expect(kit.supabaseAuth.signInWithOtp).toHaveBeenCalledWith({
+      phone: '+919876543210',
+      options: { channel: 'sms', shouldCreateUser: true, data: {} }
+    })
+  })
+
+  it('passes shouldCreateUser=false through to the client', async () => {
+    const kit = buildDeps({ signInWithOtp: vi.fn().mockResolvedValue({ error: null }) })
+
+    await sendPhoneOtp({ phone: '+919876543210', shouldCreateUser: false }, kit.deps)
+
+    expect(kit.supabaseAuth.signInWithOtp).toHaveBeenCalledWith({
+      phone: '+919876543210',
+      options: { channel: 'sms', shouldCreateUser: false, data: {} }
+    })
+  })
+
+  it('sanitizes names and composes full_name metadata', async () => {
+    const kit = buildDeps({ signInWithOtp: vi.fn().mockResolvedValue({ error: null }) })
+
+    await sendPhoneOtp(
+      { phone: '+919876543210', firstName: ' Riya  ', lastName: 'Sharma' },
+      kit.deps
+    )
+
+    expect(kit.supabaseAuth.signInWithOtp).toHaveBeenCalledWith({
+      phone: '+919876543210',
+      options: {
+        channel: 'sms',
+        shouldCreateUser: true,
+        data: { first_name: 'Riya', last_name: 'Sharma', full_name: 'Riya Sharma' }
+      }
+    })
+  })
+
+  it('gates on an invalid name, toasts, and does not call the client', async () => {
+    const kit = buildDeps({ signInWithOtp: vi.fn() })
+
+    const result = await sendPhoneOtp(
+      { phone: '+919876543210', lastName: 'A'.repeat(51) },
+      kit.deps
+    )
+
+    expect(result.success).toBe(false)
+    expect(kit.supabaseAuth.signInWithOtp).not.toHaveBeenCalled()
+    expect(kit.toast.error).toHaveBeenCalledWith(expect.stringMatching(/Last name/))
+  })
+
+  it('returns an error and toasts on a Supabase error', async () => {
+    const kit = buildDeps({
+      signInWithOtp: vi.fn().mockResolvedValue({ error: { message: 'Rate limited' } })
+    })
+
+    const result = await sendPhoneOtp({ phone: '+919876543210' }, kit.deps)
+
+    expect(result).toEqual({ success: false, error: 'Rate limited' })
+    expect(kit.toast.error).toHaveBeenCalledWith("Couldn't send code: Rate limited")
+  })
+
+  it('returns an error and toasts when the call throws', async () => {
+    const kit = buildDeps({ signInWithOtp: vi.fn().mockRejectedValue(new Error('boom')) })
+
+    const result = await sendPhoneOtp({ phone: '+919876543210' }, kit.deps)
+
+    expect(result).toEqual({ success: false, error: 'boom' })
+    expect(kit.toast.error).toHaveBeenCalledWith("Couldn't send code: boom")
+  })
+})
+
+describe('verifyPhoneOtp', () => {
+  it('succeeds, identifies, and captures "New user created" once for a genuinely new account', async () => {
+    const user = makeUser({
+      id: 'u-phone',
+      phone: '+919876543210',
+      created_at: new Date(Date.now() - 60_000).toISOString() // 1 minute ago
+    })
+    const kit = buildDeps({ verifyOtp: vi.fn().mockResolvedValue({ data: { user }, error: null }) })
+
+    const result = await verifyPhoneOtp({ phone: '+919876543210', token: '123456' }, kit.deps)
+
+    expect(result).toEqual({ success: true, user })
+    expect(kit.toast.success).toHaveBeenCalledWith('Phone verified')
+    expect(kit.posthog.identify).toHaveBeenCalledWith('u-phone', { phone: '+919876543210' })
+    expect(kit.posthog.capture).toHaveBeenCalledTimes(1)
+    expect(kit.posthog.capture).toHaveBeenCalledWith('New user created', {
+      user_id: 'u-phone',
+      timestamp: expect.any(String)
+    })
+  })
+
+  it('identifies but does NOT capture "New user created" for an existing account', async () => {
+    const user = makeUser({
+      id: 'u-phone',
+      phone: '+919876543210',
+      created_at: new Date(Date.now() - 60 * 60_000).toISOString() // 1 hour ago
+    })
+    const kit = buildDeps({ verifyOtp: vi.fn().mockResolvedValue({ data: { user }, error: null }) })
+
+    const result = await verifyPhoneOtp({ phone: '+919876543210', token: '123456' }, kit.deps)
+
+    expect(result).toEqual({ success: true, user })
+    expect(kit.posthog.identify).toHaveBeenCalledTimes(1)
+    expect(kit.posthog.capture).not.toHaveBeenCalled()
+  })
+
+  it('returns an error and toasts on a Supabase error', async () => {
+    const kit = buildDeps({
+      verifyOtp: vi.fn().mockResolvedValue({ data: {}, error: { message: 'Invalid otp' } })
+    })
+
+    const result = await verifyPhoneOtp({ phone: '+919876543210', token: '123456' }, kit.deps)
+
+    expect(result).toEqual({ success: false, error: 'Invalid otp' })
+    expect(kit.toast.error).toHaveBeenCalledWith('Verification failed: Invalid otp')
+    expect(kit.posthog.identify).not.toHaveBeenCalled()
+    expect(kit.posthog.capture).not.toHaveBeenCalled()
+  })
+
+  it('returns an error and toasts when the call throws', async () => {
+    const kit = buildDeps({ verifyOtp: vi.fn().mockRejectedValue(new Error('boom')) })
+
+    const result = await verifyPhoneOtp({ phone: '+919876543210', token: '123456' }, kit.deps)
+
+    expect(result).toEqual({ success: false, error: 'boom' })
+    expect(kit.toast.error).toHaveBeenCalledWith('Verification failed: boom')
+  })
+})
+
+describe('signInWithGoogle', () => {
+  it('succeeds without a toast and calls OAuth with the google provider', async () => {
+    const kit = buildDeps({ signInWithOAuth: vi.fn().mockResolvedValue({ error: null }) })
+
+    const result = await signInWithGoogle({ redirectTo: 'https://host/cb' }, kit.deps)
+
+    expect(result).toEqual({ success: true })
+    expect(kit.supabaseAuth.signInWithOAuth).toHaveBeenCalledWith({
+      provider: 'google',
+      options: {
+        redirectTo: 'https://host/cb',
+        queryParams: { access_type: 'online', prompt: 'consent' }
+      }
+    })
+    expect(kit.toast.success).not.toHaveBeenCalled()
+    expect(kit.toast.error).not.toHaveBeenCalled()
+  })
+
+  it('returns an error and toasts on a Supabase error', async () => {
+    const kit = buildDeps({
+      signInWithOAuth: vi.fn().mockResolvedValue({ error: { message: 'No provider' } })
+    })
+
+    const result = await signInWithGoogle({}, kit.deps)
+
+    expect(result).toEqual({ success: false, error: 'No provider' })
+    expect(kit.toast.error).toHaveBeenCalledWith('Google sign in failed: No provider')
+  })
+
+  it('returns an error and toasts when the call throws', async () => {
+    const kit = buildDeps({ signInWithOAuth: vi.fn().mockRejectedValue(new Error('boom')) })
+
+    const result = await signInWithGoogle({}, kit.deps)
+
+    expect(result).toEqual({ success: false, error: 'boom' })
+    expect(kit.toast.error).toHaveBeenCalledWith('Google sign in failed: boom')
+  })
+})
+
+describe('resendVerificationEmail', () => {
+  it('succeeds with a message and no toast', async () => {
+    const kit = buildDeps({ resend: vi.fn().mockResolvedValue({ error: null }) })
+
+    const result = await resendVerificationEmail({ email: 'A@B.com' }, kit.deps)
+
+    expect(result).toEqual({ success: true, message: 'Verification code resent successfully' })
+    expect(kit.supabaseAuth.resend).toHaveBeenCalledWith({
+      type: 'signup',
+      email: 'a@b.com',
+      options: { emailRedirectTo: `${window.location.origin}/auth/callback` }
+    })
+    expect(kit.toast.success).not.toHaveBeenCalled()
+    expect(kit.toast.error).not.toHaveBeenCalled()
+  })
+
+  it('returns an error and no toast on a Supabase error', async () => {
+    const kit = buildDeps({ resend: vi.fn().mockResolvedValue({ error: { message: 'Too many' } }) })
+
+    const result = await resendVerificationEmail({ email: 'a@b.com' }, kit.deps)
+
+    expect(result).toEqual({ success: false, error: 'Too many' })
+    expect(kit.toast.error).not.toHaveBeenCalled()
+  })
+
+  it('returns an error when the call throws', async () => {
+    const kit = buildDeps({ resend: vi.fn().mockRejectedValue(new Error('boom')) })
+
+    const result = await resendVerificationEmail({ email: 'a@b.com' }, kit.deps)
+
+    expect(result).toEqual({ success: false, error: 'boom' })
+  })
+})
+
+describe('resetPassword', () => {
+  it('succeeds, toasts success, and returns the message', async () => {
+    const kit = buildDeps({
+      resetPasswordForEmail: vi.fn().mockResolvedValue({ error: null })
+    })
+
+    const result = await resetPassword({ email: 'a@b.com' }, kit.deps)
+
+    expect(result).toEqual({ success: true, message: 'Password reset email sent' })
+    expect(kit.toast.success).toHaveBeenCalledWith(
+      'Password reset email sent! Please check your inbox.'
+    )
+    expect(kit.supabaseAuth.resetPasswordForEmail).toHaveBeenCalledWith('a@b.com', {
+      redirectTo: `${window.location.origin}/auth/reset-password`
+    })
+  })
+
+  it('returns an error and toasts on a Supabase error', async () => {
+    const kit = buildDeps({
+      resetPasswordForEmail: vi.fn().mockResolvedValue({ error: { message: 'No user' } })
+    })
+
+    const result = await resetPassword({ email: 'a@b.com' }, kit.deps)
+
+    expect(result).toEqual({ success: false, error: 'No user' })
+    expect(kit.toast.error).toHaveBeenCalledWith('Password reset failed: No user')
+  })
+
+  it('returns an error and toasts when the call throws', async () => {
+    const kit = buildDeps({
+      resetPasswordForEmail: vi.fn().mockRejectedValue(new Error('boom'))
+    })
+
+    const result = await resetPassword({ email: 'a@b.com' }, kit.deps)
+
+    expect(result).toEqual({ success: false, error: 'boom' })
+    expect(kit.toast.error).toHaveBeenCalledWith('Password reset failed: boom')
+  })
+})
+
+describe('signOut', () => {
+  it('succeeds, toasts, and calls supabase.auth.signOut', async () => {
+    const kit = buildDeps({ signOut: vi.fn().mockResolvedValue({}) })
+
+    const result = await signOut(kit.deps)
+
+    expect(result).toEqual({ success: true })
+    expect(kit.supabaseAuth.signOut).toHaveBeenCalledTimes(1)
+    expect(kit.toast.success).toHaveBeenCalledWith('Signed out successfully')
+  })
+
+  it('returns an error and toasts when the call throws', async () => {
+    const kit = buildDeps({ signOut: vi.fn().mockRejectedValue(new Error('boom')) })
+
+    const result = await signOut(kit.deps)
+
+    expect(result).toEqual({ success: false, error: 'boom' })
+    expect(kit.toast.error).toHaveBeenCalledWith('Sign out failed: boom')
+  })
+})

--- a/src/lib/__tests__/auth-session.test.ts
+++ b/src/lib/__tests__/auth-session.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi } from 'vitest'
+import { resolveInitialUser, reduceAuthStateChange } from '../auth/session'
+import type {
+  SessionDeps,
+  PosthogSeam,
+  SupabaseAuthClient,
+  AuthStateChangeResult
+} from '../auth/types'
+import type { Session, User } from '@supabase/supabase-js'
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 'user-123',
+    app_metadata: {},
+    user_metadata: {},
+    aud: 'authenticated',
+    created_at: new Date().toISOString(),
+    ...overrides
+  } as unknown as User
+}
+
+function mockSupabase(getUser: () => any): SupabaseAuthClient {
+  return { auth: { getUser } } as unknown as SupabaseAuthClient
+}
+
+function mockPosthog(overrides: Partial<PosthogSeam> = {}): PosthogSeam & {
+  calls: { identify: any[]; reset: any[]; capture: any[] }
+} {
+  const identify = vi.fn()
+  const reset = vi.fn()
+  const capture = vi.fn()
+  return {
+    identify,
+    reset,
+    capture,
+    get_distinct_id: vi.fn().mockReturnValue('anon'),
+    ...overrides,
+    calls: { identify, reset, capture }
+  } as any
+}
+
+describe('resolveInitialUser', () => {
+  it('returns the user when getUser() resolves with a session', async () => {
+    const user = makeUser({ id: 'user-1' })
+    const supabase = mockSupabase(async () => ({ data: { user }, error: null }))
+    const deps: SessionDeps = { supabase, posthog: mockPosthog() }
+
+    const result = await resolveInitialUser(deps)
+
+    expect(result).toEqual({ user, error: null })
+  })
+
+  it('treats "Auth session missing!" as a logged-out state, not an error', async () => {
+    const supabase = mockSupabase(async () => ({
+      data: { user: null },
+      error: { message: 'Auth session missing!', name: 'AuthSessionMissingError' }
+    }))
+    const deps: SessionDeps = { supabase, posthog: mockPosthog() }
+
+    const result = await resolveInitialUser(deps)
+
+    expect(result).toEqual({ user: null, error: null })
+  })
+
+  it('treats an AuthSessionMissingError name (without the message) as logged-out', async () => {
+    const supabase = mockSupabase(async () => ({
+      data: { user: null },
+      error: { message: 'some other text', name: 'AuthSessionMissingError' }
+    }))
+    const deps: SessionDeps = { supabase, posthog: mockPosthog() }
+
+    const result = await resolveInitialUser(deps)
+
+    expect(result).toEqual({ user: null, error: null })
+  })
+
+  it('returns the error message for a generic auth error', async () => {
+    const supabase = mockSupabase(async () => ({
+      data: { user: null },
+      error: { message: 'JWT expired', name: 'AuthRetryableError' }
+    }))
+    const deps: SessionDeps = { supabase, posthog: mockPosthog() }
+
+    const result = await resolveInitialUser(deps)
+
+    expect(result).toEqual({ user: null, error: 'JWT expired' })
+  })
+
+  it('returns a message when getUser() throws', async () => {
+    const supabase = mockSupabase(async () => {
+      throw new Error('network down')
+    })
+    const deps: SessionDeps = { supabase, posthog: mockPosthog() }
+
+    const result = await resolveInitialUser(deps)
+
+    expect(result).toEqual({ user: null, error: 'network down' })
+  })
+
+  it('falls back to a generic message when getUser() throws a non-Error', async () => {
+    const supabase = mockSupabase(async () => {
+      throw 'string error'
+    })
+    const deps: SessionDeps = { supabase, posthog: mockPosthog() }
+
+    const result = await resolveInitialUser(deps)
+
+    expect(result).toEqual({ user: null, error: 'An unexpected error occurred' })
+  })
+})
+
+describe('reduceAuthStateChange', () => {
+  function sessionWith(user: User | null): Session | null {
+    if (!user) return null
+    return {
+      user,
+      access_token: 'x',
+      refresh_token: 'y',
+      expires_in: 3600,
+      token_type: 'bearer'
+    } as unknown as Session
+  }
+
+  it('returns the session user and identifies a new identity', () => {
+    const posthog = mockPosthog({ get_distinct_id: vi.fn().mockReturnValue('anon') as any })
+    const user = makeUser({ id: 'user-1', email: 'a@b.com' })
+
+    const result = reduceAuthStateChange('SIGNED_IN', sessionWith(user), { posthog })
+
+    expect(result).toEqual({ user })
+    expect(posthog.identify).toHaveBeenCalledTimes(1)
+    expect(posthog.identify).toHaveBeenCalledWith('user-1', { email: 'a@b.com' })
+    expect(posthog.reset).not.toHaveBeenCalled()
+  })
+
+  it('does NOT identify when distinct_id already matches (redundant guard)', () => {
+    const posthog = mockPosthog({ get_distinct_id: vi.fn().mockReturnValue('user-1') as any })
+    const user = makeUser({ id: 'user-1', email: 'a@b.com' })
+
+    const result = reduceAuthStateChange('SIGNED_IN', sessionWith(user), { posthog })
+
+    expect(result).toEqual({ user })
+    expect(posthog.identify).not.toHaveBeenCalled()
+    expect(posthog.reset).not.toHaveBeenCalled()
+  })
+
+  it('resets identity on SIGNED_OUT', () => {
+    const posthog = mockPosthog()
+
+    const result = reduceAuthStateChange('SIGNED_OUT', sessionWith(null), { posthog })
+
+    expect(result).toEqual({ user: null })
+    expect(posthog.reset).toHaveBeenCalledTimes(1)
+    expect(posthog.identify).not.toHaveBeenCalled()
+  })
+
+  it('fires identify only once for a repeated SIGNED_IN of the same identity', () => {
+    const getDistinctId = vi.fn().mockReturnValueOnce('anon').mockReturnValueOnce('user-1')
+    const posthog = mockPosthog({ get_distinct_id: getDistinctId as any })
+    const user = makeUser({ id: 'user-1' })
+
+    const first = reduceAuthStateChange('SIGNED_IN', sessionWith(user), { posthog })
+    const second = reduceAuthStateChange('SIGNED_IN', sessionWith(user), { posthog })
+
+    const expected: AuthStateChangeResult = { user }
+    expect(first).toEqual(expected)
+    expect(second).toEqual(expected)
+    expect(posthog.identify).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not identify or reset for a null session that is not SIGNED_OUT', () => {
+    const posthog = mockPosthog()
+
+    const result = reduceAuthStateChange('INITIAL_SESSION', sessionWith(null), { posthog })
+
+    expect(result).toEqual({ user: null })
+    expect(posthog.identify).not.toHaveBeenCalled()
+    expect(posthog.reset).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/__tests__/name-validator.test.ts
+++ b/src/lib/__tests__/name-validator.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeAndValidateName, composeFullNameMetadata } from '../auth/name-validator'
+
+describe('sanitizeAndValidateName', () => {
+  it('returns valid for undefined (optional parameter)', () => {
+    expect(sanitizeAndValidateName(undefined, 'First name')).toEqual({ isValid: true })
+    expect(sanitizeAndValidateName(undefined, 'First name').value).toBeUndefined()
+  })
+
+  it('trims leading and trailing whitespace', () => {
+    expect(sanitizeAndValidateName('  Ashish  ', 'First name')).toEqual({
+      isValid: true,
+      value: 'Ashish'
+    })
+  })
+
+  it('rejects an empty / whitespace-only value', () => {
+    const result = sanitizeAndValidateName('   ', 'First name')
+    expect(result.isValid).toBe(false)
+    expect(result.error).toMatch(/cannot be empty/)
+  })
+
+  it('strips control characters and newlines', () => {
+    expect(sanitizeAndValidateName('A\u0000s\u0007h\u000ais\u000dh', 'First name')).toEqual({
+      isValid: true,
+      value: 'Ashish'
+    })
+  })
+
+  it('strips the DEL character (code 127)', () => {
+    expect(sanitizeAndValidateName('A\u007F', 'First name')).toEqual({
+      isValid: true,
+      value: 'A'
+    })
+  })
+
+  it('collapses repeated internal whitespace into single spaces', () => {
+    expect(sanitizeAndValidateName('Ashish   Kumar   Huddar', 'Full name')).toEqual({
+      isValid: true,
+      value: 'Ashish Kumar Huddar'
+    })
+  })
+
+  it('strips tab characters as control characters (ASCII 9)', () => {
+    // Tabs fall below ASCII 32, so they are removed entirely (not converted to
+    // spaces) before the whitespace-collapse step runs.
+    expect(sanitizeAndValidateName('Ashish\tKumar', 'Full name')).toEqual({
+      isValid: true,
+      value: 'AshishKumar'
+    })
+  })
+
+  it('rejects a value that is only invalid/control characters', () => {
+    const result = sanitizeAndValidateName('\u0000\u0001\u0002', 'First name')
+    expect(result.isValid).toBe(false)
+    expect(result.error).toMatch(/only invalid characters/)
+  })
+
+  it('accepts a name at exactly the max length (50)', () => {
+    const exactlyFifty = 'A'.repeat(50)
+    expect(sanitizeAndValidateName(exactlyFifty, 'First name')).toEqual({
+      isValid: true,
+      value: exactlyFifty
+    })
+  })
+
+  it('rejects a name exceeding the max length (50)', () => {
+    const tooLong = 'A'.repeat(51)
+    const result = sanitizeAndValidateName(tooLong, 'First name')
+    expect(result.isValid).toBe(false)
+    expect(result.error).toMatch(/must not exceed 50 characters/)
+    expect(result.error).toContain('51 characters')
+  })
+
+  it('counts length after sanitization, not before', () => {
+    // 25 + 3 spaces + 24 = 52 on the wire, but collapses to 25 + 1 + 24 = 50
+    // after whitespace normalization, so it stays within the limit.
+    const collapsesToFifty = 'A'.repeat(25) + '   ' + 'B'.repeat(24)
+    expect(sanitizeAndValidateName(collapsesToFifty, 'First name').isValid).toBe(true)
+  })
+
+  it('uses the provided field name in error messages', () => {
+    expect(sanitizeAndValidateName('', 'Last name').error).toMatch(/Last name/)
+    expect(sanitizeAndValidateName('A'.repeat(51), 'Last name').error).toMatch(/Last name/)
+  })
+})
+
+describe('composeFullNameMetadata', () => {
+  it('composes full_name from first and last name', () => {
+    expect(composeFullNameMetadata('Ashish', 'Huddar')).toEqual({
+      first_name: 'Ashish',
+      last_name: 'Huddar',
+      full_name: 'Ashish Huddar'
+    })
+  })
+
+  it('uses only first_name when last name is absent', () => {
+    expect(composeFullNameMetadata('Ashish', undefined)).toEqual({
+      first_name: 'Ashish',
+      full_name: 'Ashish'
+    })
+  })
+
+  it('uses only last_name when first name is absent', () => {
+    expect(composeFullNameMetadata(undefined, 'Huddar')).toEqual({
+      last_name: 'Huddar',
+      full_name: 'Huddar'
+    })
+  })
+
+  it('returns an empty record when neither name is present', () => {
+    expect(composeFullNameMetadata(undefined, undefined)).toEqual({})
+  })
+})

--- a/src/lib/analytics/redact-invite-token.ts
+++ b/src/lib/analytics/redact-invite-token.ts
@@ -1,0 +1,20 @@
+// The consultant-invite signup link carries a 7-day bearer token in the URL PATH
+// (/signup/invite/<token>). PostHog autocapture ($pageview $current_url) and Sentry replay would
+// otherwise ship that token to first-party analytics, leaking a live invite secret to anyone with
+// analytics read access. Redact the token segment from any captured string before it leaves the
+// browser. (Residual: browser history and server access logs still carry the URL, which is
+// inherent to magic-link invites and acceptable here; a deeper fix would move the token out of
+// the URL entirely.)
+//
+// Shared by the PostHog `before_send` and the Sentry `beforeSend`, so neither can leak the token.
+const INVITE_TOKEN_RE = /\/signup\/invite\/[^\s/?#$]+/g
+
+export const redactInviteToken = (value: unknown): unknown =>
+  typeof value === 'string' ? value.replace(INVITE_TOKEN_RE, '/signup/invite/[redacted]') : value
+
+export const redactInviteTokens = (obj: Record<string, unknown> | undefined | null): void => {
+  if (!obj) return
+  for (const key of Object.keys(obj)) {
+    obj[key] = redactInviteToken(obj[key])
+  }
+}

--- a/src/lib/analytics/redact-invite-token.ts
+++ b/src/lib/analytics/redact-invite-token.ts
@@ -1,16 +1,16 @@
-// The consultant-invite signup link carries a 7-day bearer token in the URL PATH
-// (/signup/invite/<token>). PostHog autocapture ($pageview $current_url) and Sentry replay would
-// otherwise ship that token to first-party analytics, leaking a live invite secret to anyone with
-// analytics read access. Redact the token segment from any captured string before it leaves the
-// browser. (Residual: browser history and server access logs still carry the URL, which is
-// inherent to magic-link invites and acceptable here; a deeper fix would move the token out of
-// the URL entirely.)
+// Consultant signup links carry a 7-day bearer token in the URL PATH: farmer invites use
+// /signup/invite/<token> and team-member invites use /signup/member/<token>. PostHog autocapture
+// ($pageview $current_url) and Sentry replay would otherwise ship that token to first-party
+// analytics, leaking a live invite secret to anyone with analytics read access. Redact the token
+// segment from any captured string before it leaves the browser. (Residual: browser history and
+// server access logs still carry the URL, which is inherent to magic-link invites and acceptable
+// here; a deeper fix would move the token out of the URL entirely.)
 //
 // Shared by the PostHog `before_send` and the Sentry `beforeSend`, so neither can leak the token.
-const INVITE_TOKEN_RE = /\/signup\/invite\/[^\s/?#$]+/g
+const INVITE_TOKEN_RE = /\/signup\/(invite|member)\/[^\s/?#$]+/g
 
 export const redactInviteToken = (value: unknown): unknown =>
-  typeof value === 'string' ? value.replace(INVITE_TOKEN_RE, '/signup/invite/[redacted]') : value
+  typeof value === 'string' ? value.replace(INVITE_TOKEN_RE, '/signup/$1/[redacted]') : value
 
 export const redactInviteTokens = (obj: Record<string, unknown> | undefined | null): void => {
   if (!obj) return

--- a/src/lib/auth/auth-operations.ts
+++ b/src/lib/auth/auth-operations.ts
@@ -1,0 +1,372 @@
+import {
+  type AuthOperationDeps,
+  type ResetPasswordParams,
+  type ResendVerificationEmailResult,
+  type ResetPasswordResult,
+  type SendPhoneOtpParams,
+  type SendPhoneOtpResult,
+  type SignInWithEmailParams,
+  type SignInWithEmailResult,
+  type SignInWithGoogleParams,
+  type SignInWithGoogleResult,
+  type SignOutResult,
+  type SignUpWithEmailParams,
+  type SignUpWithEmailResult,
+  type VerifyOtpParams,
+  type VerifyOtpResult,
+  type VerifyPhoneOtpParams,
+  type VerifyPhoneOtpResult
+} from './types'
+import { composeFullNameMetadata, sanitizeAndValidateName } from './name-validator'
+
+/**
+ * Auth operations extracted from `useSupabaseAuth` as plain, dependency-injected
+ * functions. Each accepts a `deps` object (a Supabase client, a `toast` seam, and
+ * a `posthog` seam) and returns the exact result shape the hook returned before
+ * extraction. They do NOT touch React state — the hook owns loading/error/user
+ * state and derives it from these return values.
+ *
+ * Behavior is preserved bit-for-bit: the same Supabase calls, the same
+ * success/error toasts, the same PostHog `identify`/`capture` calls, and the
+ * same name validation/sanitization.
+ */
+
+function unexpectedErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : 'An unexpected error occurred'
+}
+
+export async function signInWithEmail(
+  params: SignInWithEmailParams,
+  deps: AuthOperationDeps
+): Promise<SignInWithEmailResult> {
+  const { supabase, toast } = deps
+  const { email, password } = params
+
+  try {
+    const { data, error } = await supabase.auth.signInWithPassword({
+      email,
+      password
+    })
+
+    if (error) {
+      toast.error(`Login failed: ${error.message}`)
+      return { success: false, error: error.message }
+    }
+
+    toast.success('Login successful!')
+    return { success: true, user: data.user }
+  } catch (err) {
+    const errorMessage = unexpectedErrorMessage(err)
+    toast.error(`Login failed: ${errorMessage}`)
+    return { success: false, error: errorMessage }
+  }
+}
+
+export async function signUpWithEmail(
+  params: SignUpWithEmailParams,
+  deps: AuthOperationDeps
+): Promise<SignUpWithEmailResult> {
+  const { supabase, toast } = deps
+  const { email, password, confirmPassword, firstName, lastName } = params
+
+  // Validate password confirmation if provided
+  if (confirmPassword && password !== confirmPassword) {
+    return { success: false, error: 'Passwords do not match' }
+  }
+
+  // Validate and sanitize name fields
+  const userMetadata: Record<string, string> = {}
+
+  const firstNameResult = sanitizeAndValidateName(firstName, 'First name')
+  if (!firstNameResult.isValid) {
+    const error = firstNameResult.error || 'Invalid first name'
+    toast.error(error)
+    return { success: false, error }
+  }
+  if (firstNameResult.value) {
+    userMetadata.first_name = firstNameResult.value
+  }
+
+  const lastNameResult = sanitizeAndValidateName(lastName, 'Last name')
+  if (!lastNameResult.isValid) {
+    const error = lastNameResult.error || 'Invalid last name'
+    toast.error(error)
+    return { success: false, error }
+  }
+  if (lastNameResult.value) {
+    userMetadata.last_name = lastNameResult.value
+  }
+
+  // Create full_name field for UI display
+  const fullName = composeFullNameMetadata(userMetadata.first_name, userMetadata.last_name)
+  if (fullName.full_name) {
+    userMetadata.full_name = fullName.full_name
+  }
+
+  try {
+    const { data, error } = await supabase.auth.signUp({
+      email: email.toLowerCase(),
+      password,
+      options: {
+        emailRedirectTo: `${window.location.origin}/auth/callback`,
+        data: userMetadata
+      }
+    })
+
+    if (error) {
+      toast.error(`Sign up failed: ${error.message}`)
+      return { success: false, error: error.message }
+    }
+
+    const needsOtpVerification = !data.user?.email_confirmed_at
+    if (needsOtpVerification) {
+      toast.success('Account created! Please check your email for the verification code.')
+    } else {
+      toast.success('Account created successfully!')
+    }
+
+    return {
+      success: true,
+      user: data.user,
+      needsOtpVerification
+    }
+  } catch (err) {
+    const errorMessage = unexpectedErrorMessage(err)
+    toast.error(`Sign up failed: ${errorMessage}`)
+    return { success: false, error: errorMessage }
+  }
+}
+
+export async function verifyOtp(
+  params: VerifyOtpParams,
+  deps: AuthOperationDeps
+): Promise<VerifyOtpResult> {
+  const { supabase, toast, posthog } = deps
+  const { email, token, otpType = 'email' } = params
+
+  try {
+    const { data, error } = await supabase.auth.verifyOtp({
+      email,
+      token,
+      type: otpType
+    })
+
+    if (error) {
+      toast.error(`Verification failed: ${error.message}`)
+      return { success: false, error: error.message }
+    }
+
+    toast.success('Email verified successfully!')
+
+    // 'email' is the only otpType this app ever passes here (verify-otp page is signup-only).
+    if (otpType === 'email') {
+      posthog.identify(data.user?.id, { email: data.user?.email })
+      posthog.capture('New user created', {
+        user_id: data.user?.id,
+        timestamp: new Date().toISOString()
+      })
+    }
+
+    return { success: true, user: data.user }
+  } catch (err) {
+    const errorMessage = unexpectedErrorMessage(err)
+    toast.error(`Verification failed: ${errorMessage}`)
+    return { success: false, error: errorMessage }
+  }
+}
+
+// Sends an SMS OTP to the given phone, creating the account if it doesn't exist. Names are
+// attached as user metadata here because Supabase only applies it at user-creation time
+// (this call) — the same full_name the handle_new_user trigger reads into profiles.
+export async function sendPhoneOtp(
+  params: SendPhoneOtpParams,
+  deps: AuthOperationDeps
+): Promise<SendPhoneOtpResult> {
+  const { supabase, toast } = deps
+  const { phone, firstName, lastName, shouldCreateUser = true } = params
+
+  const userMetadata: Record<string, string> = {}
+
+  const firstNameResult = sanitizeAndValidateName(firstName, 'First name')
+  if (!firstNameResult.isValid) {
+    const error = firstNameResult.error || 'Invalid first name'
+    toast.error(error)
+    return { success: false, error }
+  }
+  if (firstNameResult.value) userMetadata.first_name = firstNameResult.value
+
+  const lastNameResult = sanitizeAndValidateName(lastName, 'Last name')
+  if (!lastNameResult.isValid) {
+    const error = lastNameResult.error || 'Invalid last name'
+    toast.error(error)
+    return { success: false, error }
+  }
+  if (lastNameResult.value) userMetadata.last_name = lastNameResult.value
+
+  const fullName = composeFullNameMetadata(userMetadata.first_name, userMetadata.last_name)
+  if (fullName.full_name) {
+    userMetadata.full_name = fullName.full_name
+  }
+
+  try {
+    const { error } = await supabase.auth.signInWithOtp({
+      phone,
+      options: { channel: 'sms', shouldCreateUser, data: userMetadata }
+    })
+
+    if (error) {
+      toast.error(`Couldn't send code: ${error.message}`)
+      return { success: false, error: error.message }
+    }
+
+    toast.success('Verification code sent')
+    return { success: true }
+  } catch (err) {
+    const errorMessage = unexpectedErrorMessage(err)
+    toast.error(`Couldn't send code: ${errorMessage}`)
+    return { success: false, error: errorMessage }
+  }
+}
+
+// Verifies the SMS OTP. On success the user has a confirmed phone and an active session
+// (cookie-based), which the invite/accept route reads to prove phone ownership.
+export async function verifyPhoneOtp(
+  params: VerifyPhoneOtpParams,
+  deps: AuthOperationDeps
+): Promise<VerifyPhoneOtpResult> {
+  const { supabase, toast, posthog } = deps
+  const { phone, token } = params
+
+  try {
+    const { data, error } = await supabase.auth.verifyOtp({ phone, token, type: 'sms' })
+
+    if (error) {
+      toast.error(`Verification failed: ${error.message}`)
+      return { success: false, error: error.message }
+    }
+
+    toast.success('Phone verified')
+
+    // Phone-OTP verify is the acquisition funnel for the consultant-invite feature: identify the
+    // farmer and fire 'New user created' for genuinely new accounts (created within the last
+    // couple of minutes), mirroring the email verify path. PII (phone) stays in identify(),
+    // never in the capture event. TODO: email + phone both identify per-flow, but the documented
+    // convention is to identify once at the onAuthStateChange chokepoint; consolidate later.
+    if (data.user) {
+      posthog.identify(data.user.id, { phone: data.user.phone })
+      const createdMs = data.user.created_at ? new Date(data.user.created_at).getTime() : 0
+      if (createdMs && Date.now() - createdMs < 2 * 60 * 1000) {
+        posthog.capture('New user created', {
+          user_id: data.user.id,
+          timestamp: new Date().toISOString()
+        })
+      }
+    }
+
+    return { success: true, user: data.user }
+  } catch (err) {
+    const errorMessage = unexpectedErrorMessage(err)
+    toast.error(`Verification failed: ${errorMessage}`)
+    return { success: false, error: errorMessage }
+  }
+}
+
+export async function resendVerificationEmail(
+  params: ResetPasswordParams,
+  deps: AuthOperationDeps
+): Promise<ResendVerificationEmailResult> {
+  const { supabase } = deps
+  const { email } = params
+
+  try {
+    const { error } = await supabase.auth.resend({
+      type: 'signup',
+      email: email.toLowerCase(),
+      options: {
+        emailRedirectTo: `${window.location.origin}/auth/callback`
+      }
+    })
+
+    if (error) {
+      return { success: false, error: error.message }
+    }
+
+    return { success: true, message: 'Verification code resent successfully' }
+  } catch (err) {
+    return { success: false, error: unexpectedErrorMessage(err) }
+  }
+}
+
+export async function resetPassword(
+  params: ResetPasswordParams,
+  deps: AuthOperationDeps
+): Promise<ResetPasswordResult> {
+  const { supabase, toast } = deps
+  const { email } = params
+
+  try {
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: `${window.location.origin}/auth/reset-password`
+    })
+
+    if (error) {
+      toast.error(`Password reset failed: ${error.message}`)
+      return { success: false, error: error.message }
+    }
+
+    toast.success('Password reset email sent! Please check your inbox.')
+    return { success: true, message: 'Password reset email sent' }
+  } catch (err) {
+    const errorMessage = unexpectedErrorMessage(err)
+    toast.error(`Password reset failed: ${errorMessage}`)
+    return { success: false, error: errorMessage }
+  }
+}
+
+export async function signInWithGoogle(
+  params: SignInWithGoogleParams,
+  deps: AuthOperationDeps
+): Promise<SignInWithGoogleResult> {
+  const { supabase, toast } = deps
+  const { redirectTo = `${window.location.origin}/auth/callback` } = params
+
+  try {
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo,
+        queryParams: {
+          access_type: 'online',
+          prompt: 'consent'
+        }
+      }
+    })
+
+    if (error) {
+      toast.error(`Google sign in failed: ${error.message}`)
+      return { success: false, error: error.message }
+    }
+
+    // The user will be redirected to the OAuth provider; we don't set the user here.
+    return { success: true }
+  } catch (err) {
+    const errorMessage = unexpectedErrorMessage(err)
+    toast.error(`Google sign in failed: ${errorMessage}`)
+    return { success: false, error: errorMessage }
+  }
+}
+
+export async function signOut(deps: AuthOperationDeps): Promise<SignOutResult> {
+  const { supabase, toast } = deps
+
+  try {
+    await supabase.auth.signOut()
+
+    toast.success('Signed out successfully')
+    return { success: true }
+  } catch (err) {
+    const errorMessage = unexpectedErrorMessage(err)
+    toast.error(`Sign out failed: ${errorMessage}`)
+    return { success: false, error: errorMessage }
+  }
+}

--- a/src/lib/auth/auth-operations.ts
+++ b/src/lib/auth/auth-operations.ts
@@ -1,6 +1,7 @@
 import {
   type AuthOperationDeps,
   type ResetPasswordParams,
+  type ResendVerificationEmailParams,
   type ResendVerificationEmailResult,
   type ResetPasswordResult,
   type SendPhoneOtpParams,
@@ -272,7 +273,7 @@ export async function verifyPhoneOtp(
 }
 
 export async function resendVerificationEmail(
-  params: ResetPasswordParams,
+  params: ResendVerificationEmailParams,
   deps: AuthOperationDeps
 ): Promise<ResendVerificationEmailResult> {
   const { supabase } = deps

--- a/src/lib/auth/auth-operations.ts
+++ b/src/lib/auth/auth-operations.ts
@@ -362,7 +362,11 @@ export async function signOut(deps: AuthOperationDeps): Promise<SignOutResult> {
   const { supabase, toast } = deps
 
   try {
-    await supabase.auth.signOut()
+    const { error } = await supabase.auth.signOut()
+    if (error) {
+      toast.error(`Sign out failed: ${error.message}`)
+      return { success: false, error: error.message }
+    }
 
     toast.success('Signed out successfully')
     return { success: true }

--- a/src/lib/auth/auth-operations.ts
+++ b/src/lib/auth/auth-operations.ts
@@ -250,8 +250,8 @@ export async function verifyPhoneOtp(
     // Phone-OTP verify is the acquisition funnel for the consultant-invite feature: identify the
     // farmer and fire 'New user created' for genuinely new accounts (created within the last
     // couple of minutes), mirroring the email verify path. PII (phone) stays in identify(),
-    // never in the capture event. TODO: email + phone both identify per-flow, but the documented
-    // convention is to identify once at the onAuthStateChange chokepoint; consolidate later.
+    // never in the capture event. NOTE: email + phone both identify per-flow here; consolidating
+    // these onto the onAuthStateChange chokepoint is tracked in #158.
     if (data.user) {
       posthog.identify(data.user.id, { phone: data.user.phone })
       const createdMs = data.user.created_at ? new Date(data.user.created_at).getTime() : 0

--- a/src/lib/auth/auth-operations.ts
+++ b/src/lib/auth/auth-operations.ts
@@ -19,6 +19,7 @@ import {
   type VerifyPhoneOtpResult
 } from './types'
 import { composeFullNameMetadata, sanitizeAndValidateName } from './name-validator'
+import { AUTH } from '../constants'
 
 /**
  * Auth operations extracted from `useSupabaseAuth` as plain, dependency-injected
@@ -256,7 +257,7 @@ export async function verifyPhoneOtp(
     if (data.user) {
       posthog.identify(data.user.id, { phone: data.user.phone })
       const createdMs = data.user.created_at ? new Date(data.user.created_at).getTime() : 0
-      if (createdMs && Date.now() - createdMs < 2 * 60 * 1000) {
+      if (createdMs && Date.now() - createdMs < AUTH.NEW_USER_THRESHOLD_MS) {
         posthog.capture('New user created', {
           user_id: data.user.id,
           timestamp: new Date().toISOString()

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -1,0 +1,4 @@
+export * from './types'
+export * from './name-validator'
+export * from './session'
+export * from './auth-operations'

--- a/src/lib/auth/name-validator.ts
+++ b/src/lib/auth/name-validator.ts
@@ -1,0 +1,94 @@
+import { VALIDATION } from '@/lib/constants'
+import type { SanitizedNameResult } from './types'
+
+/**
+ * Sanitizes and validates a name field
+ * - Returns valid for undefined (optional parameter)
+ * - Trims whitespace
+ * - Removes control characters and newlines
+ * - Collapses repeated spaces
+ * - Enforces max length of 50 characters
+ */
+export function sanitizeAndValidateName(
+  name: string | undefined,
+  fieldName: string
+): SanitizedNameResult {
+  // Return valid if name is undefined (optional parameter)
+  if (name === undefined) {
+    return {
+      isValid: true
+    }
+  }
+
+  // Trim whitespace
+  let sanitized = name.trim()
+
+  // Check if empty after trimming
+  if (!sanitized) {
+    return {
+      isValid: false,
+      error: `${fieldName} cannot be empty or contain only whitespace`
+    }
+  }
+
+  // Remove control characters and newlines (ASCII 0-31 and 127)
+  // Using character-code filter instead of regex to avoid lint warnings
+  sanitized = sanitized
+    .split('')
+    .filter((char) => {
+      const code = char.charCodeAt(0)
+      return code >= 32 && code !== 127
+    })
+    .join('')
+
+  // Collapse repeated spaces into single space
+  sanitized = sanitized.replace(/\s+/g, ' ')
+
+  // Trim again after sanitization
+  sanitized = sanitized.trim()
+
+  // Check if empty after full sanitization
+  if (!sanitized) {
+    return {
+      isValid: false,
+      error: `${fieldName} contains only invalid characters`
+    }
+  }
+
+  // Check length and reject if it exceeds the limit
+  if (sanitized.length > VALIDATION.MAX_NAME_LENGTH) {
+    return {
+      isValid: false,
+      error: `${fieldName} must not exceed ${VALIDATION.MAX_NAME_LENGTH} characters (currently ${sanitized.length} characters)`
+    }
+  }
+
+  return {
+    isValid: true,
+    value: sanitized
+  }
+}
+
+/**
+ * Composes the `full_name` user-metadata field from the sanitized first and
+ * last name. Returns an empty record when neither name is present.
+ */
+export function composeFullNameMetadata(
+  firstName?: string,
+  lastName?: string
+): { first_name?: string; last_name?: string; full_name?: string } {
+  const metadata: { first_name?: string; last_name?: string; full_name?: string } = {}
+
+  if (firstName) metadata.first_name = firstName
+  if (lastName) metadata.last_name = lastName
+
+  if (metadata.first_name && metadata.last_name) {
+    metadata.full_name = `${metadata.first_name} ${metadata.last_name}`
+  } else if (metadata.first_name) {
+    metadata.full_name = metadata.first_name
+  } else if (metadata.last_name) {
+    metadata.full_name = metadata.last_name
+  }
+
+  return metadata
+}

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -1,0 +1,78 @@
+import type { AuthChangeEvent, Session, User } from '@supabase/supabase-js'
+import type { AuthStateChangeResult, InitialUserResult, SessionDeps } from './types'
+
+/**
+ * Resolves the initial authenticated user via `supabase.auth.getUser()` (secure
+ * verification). The three cases mirror the original hook behavior:
+ *
+ * 1. A user is present → return it.
+ * 2. `Auth session missing!` / `AuthSessionMissingError` → treated as a logged
+ *    out state (NOT an error), returns `{ user: null, error: null }`.
+ * 3. Any other error → returns the error message.
+ */
+export async function resolveInitialUser(deps: SessionDeps): Promise<InitialUserResult> {
+  const { supabase } = deps
+
+  try {
+    const {
+      data: { user },
+      error
+    } = await supabase.auth.getUser()
+
+    if (error) {
+      // "Auth session missing!" means no session exists - this is expected when not logged in
+      // Don't treat this as an error, just set user to null
+      if (error.message === 'Auth session missing!' || error.name === 'AuthSessionMissingError') {
+        return { user: null, error: null }
+      }
+
+      console.error('Auth error:', error.message, error.name)
+      return { user: null, error: error.message }
+    }
+
+    return { user: user ?? null, error: null }
+  } catch (err) {
+    return {
+      user: null,
+      error: err instanceof Error ? err.message : 'An unexpected error occurred'
+    }
+  }
+}
+
+/**
+ * Maps an `onAuthStateChange` event to the next session user state and keeps
+ * PostHog's identity in sync. This is the single chokepoint for analytics
+ * identity:
+ *
+ * - On an authenticated session, `identify` is called only when the PostHog
+ *   distinct id differs from the session user's id (guard against redundant
+ *   identify calls).
+ * - On `SIGNED_OUT`, `reset()` clears identity so a shared browser doesn't
+ *   leak the previous user.
+ *
+ * Only the `user` slice of auth state changes here — loading/error are owned by
+ * the hook, mirroring the original behavior.
+ */
+export function reduceAuthStateChange(
+  event: AuthChangeEvent,
+  session: Session | null,
+  deps: Pick<SessionDeps, 'posthog'>
+): AuthStateChangeResult {
+  const { posthog } = deps
+  const sessionUser: User | null = session?.user ?? null
+
+  // Keep PostHog's distinct_id in sync with the authenticated user so every
+  // event is attributed to a stable unique identifier across all entry
+  // paths — email login, Google OAuth, and session restore — not just the
+  // signup OTP flow. The id guard avoids redundant identify calls. Reset on
+  // sign-out so the next user on a shared browser doesn't inherit this identity.
+  if (sessionUser) {
+    if (posthog.get_distinct_id() !== sessionUser.id) {
+      posthog.identify(sessionUser.id, { email: sessionUser.email })
+    }
+  } else if (event === 'SIGNED_OUT') {
+    posthog.reset()
+  }
+
+  return { user: sessionUser }
+}

--- a/src/lib/auth/types.ts
+++ b/src/lib/auth/types.ts
@@ -36,6 +36,10 @@ export interface ResetPasswordParams {
   email: string
 }
 
+export interface ResendVerificationEmailParams {
+  email: string
+}
+
 export interface VerifyOtpParams {
   email: string
   token: string

--- a/src/lib/auth/types.ts
+++ b/src/lib/auth/types.ts
@@ -1,0 +1,158 @@
+import { type SupabaseClient, type User } from '@supabase/supabase-js'
+import type { Database } from '@/types/database'
+
+/**
+ * Shared types and dependency seams for the auth modules under `src/lib/auth`.
+ *
+ * These modules contain no React imports and no module-level side effects, so
+ * they can be unit-tested by injecting fakes (see `farm-access.test.ts` for the
+ * dependency-injection pattern). The runtime React glue lives in
+ * `useSupabaseAuth`, which builds these deps from the real Supabase client,
+ * `sonner`'s `toast`, and `posthog-js`.
+ */
+
+export interface AuthState {
+  user: User | null
+  loading: boolean
+  error: string | null
+}
+
+// --- Operation parameter types (kept identical to the pre-extraction hook) ---
+
+export interface SignInWithEmailParams {
+  email: string
+  password: string
+}
+
+export interface SignUpWithEmailParams {
+  email: string
+  password: string
+  confirmPassword?: string
+  firstName?: string
+  lastName?: string
+}
+
+export interface ResetPasswordParams {
+  email: string
+}
+
+export interface VerifyOtpParams {
+  email: string
+  token: string
+  otpType?: 'email' | 'recovery' | 'invite' | 'email_change'
+}
+
+export interface SendPhoneOtpParams {
+  phone: string // E.164, e.g. +919876543210
+  firstName?: string
+  lastName?: string
+  // Defaults to true so the invite flow still creates the farmer account. The
+  // login page passes false so an unknown number can't silently create an
+  // orphaned account with no profile/org.
+  shouldCreateUser?: boolean
+}
+
+export interface VerifyPhoneOtpParams {
+  phone: string // E.164
+  token: string
+}
+
+export interface SignInWithGoogleParams {
+  redirectTo?: string
+}
+
+// --- Operation result types (identical to the shapes returned today) ---
+
+export type SignInWithEmailResult =
+  | { success: true; user: User }
+  | { success: false; error: string }
+
+export type SignUpWithEmailResult =
+  | { success: true; user: User | null; needsOtpVerification: boolean }
+  | { success: false; error: string }
+
+export type VerifyOtpResult =
+  | { success: true; user: User | null }
+  | { success: false; error: string }
+
+export type SendPhoneOtpResult = { success: true } | { success: false; error: string }
+
+export type VerifyPhoneOtpResult =
+  | { success: true; user: User | null }
+  | { success: false; error: string }
+
+export type SignInWithGoogleResult = { success: true } | { success: false; error: string }
+
+export type ResendVerificationEmailResult =
+  | { success: true; message: string }
+  | { success: false; error: string }
+
+export type ResetPasswordResult =
+  | { success: true; message: string }
+  | { success: false; error: string }
+
+export type SignOutResult = { success: true } | { success: false; error: string }
+
+// --- Name validation ---
+
+export interface SanitizedNameResult {
+  isValid: boolean
+  value?: string
+  error?: string
+}
+
+// --- Dependency seams ---
+
+/**
+ * Structural supertype satisfied by the real `toast` from `sonner`. Only the
+ * two channels the auth flows use are required.
+ */
+export interface ToastSeam {
+  success: (message: string) => void
+  error: (message: string) => void
+}
+
+/**
+ * Structural supertype satisfied by the real `posthog` client. Only the
+ * identity / capture methods the auth flows use are required.
+ */
+export interface PosthogSeam {
+  identify: (distinctId: string | undefined, properties?: Record<string, any>) => void
+  capture: (eventName: string, properties?: Record<string, any>) => void
+  get_distinct_id: () => string
+  reset: () => void
+}
+
+/**
+ * A Supabase browser client typed the same way `createClient()` is in
+ * `src/lib/supabase.ts`. Tests inject a fake by casting via `as unknown as`.
+ */
+export type SupabaseAuthClient = SupabaseClient<Database>
+
+/**
+ * Dependencies injected into every auth operation. Keeping these as parameters
+ * (instead of importing them at module scope) is what makes the operations
+ * unit-testable without React or a live Supabase instance.
+ */
+export interface AuthOperationDeps {
+  supabase: SupabaseAuthClient
+  toast: ToastSeam
+  posthog: PosthogSeam
+}
+
+/**
+ * Dependencies for the session/identity transition unit.
+ */
+export interface SessionDeps {
+  supabase: SupabaseAuthClient
+  posthog: PosthogSeam
+}
+
+export interface InitialUserResult {
+  user: User | null
+  error: string | null
+}
+
+export interface AuthStateChangeResult {
+  user: User | null
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -29,3 +29,10 @@ export const VALIDATION = {
   MAX_PHOTOS_PER_DAY: 50,
   MAX_NAME_LENGTH: 50
 } as const
+
+// Auth constants
+export const AUTH = {
+  // A user is considered "new" (for the 'New user created' capture) if their account was
+  // created within this window of the verify op running.
+  NEW_USER_THRESHOLD_MS: 2 * 60 * 1000
+} as const

--- a/src/lib/posthog-server.ts
+++ b/src/lib/posthog-server.ts
@@ -7,7 +7,7 @@ import { PostHog } from 'posthog-node'
 let posthogInstance: PostHog | null = null
 
 export function getPostHogServer(): PostHog | null {
-  const key = process.env.NEXT_PUBLIC_POSTHOG_KEY
+  const key = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN
   if (!key) {
     // No key configured (e.g. local without analytics) — degrade gracefully.
     return null

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config'
+import path from 'node:path'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src')
+    }
+  },
+  test: {
+    environment: 'node',
+    setupFiles: ['./vitest.setup.ts'],
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    exclude: ['**/node_modules/**', '**/.next/**', '**/.claude/**', '**/dist/**']
+  }
+})

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,11 @@
+import { vi } from 'vitest'
+
+// The extracted auth operations read `window.location.origin` to build redirect
+// URLs. The test suite runs in the default `node` environment (jsdom is
+// unavailable due to a broken transitive dependency), so provide a stable,
+// minimal `window`/`location` for any code path under test that needs it.
+if (typeof globalThis.window === 'undefined') {
+  const ORIGIN = 'http://localhost:3000'
+  vi.stubGlobal('window', { location: { origin: ORIGIN } })
+  vi.stubGlobal('location', { origin: ORIGIN })
+}


### PR DESCRIPTION
Closes #153 · Parent PRD: #152

## What

Slice 1 of the auth-consolidation PRD (#152): extract the auth logic that lived inside `useSupabaseAuth` into dependency-injected, vitest-tested modules under `src/lib/auth/` — **without changing any runtime wiring or consumer behavior**. The hook keeps its exact public return shape, so all 35 consumers compile and behave identically. This sets up the `AuthProvider` consolidation in a later slice.

## Changes

- **`src/lib/auth/session.ts`** — `resolveInitialUser` (initial `getUser()` with the 3 cases: user present / `Auth session missing!` / generic error) + `reduceAuthStateChange` (event → state + PostHog `identify` with the `distinct_id` guard, `reset` on `SIGNED_OUT`). No React imports.
- **`src/lib/auth/auth-operations.ts`** — all 9 operations as DI functions returning today's result shapes (signInWithEmail, signUpWithEmail, verifyOtp, sendPhoneOtp, verifyPhoneOtp, signInWithGoogle, resendVerificationEmail, resetPassword, signOut).
- **`src/lib/auth/name-validator.ts`** — `sanitizeAndValidateName` + `composeFullNameMetadata` as pure functions.
- **`src/lib/auth/types.ts`** — shared types + `toast` / `posthog` / `supabase` dependency-seam interfaces.
- **`src/hooks/useSupabaseAuth.ts`** — 620 → 202 lines; now thin glue that injects the real `supabase`/`toast`/`posthog` and maps results onto React state via one `applyResult` helper.
- **`package.json`** — added `"test": "vitest run"`.
- **`vitest.config.ts`** + **`vitest.setup.ts`** — `@/` alias + minimal `window.location` stub.

## Behavior preserved

Same Supabase calls, same success/error toasts, same PostHog `identify`/`capture` calls (incl. the per-operation `New user created` capture on email-verify and phone-verify), same name validation/sanitization, same `clearLastRoute` on sign-out. The session/identity decision logic is extracted verbatim, including the `distinct_id` guard.

## Tests

62 new tests, following the existing DI mock pattern in `farm-access.test.ts` and the pure-function style of `phone.test.ts`:
- **`auth-operations.test.ts` (35)** — each operation's success/error paths + correct toasts; name validation/sanitization gating and `full_name` metadata composition for signup & phone-OTP send; `New user created` fires once for a new phone account and not for an existing one.
- **`auth-session.test.ts` (11)** — initial-user resolution for all three cases; `identify` fires once per new identity (distinct_id guard) and `reset` fires on sign-out.
- **`name-validator.test.ts` (16)** — trim, control-char strip (incl. tab/DEL), whitespace collapse, max-length boundary, `undefined` → valid, `full_name` composition.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — **0 errors**
- `bun run test` — **90 passed** (62 new)

> Note: `consultant-triage-service` and `consultant-visit-service` test files are **pre-existing** failures on `main` — they import `supabase.ts` at module load (creating a browser client without env vars), which is exactly the anti-pattern these DI modules avoid. This PR does not touch them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted auth logic from `useSupabaseAuth` into DI modules under `src/lib/auth`, preserving the hook API and behavior. Also hardened analytics by redacting invite/member tokens and avoiding PII in event properties, and added lightweight PostHog events on consultant pages. Closes #153 (PRD #152).

- **Refactors**
  - New DI modules: `session.ts`, `auth-operations.ts`, `name-validator.ts`, `types.ts` (+ `index.ts` exports); `useSupabaseAuth` is now thin glue that injects `supabase`, `sonner` `toast`, and `posthog-js`.
  - Added `ResendVerificationEmailParams` and `AUTH.NEW_USER_THRESHOLD_MS` (new-user capture window) with no behavior changes.
  - 62 `vitest` tests cover auth operations, session/identity, and name validation.
  - Analytics: redacts invite/member tokens across PostHog and Sentry and avoids PII by using bounded error categories; added consultant view/action captures (farmer list/profile, team, triage, visit start) and `identify` on consultant layout; renamed a payment event; switched server key to `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN`.
  - Landing: gated render during auth redirect to avoid marketing-page flash and justified the client-side redirect with an inline `react-doctor` disable.

- **Dependencies**
  - Added `vitest` to devDependencies and a `test` script (`"test": "vitest run"`).

<sup>Written for commit 6d457feae61a479585f834c1244b3b491552ca0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ashish921998/Vinesight/pull/157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Vitest coverage for auth operations, session initialization/state transitions, and name sanitization/metadata.
* **Refactor**
  * Centralized authentication flows into shared operations with consistent loading/error/user updates.
* **Bug Fixes**
  * Improved auth initialization and state transitions; standardized analytics identify/reset behavior.
  * Updated protected-route handling to redirect to the login page; improved landing-page loading display for authenticated users.
* **New Features**
  * Expanded PostHog tracking across consultant pages/dialogs, including invite events, plus invite-token redaction and PostHog project-token configuration.
* **Chores**
  * Added Vitest setup/config and enabled `npm test` to run `vitest run`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->