### PR TITLE
fix(invite): fixed +91 prefix with a separate number field

### DIFF
--- a/src/components/consultant/InviteFarmerDialog.tsx
+++ b/src/components/consultant/InviteFarmerDialog.tsx
@@ -14,7 +14,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { toast } from 'sonner'
 import { UserPlus, Copy, Check, MessageCircle, Send, Loader2, RefreshCw } from 'lucide-react'
-import { normalizePhone } from '@/lib/phone'
+import { normalizePhone, toIndianNationalDigits } from '@/lib/phone'
 import posthog from 'posthog-js'
 
 interface InviteResult {
@@ -53,9 +53,10 @@ export function InviteFarmerDialog({ organizationId, trigger }: InviteFarmerDial
     : ''
 
   const handleCreate = async () => {
-    const normalized = normalizePhone(phone)
+    // `phone` holds the 10-digit national number; the +91 country code is fixed in the UI.
+    const normalized = normalizePhone(`+91${phone}`)
     if (!normalized) {
-      toast.error('Enter a valid phone number')
+      toast.error('Enter a valid 10-digit mobile number')
       return
     }
 
@@ -143,24 +144,32 @@ export function InviteFarmerDialog({ organizationId, trigger }: InviteFarmerDial
           <div className="space-y-4">
             <div className="space-y-2">
               <Label htmlFor="invite-phone">Phone number</Label>
-              {/* type=tel stays free-form, but strip anything that isn't a digit, +, or
-                  space as it's typed so letters can't be entered. normalizePhone still
-                  validates and cleans the value on submit. */}
-              <Input
-                id="invite-phone"
-                type="tel"
-                inputMode="tel"
-                value={phone}
-                onChange={(e) => setPhone(e.target.value.replace(/[^\d+\s]/g, ''))}
-                placeholder="e.g. 98765 43210"
-              />
+              {/* +91 is a fixed, non-editable prefix; the input takes only the 10-digit
+                  national number. toIndianNationalDigits keeps it digits-only and strips a
+                  redundant 91/0 if the user pastes a full number, so the prefix never doubles up. */}
+              <div className="flex">
+                <span className="inline-flex items-center rounded-l-md border border-r-0 border-input bg-muted px-3 text-sm text-muted-foreground">
+                  +91
+                </span>
+                <Input
+                  id="invite-phone"
+                  type="tel"
+                  inputMode="numeric"
+                  autoComplete="tel-national"
+                  maxLength={10}
+                  className="rounded-l-none"
+                  value={phone}
+                  onChange={(e) => setPhone(toIndianNationalDigits(e.target.value))}
+                  placeholder="98765 43210"
+                />
+              </div>
               <p className="text-xs text-muted-foreground">
-                Indian numbers default to +91. Include the country code for other countries.
+                Enter the 10-digit Indian mobile number, without the +91 country code.
               </p>
             </div>
             <Button
               onClick={handleCreate}
-              disabled={submitting || !phone.trim()}
+              disabled={submitting || phone.length !== 10}
               className="w-full gap-2"
             >
               {submitting ? (

--- a/src/components/consultant/InviteFarmerDialog.tsx
+++ b/src/components/consultant/InviteFarmerDialog.tsx
@@ -156,7 +156,6 @@ export function InviteFarmerDialog({ organizationId, trigger }: InviteFarmerDial
                   type="tel"
                   inputMode="numeric"
                   autoComplete="tel-national"
-                  maxLength={10}
                   className="rounded-l-none"
                   value={phone}
                   onChange={(e) => setPhone(toIndianNationalDigits(e.target.value))}

--- a/src/components/consultant/InviteFarmerDialog.tsx
+++ b/src/components/consultant/InviteFarmerDialog.tsx
@@ -168,7 +168,7 @@ export function InviteFarmerDialog({ organizationId, trigger }: InviteFarmerDial
             </div>
             <Button
               onClick={handleCreate}
-              disabled={submitting || phone.length !== 10}
+              disabled={submitting || !normalizePhone(`+91${phone}`)}
               className="w-full gap-2"
             >
               {submitting ? (

--- a/src/lib/__tests__/phone.test.ts
+++ b/src/lib/__tests__/phone.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { normalizePhone } from '../phone'
+import { normalizePhone, toIndianNationalDigits } from '../phone'
 
 describe('normalizePhone', () => {
   it('prefixes a bare 10-digit Indian mobile with +91', () => {
@@ -61,5 +61,30 @@ describe('normalizePhone', () => {
     expect(normalizePhone('')).toBeNull()
     expect(normalizePhone('   ')).toBeNull()
     expect(normalizePhone('abcd')).toBeNull()
+  })
+})
+
+describe('toIndianNationalDigits', () => {
+  it('keeps a bare 10-digit number and strips separators', () => {
+    expect(toIndianNationalDigits('98765 43210')).toBe('9876543210')
+    expect(toIndianNationalDigits('98765-43210')).toBe('9876543210')
+  })
+
+  it('drops a pasted 91 country code so the fixed +91 prefix never doubles up', () => {
+    expect(toIndianNationalDigits('919876543210')).toBe('9876543210')
+    expect(toIndianNationalDigits('+91 98765 43210')).toBe('9876543210')
+  })
+
+  it('drops a trunk 0 from an 11-digit number', () => {
+    expect(toIndianNationalDigits('09876543210')).toBe('9876543210')
+  })
+
+  it('caps to 10 digits and strips non-digits', () => {
+    expect(toIndianNationalDigits('9876543210999')).toBe('9876543210')
+    expect(toIndianNationalDigits('abc987def654ghi3210')).toBe('9876543210')
+  })
+
+  it('returns an empty string for empty input', () => {
+    expect(toIndianNationalDigits('')).toBe('')
   })
 })

--- a/src/lib/__tests__/phone.test.ts
+++ b/src/lib/__tests__/phone.test.ts
@@ -94,6 +94,16 @@ describe('toIndianNationalDigits', () => {
     expect(toIndianNationalDigits('9123456789')).toBe('9123456789')
   })
 
+  it('unwinds a combined trunk-0-plus-91 prefix (T-Rex finding)', () => {
+    // "0919876543210" -> would otherwise strip only the 0 and yield a wrong "9198765432".
+    expect(toIndianNationalDigits('0919876543210')).toBe('9876543210')
+    expect(toIndianNationalDigits('+091 98765 43210')).toBe('9876543210')
+  })
+
+  it('unwinds a doubled 91 country-code paste', () => {
+    expect(toIndianNationalDigits('+91 +91 98765 43210')).toBe('9876543210')
+  })
+
   it('returns an empty string for empty input', () => {
     expect(toIndianNationalDigits('')).toBe('')
   })

--- a/src/lib/__tests__/phone.test.ts
+++ b/src/lib/__tests__/phone.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { normalizePhone, toIndianNationalDigits } from '../phone'
+import { normalizePhone, toIndianNationalDigits } from '@/lib/phone'
 
 describe('normalizePhone', () => {
   it('prefixes a bare 10-digit Indian mobile with +91', () => {
@@ -82,6 +82,16 @@ describe('toIndianNationalDigits', () => {
   it('caps to 10 digits and strips non-digits', () => {
     expect(toIndianNationalDigits('9876543210999')).toBe('9876543210')
     expect(toIndianNationalDigits('abc987def654ghi3210')).toBe('9876543210')
+  })
+
+  it('strips a 91 country code even when the paste carries extra trailing digits', () => {
+    // "+91 98765 432100" -> would otherwise keep the 91 and yield a wrong "9198765432".
+    expect(toIndianNationalDigits('+91 98765 432100')).toBe('9876543210')
+    expect(toIndianNationalDigits('9198765432100')).toBe('9876543210')
+  })
+
+  it('leaves a genuine 10-digit mobile that starts with 91 untouched', () => {
+    expect(toIndianNationalDigits('9123456789')).toBe('9123456789')
   })
 
   it('returns an empty string for empty input', () => {

--- a/src/lib/phone.ts
+++ b/src/lib/phone.ts
@@ -31,19 +31,25 @@ export interface NormalizedPhone {
  * code or trunk 0 so the user doesn't end up with a doubled prefix:
  *  - a "91…" value over 10 digits -> the 91 country code is dropped.
  *  - a "0…" value over 10 digits   -> the trunk 0 is dropped.
- * Both are only stripped when the value is longer than 10 digits, so a genuine 10-digit
- * mobile that happens to start with "91" (or contains a 0) is left untouched. Stripping is
- * length-driven rather than pinned to an exact count, so a paste with extra trailing digits
- * (e.g. "+91 98765 432100") still has its prefix removed instead of slipping through.
+ * Prefixes are stripped in a loop, so combined or repeated prefixes (e.g. a trunk-plus-country
+ * "0919876543210", or a doubled "+91 +91 98765 43210" paste) are fully unwound rather than
+ * leaving a country code embedded in the result. Stripping only runs while the value is longer
+ * than 10 digits, so a genuine 10-digit mobile that happens to start with "91" (or contains a 0)
+ * is left untouched, and it's length-driven rather than pinned to an exact count so a paste with
+ * extra trailing digits still has its prefix removed instead of slipping through.
  * The result is always digits only, capped at 10.
  */
 export function toIndianNationalDigits(input: string): string {
   let digits = (input || '').replace(/\D/g, '')
 
-  if (digits.length > 10 && digits.startsWith(DEFAULT_COUNTRY_CODE)) {
-    digits = digits.slice(2)
-  } else if (digits.length > 10 && digits.startsWith('0')) {
-    digits = digits.slice(1)
+  while (digits.length > 10) {
+    if (digits.startsWith('0')) {
+      digits = digits.slice(1)
+    } else if (digits.startsWith(DEFAULT_COUNTRY_CODE)) {
+      digits = digits.slice(2)
+    } else {
+      break
+    }
   }
 
   return digits.slice(0, 10)

--- a/src/lib/phone.ts
+++ b/src/lib/phone.ts
@@ -29,16 +29,20 @@ export interface NormalizedPhone {
  * Reduce arbitrary user input to the bare 10-digit Indian national mobile number, for use with
  * a fixed "+91" prefix in the UI. Forgiving about pasted values that already carry a country
  * code or trunk 0 so the user doesn't end up with a doubled prefix:
- *  - a 12-digit "91…" value     -> the 91 country code is dropped.
- *  - an 11-digit "0…" value     -> the trunk 0 is dropped.
+ *  - a "91…" value over 10 digits -> the 91 country code is dropped.
+ *  - a "0…" value over 10 digits   -> the trunk 0 is dropped.
+ * Both are only stripped when the value is longer than 10 digits, so a genuine 10-digit
+ * mobile that happens to start with "91" (or contains a 0) is left untouched. Stripping is
+ * length-driven rather than pinned to an exact count, so a paste with extra trailing digits
+ * (e.g. "+91 98765 432100") still has its prefix removed instead of slipping through.
  * The result is always digits only, capped at 10.
  */
 export function toIndianNationalDigits(input: string): string {
   let digits = (input || '').replace(/\D/g, '')
 
-  if (digits.length === 12 && digits.startsWith(DEFAULT_COUNTRY_CODE)) {
+  if (digits.length > 10 && digits.startsWith(DEFAULT_COUNTRY_CODE)) {
     digits = digits.slice(2)
-  } else if (digits.length === 11 && digits.startsWith('0')) {
+  } else if (digits.length > 10 && digits.startsWith('0')) {
     digits = digits.slice(1)
   }
 

--- a/src/lib/phone.ts
+++ b/src/lib/phone.ts
@@ -25,6 +25,26 @@ export interface NormalizedPhone {
  *  - Other intl numbers     -> accepted at a plausible E.164 length (11-15 digits).
  * A leading 0 after normalization (e.g. a "+0..." input) is rejected as malformed.
  */
+/**
+ * Reduce arbitrary user input to the bare 10-digit Indian national mobile number, for use with
+ * a fixed "+91" prefix in the UI. Forgiving about pasted values that already carry a country
+ * code or trunk 0 so the user doesn't end up with a doubled prefix:
+ *  - a 12-digit "91…" value     -> the 91 country code is dropped.
+ *  - an 11-digit "0…" value     -> the trunk 0 is dropped.
+ * The result is always digits only, capped at 10.
+ */
+export function toIndianNationalDigits(input: string): string {
+  let digits = (input || '').replace(/\D/g, '')
+
+  if (digits.length === 12 && digits.startsWith(DEFAULT_COUNTRY_CODE)) {
+    digits = digits.slice(2)
+  } else if (digits.length === 11 && digits.startsWith('0')) {
+    digits = digits.slice(1)
+  }
+
+  return digits.slice(0, 10)
+}
+
 export function normalizePhone(input: string): NormalizedPhone | null {
   if (!input) return null
 


### PR DESCRIPTION
## Summary

Reworks the **Invite Farmer** phone input per tester feedback:

- **+91 is now a fixed, non-editable prefix block** sitting to the left of the input, so the user only types the 10-digit national number.
- The input is digits-only and capped at 10. A new `toIndianNationalDigits` helper strips a redundant `91`/`+91` or trunk `0` if the user pastes a full number, so the country code can never double up (the "+91 still errors" case).
- The "Generate invite link" button stays disabled until a complete 10-digit number is entered, preventing the validation error the tester hit.

Validation still flows through the existing, well-tested `normalizePhone` (the UI passes `+91<number>`), and the server-side check in `/api/invite/create` is unchanged.

## Why

A tester reported that the single free-form phone box was confusing and error-prone: a bare number errored, and adding `+91` manually produced the same error. They asked for a fixed +91 block with a separate field for the number. This change implements exactly that and removes the class of formatting ambiguity.

Note: the invite flow is now India-only (+91). This matches VineSight's primary market; international invite numbers are no longer accepted from this dialog.

## Test plan

- `npm test` — added unit tests for `toIndianNationalDigits` (separators, pasted 91/+91, trunk 0, 10-digit cap, empty); all 15 phone tests pass.
- Manual: open Invite Farmer, confirm the +91 block is fixed, type `9876543210` → link generates; paste `+91 98765 43210` → field shows `9876543210`, no double prefix.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://vinesight-group.slack.com/archives/C0BARL5FNHK/p1781793760434039?thread_ts=1781793760.434039&cid=C0BARL5FNHK)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made +91 a fixed, non-editable prefix with a separate 10‑digit number field in the Invite Farmer dialog to stop double country codes and invalid inputs. Paste handling fully unwinds combined/repeated `+91`/`91`/leading `0` prefixes and trims extra trailing digits; submit only enables when the number passes full validation.

- **Bug Fixes**
  - Input/UX: Fixed "+91" prefix with a numeric-only 10‑digit field; removed input max length so full pastes reach `toIndianNationalDigits`; fully unwinds combined/repeated `+91`/`91`/`0` prefixes; disables submit until `normalizePhone('+91' + phone)` passes; India-only flow.
  - Validation: Still uses `normalizePhone` with `+91<number>`; server API unchanged; clearer error text (“Enter a valid 10-digit mobile number”).
  - Tests: Added regression tests for extra trailing digits and combined/repeated prefixes (e.g. `091…`, `+91 +91 …`); phone tests updated and passing.

<sup>Written for commit b39174165ccad6756aa2322f3ca983430ce00349. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ashish921998/Vinesight/pull/165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved Indian phone number input with a fixed, non-editable **+91** prefix.
  * Phone entry is now normalized as you type and invite link generation is enabled only when the normalized value is exactly **10 digits**.

* **Bug Fixes**
  * Invite link creation now consistently applies **+91** after normalization, with clearer errors when the number is not a valid 10-digit mobile.

* **Tests**
  * Added automated coverage for Indian digit normalization, including trunk/prefix “unwinding” and edge-case truncation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->