### PR TITLE
feat(consultant): surface Assignment screen, enforce agronomist-only assignment

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,9 +37,19 @@ The link from a Client to a single Agronomist, created by an Owner or Admin. Det
 Farmers an Agronomist can access.
 _Avoid_: mapping, allocation
 
+**Join code**:
+The Organization's public code a Farmer enters in the app to self-join as a Client.
+_Avoid_: slug (the technical column name), invite code (reserved for staff email invites)
+
 **Enrolment**:
-Bringing a Farmer into an Organization as a Client (e.g. via invitation).
+Bringing a Farmer into an Organization as a Client. Two forms: **Self-join** (Farmer enters the
+Join code) and **Invite** (consultant sends a phone invite to a new Farmer). Every Enrolment
+lands the Client **Unassigned** — an Owner/Admin then makes the Assignment.
 _Avoid_: onboarding, registration
+
+**Self-join**:
+Farmer-initiated Enrolment: the Farmer joins an Organization by entering its Join code.
+_Avoid_: signup (that's account creation, a separate step)
 
 ## Farming
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,53 @@
+# VineSight
+
+VineSight has two user-facing modules sharing one backend: the **Farmer** module
+(self-service record-keeping for grape growers) and the **Consultant** module
+(advisory organizations that access and advise farmers). This glossary defines the
+language shared across both.
+
+## Organization & Access
+
+**Organization**:
+An advisory business whose Members manage and advise Farmers.
+_Avoid_: company, agency, consultancy, firm
+
+**Member** (Organization Member):
+A user who belongs to an Organization under exactly one role — Owner, Admin, or Agronomist.
+_Avoid_: staff, consultant, team member
+
+**Owner**:
+The Member who created the Organization; full control, sees all of the org's Farmers.
+_Avoid_: superadmin
+
+**Admin**:
+A Member who can enrol Farmers, invite Members, and assign Farmers; sees all of the org's Farmers.
+_Avoid_: manager
+
+**Agronomist**:
+A Member who can access only the Farmers explicitly assigned to them.
+_Avoid_: consultant, advisor, expert
+
+**Client** (Organization Client):
+The enrolment relationship between a Farmer and an Organization — a Farmer as advised by
+that org. A Farmer must be enrolled as a Client before they can be assigned.
+_Avoid_: customer, account
+
+**Assignment**:
+The link from a Client to a single Agronomist, created by an Owner or Admin. Determines which
+Farmers an Agronomist can access.
+_Avoid_: mapping, allocation
+
+**Enrolment**:
+Bringing a Farmer into an Organization as a Client (e.g. via invitation).
+_Avoid_: onboarding, registration
+
+## Farming
+
+**Farmer**:
+An end user who owns and keeps records for one or more Farms. Becomes a Client when enrolled
+into an Organization.
+_Avoid_: grower, user, cultivator
+
+**Farm**:
+A vineyard belonging to a Farmer, with its own soil profile, crop variety, and records.
+_Avoid_: plot, field, vineyard, block

--- a/docs/adr/0001-assignment-targets-agronomist.md
+++ b/docs/adr/0001-assignment-targets-agronomist.md
@@ -49,8 +49,13 @@ three routes for friendly error messages.
   row it checks.
 - Owner/Admin-invited Farmers now require an explicit assignment step. That step is exactly what
   the newly-surfaced Team → Assignments tab provides, so the loop stays closed.
-- No backfill: the only existing assignment in the production database already targets the
-  Agronomist, so it satisfies the new invariant.
+- A one-time backfill (in `202606190001`, run before the trigger is created) resets any
+  pre-existing assignment that isn't an Agronomist to **Unassigned**. We initially believed the
+  sole production assignment already targeted the Agronomist and that no backfill was needed; in
+  fact a Self-join through the old owner-assigning `join_organization_by_slug` had left one Client
+  assigned to the **Owner**, which the new invariant rejects. The backfill nulls `assigned_to` for
+  such rows (preserving `assigned_by`, which records who enrolled the Farmer) so the table is
+  compliant and the Unassigned signal is trustworthy from the first deploy.
 - The farmer Self-join RPC `join_organization_by_slug` previously assigned new Clients to the
   org owner — which this trigger rejects. It is brought under version control and changed to land
   Self-joined Clients **Unassigned** (`assigned_to = null`), shipping in the same migration set so

--- a/docs/adr/0001-assignment-targets-agronomist.md
+++ b/docs/adr/0001-assignment-targets-agronomist.md
@@ -44,9 +44,11 @@ three routes for friendly error messages.
 
 ## Consequences
 
-- The trigger does a cross-table role lookup on every `assigned_to` write; it runs
-  `SECURITY DEFINER` with a pinned `search_path` so RLS on `organization_members` can't hide the
-  row it checks.
+- The trigger does a cross-table role lookup whenever `assigned_to` **or** `organization_id`
+  changes — moving a Client to another Organization must re-validate the existing assignee against
+  the new Org, so the trigger fires on both columns (and skips the lookup only when both are
+  unchanged). It runs `SECURITY DEFINER` with a pinned `search_path` so RLS on
+  `organization_members` can't hide the row it checks.
 - Owner/Admin-invited Farmers now require an explicit assignment step. That step is exactly what
   the newly-surfaced Team → Assignments tab provides, so the loop stays closed.
 - A one-time backfill (in `202606190001`, run before the trigger is created) resets any

--- a/docs/adr/0001-assignment-targets-agronomist.md
+++ b/docs/adr/0001-assignment-targets-agronomist.md
@@ -1,0 +1,53 @@
+---
+status: accepted
+---
+
+# An Assignment must target an Agronomist
+
+## Context
+
+`organization_clients.assigned_to` is the **Assignment** — the link naming the single
+Member responsible for a Client (an enrolled Farmer). Three code paths write it and they
+disagreed on the rules:
+
+- `POST /api/organizations/assign` (the bulk screen) rejects any `assigned_to` that isn't an
+  Agronomist in the org.
+- `POST /api/invite/accept` set `assigned_to = invite.invited_by` — **whoever sent the
+  invite**, regardless of role.
+- `POST /api/organizations/add-client` set `assigned_to` from the request without checking the
+  role.
+
+Because invite-accept keyed off the inviter, an Owner- or Admin-sent invite produced a Client
+"assigned" to a non-Agronomist. On the assignment screen that Client then shows a populated
+"Assigned to …" badge even though no Agronomist is responsible, so the **Unassigned** signal —
+the one an admin scans to find Farmers that still need an Agronomist — could not be trusted.
+
+## Decision
+
+`assigned_to` may only ever reference a Member holding the **agronomist** role in the same
+Organization, or be `NULL`. Invite-accept auto-assigns the inviter only when the inviter is an
+Agronomist; an Owner/Admin invite lands the Client **Unassigned**, to be assigned deliberately
+from Team → Assignments.
+
+The invariant is enforced in two layers: a Postgres trigger on `organization_clients` (the
+unbypassable source of truth, so future write paths can't drift) plus app-level guards in the
+three routes for friendly error messages.
+
+## Considered options
+
+- **Any Member can be the assignee** — rejected: blurs the domain model and destroys the
+  meaning of the Unassigned state.
+- **Never auto-assign on invite** — rejected: loses the natural "an Agronomist enrols their own
+  Farmer and owns them immediately" flow.
+- **App guards only, no trigger** — rejected: the failure mode we are fixing _is_ paths
+  drifting out of sync; only a DB-level invariant prevents the next path from reintroducing it.
+
+## Consequences
+
+- The trigger does a cross-table role lookup on every `assigned_to` write; it runs
+  `SECURITY DEFINER` with a pinned `search_path` so RLS on `organization_members` can't hide the
+  row it checks.
+- Owner/Admin-invited Farmers now require an explicit assignment step. That step is exactly what
+  the newly-surfaced Team → Assignments tab provides, so the loop stays closed.
+- No backfill: the only existing assignment in the production database already targets the
+  Agronomist, so it satisfies the new invariant.

--- a/docs/adr/0001-assignment-targets-agronomist.md
+++ b/docs/adr/0001-assignment-targets-agronomist.md
@@ -51,3 +51,8 @@ three routes for friendly error messages.
   the newly-surfaced Team → Assignments tab provides, so the loop stays closed.
 - No backfill: the only existing assignment in the production database already targets the
   Agronomist, so it satisfies the new invariant.
+- The farmer Self-join RPC `join_organization_by_slug` previously assigned new Clients to the
+  org owner — which this trigger rejects. It is brought under version control and changed to land
+  Self-joined Clients **Unassigned** (`assigned_to = null`), shipping in the same migration set so
+  the trigger never exists without a compatible RPC. See ADR-0002 and
+  `202606190002_join_organization_by_slug_unassigned.sql`.

--- a/docs/adr/0002-shared-db-objects-version-controlled-here.md
+++ b/docs/adr/0002-shared-db-objects-version-controlled-here.md
@@ -1,0 +1,31 @@
+---
+status: accepted
+---
+
+# Shared database objects are version-controlled in vinesight-web migrations
+
+## Context
+
+VineSight is two repos over one Supabase database: this consultant web app and the
+`vinesight-rn` farmer app. The farmer Self-join RPC `join_organization_by_slug` was created
+directly against the live database and existed in **no** migration in either repo. It stayed
+invisible to anyone reading this codebase — which is exactly why ADR-0001's
+agronomist-only trigger was designed without noticing it assigned new Clients to the org owner,
+a collision that would have broken every farmer Self-join on deploy.
+
+## Decision
+
+All shared database objects (tables, RPCs, triggers, RLS policies, indexes) are version-controlled
+as migrations in **`vinesight-web/supabase/migrations`**, which is the single source of truth for
+the shared schema. Neither app may create or alter shared DB objects out-of-band against the live
+database. Changes the farmer app needs land as reviewed migrations here.
+
+## Consequences
+
+- Any change to the contract the RN app depends on is visible, reviewable, and reproducible from a
+  clean database — cross-cutting invariants (like ADR-0001) can be reasoned about against the whole
+  schema, not a partial view.
+- Existing out-of-band objects get adopted into migrations as they're discovered
+  (`join_organization_by_slug` is the first; see `202606190002`).
+- The RN team must route schema changes through this repo, which adds coordination but removes the
+  drift class of bug that motivated this ADR.

--- a/plans/agronomist-assignment-surface-harden.md
+++ b/plans/agronomist-assignment-surface-harden.md
@@ -1,0 +1,109 @@
+# Plan — Surface + harden the Agronomist Assignment flow
+
+**Goal:** Make the existing (orphaned) Assignment screen reachable, and enforce that an
+Assignment (`organization_clients.assigned_to`) always targets an **Agronomist**.
+
+**Scope guardrails (decided in grilling):**
+
+- No widening of the agronomist's data surface (still profile / farms / soil / lab tests / triage).
+- No role-change UI, no pagination, no notifications.
+- See `docs/adr/0001-assignment-targets-agronomist.md` for the assignee-role invariant.
+
+**Domain language:** `CONTEXT.md` (Organization, Member, Owner/Admin/Agronomist, Client,
+Assignment, Enrolment, Farmer, Farm).
+
+---
+
+## Starting state (verified)
+
+- Assignment plumbing works end-to-end: `assign/route.ts`, `consultant-query-service.ts`
+  (`getFarmerClients`/`validateFarmerClient`), `farm-access.ts` rule 3, and RLS.
+- `/consultant/team/assignments/page.tsx` is **fully built but orphaned** — no link reaches it.
+- Live DB: 2 orgs; `test-org` has 1 owner + 1 agronomist + 1 active client (already assigned to
+  the agronomist); `test-orgs` is empty. 203 farms, only 1 enrolled Client. **No bad data.**
+
+---
+
+## Step 1 — DB invariant: `assigned_to` must be an Agronomist
+
+**New file:** `supabase/migrations/202606190001_assignment_targets_agronomist.sql`
+
+- `CREATE FUNCTION assert_assigned_to_is_agronomist()` — `SECURITY DEFINER`, `SET search_path = public`.
+  On `INSERT`/`UPDATE` of `organization_clients`, when `NEW.assigned_to IS NOT NULL`, require:
+  ```sql
+  EXISTS (
+    SELECT 1 FROM organization_members m
+    WHERE m.organization_id = NEW.organization_id
+      AND m.user_id = NEW.assigned_to
+      AND m.role = 'agronomist'
+  )
+  ```
+  else `RAISE EXCEPTION 'assigned_to must reference an agronomist member of the organization'`.
+- `CREATE TRIGGER trg_assignment_targets_agronomist BEFORE INSERT OR UPDATE OF assigned_to ON organization_clients FOR EACH ROW EXECUTE FUNCTION ...`.
+- Note: an Owner with `role='owner'` (even if also flagged `is_owner`) is intentionally **not**
+  a valid assignee. Owners/Admins reach all clients via admin access, not via assignment.
+
+**Verify:** after `apply_migration`, an `UPDATE ... SET assigned_to = <owner_id>` must fail; the
+existing agronomist assignment must still validate.
+
+## Step 2 — Shared app-level guard (friendly errors)
+
+**New file:** `src/lib/assignment-access.ts`
+
+- `export async function assertAssigneeIsAgronomist(admin, organizationId, assignedTo): Promise<{ ok: true } | { ok: false; error: string }>`
+  — returns ok for `assignedTo === null`; otherwise checks the `organization_members` row has
+  `role === 'agronomist'`. (Lift the inline logic currently in `assign/route.ts:80-106`.)
+
+## Step 3 — Make the three write paths agree
+
+1. **`src/app/api/organizations/assign/route.ts`** — replace the inline assignee check (lines
+   ~80-106) with `assertAssigneeIsAgronomist(...)`. Behaviour unchanged.
+2. **`src/app/api/invite/accept/route.ts`** (line ~263) — the new Client must only inherit the
+   inviter as assignee **when the inviter is an agronomist**:
+   - Look up the inviter's role in `invite.organization_id`.
+   - `assigned_to = inviterIsAgronomist ? invite.invited_by : null`.
+   - `assigned_by` can stay `invite.invited_by` (records who enrolled them, not who advises).
+3. **`src/app/api/organizations/add-client/route.ts`** (line ~188-200) — call
+   `assertAssigneeIsAgronomist(...)` before the upsert; return 400 on failure.
+
+## Step 4 — Surface the screen: Team → Members | Assignments
+
+- **`src/app/consultant/team/page.tsx`** — add a segmented tab header (Members | Assignments).
+  Render the **Assignments** tab/link **only** when `access.canViewAllFarmers` (owner/admin).
+  Keep the existing route `/consultant/team/assignments` as the Assignments target (a shared
+  tab-nav component rendered at the top of both pages is the least-invasive approach — no need to
+  merge the two page bodies).
+- **`src/app/consultant/team/assignments/page.tsx`** — keep its existing agronomist read-only
+  notice as defense-in-depth for anyone hitting the URL directly.
+- **`src/app/consultant/layout.tsx`** — the "Team" nav item's subtitle already reads
+  "Members & assignments"; no nav change required.
+
+## Step 5 — Telemetry (recommended freebie)
+
+- In `assignments/page.tsx` `submitAssignment`, emit `posthog.capture('consultant_farmer_assigned', { org_id, count, agronomist_id })` and a `consultant_farmer_unassigned` on the unassign path
+  (mirrors `consultant_farmer_list_viewed` / `consultant_team_viewed`).
+
+## Step 6 — Tests
+
+- **`src/lib/__tests__/assignment-access.test.ts`** (new) — agronomist → ok; owner/admin →
+  rejected; null → ok; non-member → rejected.
+- Extend invite-accept coverage: owner-inviter ⇒ `assigned_to = null`; agronomist-inviter ⇒
+  `assigned_to = inviter`.
+- Existing `farm-access.test.ts` / `consultant-query-service.test.ts` should stay green.
+
+## Step 7 — Verify
+
+- `bun run` typecheck + `vitest`.
+- Manual QA in `test-org`: open Team → Assignments (as owner) → assign/unassign the farmer;
+  invite a farmer as owner ⇒ lands **Unassigned**; (if feasible) invite as the agronomist ⇒
+  auto-assigned. Confirm the agronomist account does **not** see the Assignments tab.
+- DB spot-check: trigger rejects an owner/admin `assigned_to`.
+
+---
+
+## Out of scope (parking lot)
+
+- Broaden agronomist data access (journal / irrigation / spray / expenses / calculators).
+- Enrolment funnel to convert the other 202 farm-owners into Clients.
+- Per-farmer quick-assign from the directory/detail; member role-change UI; assignment workload
+  balancing & counts.

--- a/plans/agronomist-assignment-surface-harden.md
+++ b/plans/agronomist-assignment-surface-harden.md
@@ -19,8 +19,12 @@ Assignment, Enrolment, Farmer, Farm).
 - Assignment plumbing works end-to-end: `assign/route.ts`, `consultant-query-service.ts`
   (`getFarmerClients`/`validateFarmerClient`), `farm-access.ts` rule 3, and RLS.
 - `/consultant/team/assignments/page.tsx` is **fully built but orphaned** — no link reaches it.
-- Live DB: 2 orgs; `test-org` has 1 owner + 1 agronomist + 1 active client (already assigned to
-  the agronomist); `test-orgs` is empty. 203 farms, only 1 enrolled Client. **No bad data.**
+- Live DB: 2 orgs; `test-org` has 1 owner + 1 agronomist + 1 active client; `test-orgs` is empty.
+  203 farms, only 1 enrolled Client.
+  - **Correction (superseded):** this first pass reported "no bad data", but a later check found
+    that one active client was assigned to the **owner** (left by the old self-join RPC), not the
+    agronomist — i.e. one row violated the new invariant. `202606190001` backfills it to Unassigned
+    before the trigger enforces. See ADR-0001 (Consequences) and `202606190002`.
 
 ---
 
@@ -87,8 +91,12 @@ existing agronomist assignment must still validate.
 
 - **`src/lib/__tests__/assignment-access.test.ts`** (new) — agronomist → ok; owner/admin →
   rejected; null → ok; non-member → rejected.
-- Extend invite-accept coverage: owner-inviter ⇒ `assigned_to = null`; agronomist-inviter ⇒
-  `assigned_to = inviter`.
+- Invite-accept assignee rule: the inviter-role decision was extracted to `resolveInviteAssignee`
+  (in `assignment-access.ts`) and unit-tested there — owner/admin-inviter ⇒ `null`;
+  agronomist-inviter ⇒ inviter; null / non-member / lookup-error ⇒ `null`.
+  - **Follow-up (deferred):** full route-level integration tests for `POST /api/invite/accept`
+    (large mock surface: session, rate-limit, token claim, concurrent reads). The role decision
+    itself is now covered by the helper tests above, so this is hardening, not a gap in the rule.
 - Existing `farm-access.test.ts` / `consultant-query-service.test.ts` should stay green.
 
 ## Step 7 — Verify

--- a/plans/enrolment-funnel-activate-existing-farmers.md
+++ b/plans/enrolment-funnel-activate-existing-farmers.md
@@ -1,0 +1,88 @@
+# Plan — Enrolment funnel: activate existing farmers (Self-join by Join code)
+
+**Goal:** Let the consultant drive the existing-farmer Self-join funnel that the RN app already
+implements, and surface self-joined farmers so they get assigned.
+
+**Decided in grilling:**
+
+- Target: **activate existing farmers** (133 owners, 132 unenrolled, email-based, on RN) — not new-farmer acquisition.
+- Model: **Self-join by Join code** (org slug); farmer UI already built in `vinesight-rn`.
+- Self-join lands **Unassigned** (ADR-0001); the backend RPC is version-controlled (ADR-0002).
+- Consultant surface: a **Join-code card** on Command Center + Client Farmers.
+
+**Domain language:** `CONTEXT.md` — Join code, Self-join, Enrolment, Assignment.
+
+---
+
+## Status of each piece
+
+| Piece                                         | State                                                                         |
+| --------------------------------------------- | ----------------------------------------------------------------------------- |
+| RN Self-join UI (enter Join code in Settings) | **Built** (other repo)                                                        |
+| `join_organization_by_slug` RPC               | **Fixed + version-controlled in PR #169** (`202606190002`) — lands Unassigned |
+| Org Join codes (slug)                         | Exist, required at creation, unique                                           |
+| Consultant can see/share the Join code        | **Missing** ← P1                                                              |
+| Self-joined farmers visible to consultant     | Partially (they appear Unassigned in the directory) ← P2 makes it obvious     |
+
+> **P0 is already done in PR #169** (the RPC migration). P1/P2 below are a _separate_ PR.
+
+---
+
+## P1 — Join-code card (consultant onboarding surface)
+
+**Data:** the consultant UI needs the org's `name` + `slug`. `getConsultantAccess()` returns
+`organizationId` but not name/slug.
+
+- **Recommended:** extend `getConsultantAccess()` (`src/lib/consultant-access.ts`) to also return
+  `organizationName` and `joinCode` (slug) via a join: `.select('organization_id, role, is_owner, organizations(name, slug)')`.
+  Additive; the consultant layout already calls it once.
+- Alternative: a dedicated `getOrganizationJoinInfo(orgId)` fetch in the card.
+
+**Component:** `src/components/consultant/JoinCodeCard.tsx`
+
+- Shows the **Join code** prominently with a **Copy code** button.
+- **Copy invite message** button → a pre-written string from a pure, testable builder
+  `buildJoinMessage(orgName, joinCode)`:
+  > `Join "<orgName>" on VineSight. Open the app → Settings → Connect to consultant → enter code: <joinCode>`
+  > ⚠️ Confirm the exact farmer-side step labels against the RN Settings screen before finalizing copy.
+- Optional generic WhatsApp share anchor (`https://wa.me/?text=<encoded>`) mirroring `InviteFarmerDialog`'s pattern, but with no phone (consultant picks the recipient).
+- Telemetry: `consultant_join_code_copied`, `consultant_join_message_copied`.
+
+**Placement:**
+
+- `src/app/consultant/page.tsx` (Command Center) — a prominent "Onboard your farmers" card.
+- `src/app/consultant/farmers/page.tsx` (Client Farmers) — alongside the existing `InviteFarmerDialog` (which stays for the new-farmer phone path).
+- Visible to all consultant members (sharing a code is harmless); emphasis on Command Center.
+
+## P2 — Unassigned visibility (close the loop)
+
+When a farmer self-joins, they land Unassigned. Make that obvious so an Owner/Admin assigns them
+via the Team → Assignments screen (shipped in #169).
+
+- **Client Farmers** (`farmers/page.tsx`): add an **Unassigned** filter chip + a count badge
+  (`farmers.filter(f => !f.assigned_to).length`). Owner/admin only (`canViewAllFarmers`).
+- **Command Center** (`consultant/page.tsx`): a small stat "N farmers need an agronomist" linking to
+  the farmers list (or Team → Assignments).
+- No new backend; `getFarmerClients` already returns `assigned_to`.
+
+## Tests
+
+- `buildJoinMessage` unit test (pure function).
+- Light component sanity for `JoinCodeCard` (renders code, copy handler called).
+- Existing suites stay green.
+
+## Verify
+
+- `bun run typecheck` + `vitest` + lint.
+- Manual: Join code shows on Command Center + Farmers; copy works. In staging, a Self-join (RN, or
+  call `join_organization_by_slug` as a farmer) lands the farmer **Unassigned** and they appear in
+  the new filter; assigning them via Team → Assignments works end-to-end.
+
+---
+
+## Parking lot
+
+- New-farmer phone-invite conversion (0/7) — separate motion.
+- QR code / deep link for the Join code — needs an RN deep-link target (other repo).
+- Bulk onboarding (CSV / multi-share).
+- Reconcile the two Self-join paths: web Settings (`add-client`, by org name/id) vs RN (`join_organization_by_slug`, by slug). The web path already lands Unassigned, so it's ADR-0001-safe; dedupe later.

--- a/plans/enrolment-funnel-activate-existing-farmers.md
+++ b/plans/enrolment-funnel-activate-existing-farmers.md
@@ -52,7 +52,13 @@ implements, and surface self-joined farmers so they get assigned.
 
 - `src/app/consultant/page.tsx` (Command Center) — a prominent "Onboard your farmers" card.
 - `src/app/consultant/farmers/page.tsx` (Client Farmers) — alongside the existing `InviteFarmerDialog` (which stays for the new-farmer phone path).
-- Visible to all consultant members (sharing a code is harmless); emphasis on Command Center.
+- Visible to **all** consultant members — owner, admin, **and agronomist** (emphasis on Command
+  Center). **Decision (confirmed, deliberate):** an agronomist sharing the code creates Clients that
+  land Unassigned, i.e. work an owner/admin must pick up. That is acceptable and intended here —
+  maximising onboarding reach matters more, and the Unassigned surfaces (P2 + the Command-Center
+  nudge + Team → Assignments) exist precisely to catch and route that work. Revisit only if
+  agronomist-driven self-joins become a noise problem; gating the card to `canViewAllFarmers` is the
+  one-line lever.
 
 ## P2 — Unassigned visibility (close the loop)
 

--- a/src/app/api/invite/accept/route.ts
+++ b/src/app/api/invite/accept/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { getSupabaseAdmin } from '@/lib/supabase-admin'
 import { validateUserSession } from '@/lib/auth-utils'
 import { globalRateLimiter } from '@/lib/validation'
+import { resolveInviteAssignee } from '@/lib/assignment-access'
 
 // Binds an invited farmer to the inviting organization as an active client. Called from the
 // invited-farmer signup page right after the farmer verifies the OTP sent to their phone.
@@ -257,23 +258,16 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: true, message: 'Linked to organization' })
     }
 
-    // An Assignment may only ever target an agronomist. Inherit the inviter as the
-    // assigned agronomist only when they actually hold that role; an owner/admin invite
-    // lands the client Unassigned so the assignment screen's "Unassigned" signal stays
-    // trustworthy (see docs/adr/0001-assignment-targets-agronomist.md). assigned_by still
-    // records who enrolled them, regardless of role. A DB trigger backstops this.
-    let assignedAgronomist: string | null = null
-    if (invite.invited_by) {
-      const { data: inviterMembership } = await admin
-        .from('organization_members')
-        .select('role')
-        .eq('organization_id', invite.organization_id)
-        .eq('user_id', invite.invited_by)
-        .maybeSingle()
-      if (inviterMembership?.role === 'agronomist') {
-        assignedAgronomist = invite.invited_by
-      }
-    }
+    // An Assignment may only ever target an agronomist: inherit the inviter only when they
+    // hold that role, else land the client Unassigned so the assignment screen's "Unassigned"
+    // signal stays trustworthy. assigned_by still records who enrolled them, regardless of
+    // role. Shared with the assign/add-client paths and backstopped by a DB trigger. See
+    // docs/adr/0001-assignment-targets-agronomist.md.
+    const assignedAgronomist = await resolveInviteAssignee(
+      admin,
+      invite.organization_id,
+      invite.invited_by
+    )
 
     const { error: clientError } = await admin.from('organization_clients').insert({
       organization_id: invite.organization_id,

--- a/src/app/api/invite/accept/route.ts
+++ b/src/app/api/invite/accept/route.ts
@@ -251,16 +251,34 @@ export async function POST(request: NextRequest) {
     // Token claimed — link the farmer to the org. An already-active client of this org is a
     // benign duplicate/leftover-token re-accept: leave their row (and its assignment) intact
     // instead of re-asserting it, so a stray invite can't silently reassign them to a different
-    // staff member. Only a brand-new client gets a row, assigned to whoever sent the invite.
-    // (A deactivated row was already refused above, so existingClient is undefined or active.)
+    // staff member. Only a brand-new client gets a row. (A deactivated row was already refused
+    // above, so existingClient is undefined or active.)
     if (existingClient?.status === 'active') {
       return NextResponse.json({ success: true, message: 'Linked to organization' })
+    }
+
+    // An Assignment may only ever target an agronomist. Inherit the inviter as the
+    // assigned agronomist only when they actually hold that role; an owner/admin invite
+    // lands the client Unassigned so the assignment screen's "Unassigned" signal stays
+    // trustworthy (see docs/adr/0001-assignment-targets-agronomist.md). assigned_by still
+    // records who enrolled them, regardless of role. A DB trigger backstops this.
+    let assignedAgronomist: string | null = null
+    if (invite.invited_by) {
+      const { data: inviterMembership } = await admin
+        .from('organization_members')
+        .select('role')
+        .eq('organization_id', invite.organization_id)
+        .eq('user_id', invite.invited_by)
+        .maybeSingle()
+      if (inviterMembership?.role === 'agronomist') {
+        assignedAgronomist = invite.invited_by
+      }
     }
 
     const { error: clientError } = await admin.from('organization_clients').insert({
       organization_id: invite.organization_id,
       client_user_id: userId,
-      assigned_to: invite.invited_by ?? null,
+      assigned_to: assignedAgronomist,
       assigned_by: invite.invited_by ?? null,
       status: 'active'
     })

--- a/src/app/api/organizations/add-client/route.ts
+++ b/src/app/api/organizations/add-client/route.ts
@@ -4,6 +4,7 @@ import { cookies } from 'next/headers'
 import { z } from 'zod'
 import type { Database } from '@/types/database'
 import { getSupabaseAdmin } from '@/lib/supabase-admin'
+import { assertAssigneeIsAgronomist } from '@/lib/assignment-access'
 
 // P0: Validate input schema
 const AddClientSchema = z.object({
@@ -137,24 +138,17 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    // An Assignment may only target an agronomist (this previously checked org
+    // membership only). Shared with the assign + invite-accept paths and
+    // backstopped by a DB trigger.
     if (assignedTo) {
-      const { data: assigneeMembership, error: assigneeMembershipError } = await getSupabaseAdmin()
-        .from('organization_members')
-        .select('id')
-        .eq('organization_id', organizationId)
-        .eq('user_id', assignedTo)
-        .maybeSingle()
-
-      if (assigneeMembershipError) {
-        console.error('Error checking assigned agronomist membership:', assigneeMembershipError)
-        return NextResponse.json({ error: 'Failed to verify assigned agronomist' }, { status: 500 })
-      }
-
-      if (!assigneeMembership) {
-        return NextResponse.json(
-          { error: 'Assigned agronomist must belong to the organization' },
-          { status: 400 }
-        )
+      const assigneeCheck = await assertAssigneeIsAgronomist(
+        getSupabaseAdmin(),
+        organizationId,
+        assignedTo
+      )
+      if (!assigneeCheck.ok) {
+        return NextResponse.json({ error: assigneeCheck.error }, { status: assigneeCheck.status })
       }
     }
 

--- a/src/app/api/organizations/assign/route.ts
+++ b/src/app/api/organizations/assign/route.ts
@@ -4,6 +4,7 @@ import { cookies } from 'next/headers'
 import { z } from 'zod'
 import type { Database } from '@/types/database'
 import { getSupabaseAdmin } from '@/lib/supabase-admin'
+import { assertAssigneeIsAgronomist } from '@/lib/assignment-access'
 
 const AssignSchema = z.object({
   organizationId: z.string().uuid(),
@@ -75,33 +76,17 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    // If assigning to an agronomist, verify they belong to the organization
-    // and actually hold the agronomist role (not just any member).
+    // If assigning to an agronomist, verify they belong to the organization and
+    // actually hold the agronomist role (not just any member). Shared with the
+    // invite-accept and add-client paths and backstopped by a DB trigger.
     if (agronomistUserId) {
-      const { data: assigneeMembership, error: assigneeMembershipError } = await getSupabaseAdmin()
-        .from('organization_members')
-        .select('id, role')
-        .eq('organization_id', organizationId)
-        .eq('user_id', agronomistUserId)
-        .maybeSingle()
-
-      if (assigneeMembershipError) {
-        console.error('Error checking assigned agronomist membership:', assigneeMembershipError)
-        return NextResponse.json({ error: 'Failed to verify assigned agronomist' }, { status: 500 })
-      }
-
-      if (!assigneeMembership) {
-        return NextResponse.json(
-          { error: 'Assigned agronomist must belong to the organization' },
-          { status: 400 }
-        )
-      }
-
-      if (assigneeMembership.role !== 'agronomist') {
-        return NextResponse.json(
-          { error: 'Assigned user must have the agronomist role' },
-          { status: 400 }
-        )
+      const assigneeCheck = await assertAssigneeIsAgronomist(
+        getSupabaseAdmin(),
+        organizationId,
+        agronomistUserId
+      )
+      if (!assigneeCheck.ok) {
+        return NextResponse.json({ error: assigneeCheck.error }, { status: assigneeCheck.status })
       }
     }
 

--- a/src/app/consultant/team/assignments/page.tsx
+++ b/src/app/consultant/team/assignments/page.tsx
@@ -22,6 +22,8 @@ import { Loader2, Lock, Search, UserCog, Users } from 'lucide-react'
 import { getConsultantAccess, type ConsultantAccess } from '@/lib/consultant-access'
 import { getFarmerClients, type FarmerWithFarms } from '@/lib/consultant-query-service'
 import { listOrgMembers, type OrgMember } from '@/lib/team-service'
+import { TeamTabs } from '@/components/consultant/TeamTabs'
+import posthog from 'posthog-js'
 
 export default function FarmerAssignmentsPage() {
   const [access, setAccess] = useState<ConsultantAccess | null>(null)
@@ -156,6 +158,14 @@ export default function FarmerAssignmentsPage() {
           ? `Assigned ${count} farmer${count !== 1 ? 's' : ''} to ${targetAgronomistName}`
           : `Unassigned ${count} farmer${count !== 1 ? 's' : ''}`
       )
+      posthog.capture(
+        agronomistUserId ? 'consultant_farmer_assigned' : 'consultant_farmer_unassigned',
+        {
+          org_id: access.organizationId,
+          count,
+          agronomist_id: agronomistUserId ?? null
+        }
+      )
       await loadData()
     } catch (error) {
       console.error('Assignment failed:', error)
@@ -197,6 +207,8 @@ export default function FarmerAssignmentsPage() {
 
   return (
     <div className="space-y-6">
+      <TeamTabs canViewAllFarmers={access?.canViewAllFarmers ?? false} />
+
       {/* Header */}
       <div>
         <h1 className="text-2xl font-bold">Farmer Assignments</h1>

--- a/src/app/consultant/team/page.tsx
+++ b/src/app/consultant/team/page.tsx
@@ -41,6 +41,7 @@ import {
   type OrgMember,
   type PendingInvite
 } from '@/lib/team-service'
+import { TeamTabs } from '@/components/consultant/TeamTabs'
 
 type InviteRole = 'admin' | 'agronomist'
 
@@ -262,6 +263,8 @@ export default function TeamSettingsPage() {
 
   return (
     <div className="space-y-6">
+      <TeamTabs canViewAllFarmers={isAdmin} />
+
       {/* Header */}
       <div className="flex items-start justify-between gap-4">
         <div>

--- a/src/components/consultant/TeamTabs.tsx
+++ b/src/components/consultant/TeamTabs.tsx
@@ -15,7 +15,11 @@ const tabs = [
  * reachable. Assignments is an owner/admin tool, so the bar only appears when
  * the viewer can manage the whole org — agronomists see the Team page unchanged.
  */
-export function TeamTabs({ canViewAllFarmers }: { canViewAllFarmers: boolean }) {
+interface TeamTabsProps {
+  canViewAllFarmers: boolean
+}
+
+export function TeamTabs({ canViewAllFarmers }: TeamTabsProps) {
   const pathname = usePathname()
 
   if (!canViewAllFarmers) return null

--- a/src/components/consultant/TeamTabs.tsx
+++ b/src/components/consultant/TeamTabs.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { cn } from '@/lib/utils'
+
+const tabs = [
+  { label: 'Members', href: '/consultant/team' },
+  { label: 'Assignments', href: '/consultant/team/assignments' }
+]
+
+/**
+ * Sub-navigation for the Team section (Members | Assignments). Rendered at the
+ * top of both Team pages so the otherwise-orphaned Assignments screen is
+ * reachable. Assignments is an owner/admin tool, so the bar only appears when
+ * the viewer can manage the whole org — agronomists see the Team page unchanged.
+ */
+export function TeamTabs({ canViewAllFarmers }: { canViewAllFarmers: boolean }) {
+  const pathname = usePathname()
+
+  if (!canViewAllFarmers) return null
+
+  return (
+    <div className="border-b">
+      <nav className="-mb-px flex gap-1" aria-label="Team sections">
+        {tabs.map((tab) => {
+          const isActive = pathname === tab.href
+          return (
+            <Link
+              key={tab.href}
+              href={tab.href}
+              aria-current={isActive ? 'page' : undefined}
+              className={cn(
+                'border-b-2 px-4 py-2 text-sm font-medium transition-colors',
+                isActive
+                  ? 'border-primary text-foreground'
+                  : 'border-transparent text-muted-foreground hover:border-muted hover:text-foreground'
+              )}
+            >
+              {tab.label}
+            </Link>
+          )
+        })}
+      </nav>
+    </div>
+  )
+}

--- a/src/lib/__tests__/assignment-access.test.ts
+++ b/src/lib/__tests__/assignment-access.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { assertAssigneeIsAgronomist, resolveInviteAssignee } from '../assignment-access'
+import { assertAssigneeIsAgronomist, resolveInviteAssignee } from '@/lib/assignment-access'
 
 // The helper takes an admin Supabase client and runs:
 //   from('organization_members').select('role').eq().eq().maybeSingle()

--- a/src/lib/__tests__/assignment-access.test.ts
+++ b/src/lib/__tests__/assignment-access.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { assertAssigneeIsAgronomist } from '../assignment-access'
+import { assertAssigneeIsAgronomist, resolveInviteAssignee } from '../assignment-access'
 
 // The helper takes an admin Supabase client and runs:
 //   from('organization_members').select('role').eq().eq().maybeSingle()
@@ -62,5 +62,48 @@ describe('assertAssigneeIsAgronomist', () => {
       error: 'Failed to verify assigned agronomist',
       status: 500
     })
+  })
+})
+
+describe('resolveInviteAssignee', () => {
+  it('returns null for a missing inviter without hitting the database', async () => {
+    const { client, maybeSingle } = adminReturning({ data: null, error: null })
+
+    expect(await resolveInviteAssignee(client, 'org-1', null)).toBeNull()
+    expect(maybeSingle).not.toHaveBeenCalled()
+  })
+
+  it('inherits the inviter when they hold the agronomist role', async () => {
+    const { client } = adminReturning({ data: { role: 'agronomist' }, error: null })
+
+    expect(await resolveInviteAssignee(client, 'org-1', 'agro-1')).toBe('agro-1')
+  })
+
+  it('lands Unassigned when the inviter is an owner', async () => {
+    const { client } = adminReturning({ data: { role: 'owner' }, error: null })
+
+    expect(await resolveInviteAssignee(client, 'org-1', 'owner-1')).toBeNull()
+  })
+
+  it('lands Unassigned when the inviter is an admin', async () => {
+    const { client } = adminReturning({ data: { role: 'admin' }, error: null })
+
+    expect(await resolveInviteAssignee(client, 'org-1', 'admin-1')).toBeNull()
+  })
+
+  it('lands Unassigned when the inviter is not a member of the organization', async () => {
+    const { client } = adminReturning({ data: null, error: null })
+
+    expect(await resolveInviteAssignee(client, 'org-1', 'stranger')).toBeNull()
+  })
+
+  it('fails safe to Unassigned when the role lookup errors', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { client } = adminReturning({ data: null, error: { message: 'db down' } })
+
+    expect(await resolveInviteAssignee(client, 'org-1', 'agro-1')).toBeNull()
+    expect(errorSpy).toHaveBeenCalled()
+
+    errorSpy.mockRestore()
   })
 })

--- a/src/lib/__tests__/assignment-access.test.ts
+++ b/src/lib/__tests__/assignment-access.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest'
+import { assertAssigneeIsAgronomist } from '../assignment-access'
+
+// The helper takes an admin Supabase client and runs:
+//   from('organization_members').select('role').eq().eq().maybeSingle()
+// so a minimal chainable stub is enough. Typed via Parameters<> to avoid
+// pulling in the generated Database types / path aliases.
+type AdminClient = Parameters<typeof assertAssigneeIsAgronomist>[0]
+
+function adminReturning(result: { data: unknown; error: unknown }) {
+  const maybeSingle = vi.fn().mockResolvedValue(result)
+  const chain = {
+    select: () => chain,
+    eq: () => chain,
+    maybeSingle
+  }
+  return {
+    client: { from: () => chain } as unknown as AdminClient,
+    maybeSingle
+  }
+}
+
+describe('assertAssigneeIsAgronomist', () => {
+  it('allows a null assignee (Unassigned) without hitting the database', async () => {
+    const { client, maybeSingle } = adminReturning({ data: null, error: null })
+
+    expect(await assertAssigneeIsAgronomist(client, 'org-1', null)).toEqual({ ok: true })
+    expect(maybeSingle).not.toHaveBeenCalled()
+  })
+
+  it('allows an agronomist member of the organization', async () => {
+    const { client } = adminReturning({ data: { role: 'agronomist' }, error: null })
+
+    expect(await assertAssigneeIsAgronomist(client, 'org-1', 'agro-1')).toEqual({ ok: true })
+  })
+
+  it('rejects an owner/admin assignee — only agronomists may be assigned', async () => {
+    const { client } = adminReturning({ data: { role: 'admin' }, error: null })
+
+    expect(await assertAssigneeIsAgronomist(client, 'org-1', 'admin-1')).toEqual({
+      ok: false,
+      error: 'Assigned user must have the agronomist role',
+      status: 400
+    })
+  })
+
+  it('rejects an assignee who is not a member of the organization', async () => {
+    const { client } = adminReturning({ data: null, error: null })
+
+    expect(await assertAssigneeIsAgronomist(client, 'org-1', 'stranger')).toEqual({
+      ok: false,
+      error: 'Assigned agronomist must belong to the organization',
+      status: 400
+    })
+  })
+
+  it('surfaces a 500 when the membership lookup errors', async () => {
+    const { client } = adminReturning({ data: null, error: { message: 'db down' } })
+
+    expect(await assertAssigneeIsAgronomist(client, 'org-1', 'agro-1')).toEqual({
+      ok: false,
+      error: 'Failed to verify assigned agronomist',
+      status: 500
+    })
+  })
+})

--- a/src/lib/assignment-access.ts
+++ b/src/lib/assignment-access.ts
@@ -43,3 +43,39 @@ export async function assertAssigneeIsAgronomist(
 
   return { ok: true }
 }
+
+/**
+ * Resolve the Assignment target when a Farmer accepts an invite. The inviter is
+ * inherited as the assigned Agronomist only when they actually hold the
+ * `agronomist` role; an Owner/Admin invite (or any case we can't confirm) lands
+ * the Client **Unassigned** (`null`), to be assigned deliberately from
+ * Team → Assignments. Null always satisfies the assignment trigger, so this fails
+ * safe to Unassigned rather than blocking the accept. `assigned_by` is tracked
+ * separately by the caller — it records who enrolled the Farmer regardless of role.
+ * See docs/adr/0001-assignment-targets-agronomist.md.
+ */
+export async function resolveInviteAssignee(
+  admin: SupabaseClient<Database>,
+  organizationId: string,
+  invitedBy: string | null | undefined
+): Promise<string | null> {
+  if (!invitedBy) {
+    return null
+  }
+
+  const { data, error } = await admin
+    .from('organization_members')
+    .select('role')
+    .eq('organization_id', organizationId)
+    .eq('user_id', invitedBy)
+    .maybeSingle()
+
+  if (error) {
+    // Non-fatal: we couldn't confirm the inviter's role, so land Unassigned. The
+    // farmer is still linked; an Owner/Admin can assign them from Team → Assignments.
+    console.error('Error resolving invite assignee role:', error)
+    return null
+  }
+
+  return data?.role === 'agronomist' ? invitedBy : null
+}

--- a/src/lib/assignment-access.ts
+++ b/src/lib/assignment-access.ts
@@ -1,0 +1,45 @@
+import { type SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/types/database'
+
+export type AssigneeCheckResult = { ok: true } | { ok: false; error: string; status: 400 | 500 }
+
+/**
+ * Validate a proposed Assignment target (`organization_clients.assigned_to`).
+ *
+ * An Assignment may only ever target an Agronomist: `assignedTo` must be null
+ * (Unassigned) or a member holding the `agronomist` role in the SAME
+ * organization. This mirrors the database trigger
+ * (202606190001_assignment_targets_agronomist) so API routes can return a
+ * friendly message before the DB raises. See
+ * docs/adr/0001-assignment-targets-agronomist.md.
+ */
+export async function assertAssigneeIsAgronomist(
+  admin: SupabaseClient<Database>,
+  organizationId: string,
+  assignedTo: string | null | undefined
+): Promise<AssigneeCheckResult> {
+  if (!assignedTo) {
+    return { ok: true }
+  }
+
+  const { data, error } = await admin
+    .from('organization_members')
+    .select('role')
+    .eq('organization_id', organizationId)
+    .eq('user_id', assignedTo)
+    .maybeSingle()
+
+  if (error) {
+    return { ok: false, error: 'Failed to verify assigned agronomist', status: 500 }
+  }
+
+  if (!data) {
+    return { ok: false, error: 'Assigned agronomist must belong to the organization', status: 400 }
+  }
+
+  if (data.role !== 'agronomist') {
+    return { ok: false, error: 'Assigned user must have the agronomist role', status: 400 }
+  }
+
+  return { ok: true }
+}

--- a/src/lib/assignment-access.ts
+++ b/src/lib/assignment-access.ts
@@ -30,6 +30,9 @@ export async function assertAssigneeIsAgronomist(
     .maybeSingle()
 
   if (error) {
+    // Surface the underlying fault server-side; the caller only sees the 500. Mirrors
+    // resolveInviteAssignee and the inline checks this helper replaced.
+    console.error('Error verifying assigned agronomist role:', error)
     return { ok: false, error: 'Failed to verify assigned agronomist', status: 500 }
   }
 

--- a/supabase/migrations/202606190001_assignment_targets_agronomist.sql
+++ b/supabase/migrations/202606190001_assignment_targets_agronomist.sql
@@ -20,10 +20,14 @@ security definer
 set search_path = public
 as $$
 begin
-  -- Only validate when assigned_to is actually being set to a non-null value.
-  -- An UPDATE that doesn't change assigned_to (or sets it to NULL, e.g. the
-  -- unassign action or the FK ON DELETE SET NULL cascade) is always allowed.
-  if tg_op = 'UPDATE' and new.assigned_to is not distinct from old.assigned_to then
+  -- Re-validate whenever the assignee OR the owning organization changes — either can
+  -- break "assignee is an agronomist in THIS org" (e.g. moving the client to another org
+  -- while keeping the old org's agronomist). Skip only when BOTH are unchanged, so a
+  -- status/updated_at-only write, an unassign (assigned_to -> NULL), or the FK
+  -- ON DELETE SET NULL cascade still costs no role lookup.
+  if tg_op = 'UPDATE'
+     and new.assigned_to is not distinct from old.assigned_to
+     and new.organization_id is not distinct from old.organization_id then
     return new;
   end if;
 
@@ -69,6 +73,6 @@ where oc.assigned_to is not null
 drop trigger if exists trg_assignment_targets_agronomist on public.organization_clients;
 
 create trigger trg_assignment_targets_agronomist
-  before insert or update of assigned_to on public.organization_clients
+  before insert or update of assigned_to, organization_id on public.organization_clients
   for each row
   execute function public.assert_organization_client_assignee_is_agronomist();

--- a/supabase/migrations/202606190001_assignment_targets_agronomist.sql
+++ b/supabase/migrations/202606190001_assignment_targets_agronomist.sql
@@ -46,6 +46,26 @@ $$;
 
 revoke all on function public.assert_organization_client_assignee_is_agronomist() from public;
 
+-- One-time reconciliation, run before the trigger starts enforcing. Any assignment
+-- that predates this invariant is reset to Unassigned so the table is already
+-- compliant on deploy and the "Unassigned" signal the app relies on is trustworthy
+-- from the first day. The known offender is the old out-of-band
+-- join_organization_by_slug, which assigned every farmer Self-join to the org OWNER
+-- (see ADR-0002 / 202606190002); that left a production client assigned to a
+-- non-agronomist, which the trigger below would otherwise reject on the next write.
+-- Only assigned_to is nulled: assigned_by records WHO enrolled the farmer (provenance),
+-- not who advises them, and the trigger constrains only assigned_to.
+update public.organization_clients oc
+set assigned_to = null
+where oc.assigned_to is not null
+  and not exists (
+    select 1
+    from public.organization_members m
+    where m.organization_id = oc.organization_id
+      and m.user_id = oc.assigned_to
+      and m.role = 'agronomist'
+  );
+
 drop trigger if exists trg_assignment_targets_agronomist on public.organization_clients;
 
 create trigger trg_assignment_targets_agronomist

--- a/supabase/migrations/202606190001_assignment_targets_agronomist.sql
+++ b/supabase/migrations/202606190001_assignment_targets_agronomist.sql
@@ -1,0 +1,54 @@
+-- Invariant: an Assignment must target an Agronomist.
+--
+-- organization_clients.assigned_to names the single member responsible for a
+-- client (an enrolled farmer). Three write paths set it — the bulk assign API,
+-- invite-accept, and add-client — and only the bulk assign API checked the
+-- assignee's role. invite-accept in particular set assigned_to to whoever sent
+-- the invite, so an owner/admin invite produced a client "assigned" to a
+-- non-agronomist, making the Unassigned signal on the assignment screen
+-- untrustworthy.
+--
+-- This trigger is the unbypassable source of truth: assigned_to may only ever be
+-- NULL or a member holding the 'agronomist' role in the SAME organization. App
+-- routes keep their own checks for friendly error messages; this backstops every
+-- current and future path. See docs/adr/0001-assignment-targets-agronomist.md.
+
+create or replace function public.assert_organization_client_assignee_is_agronomist()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  -- Only validate when assigned_to is actually being set to a non-null value.
+  -- An UPDATE that doesn't change assigned_to (or sets it to NULL, e.g. the
+  -- unassign action or the FK ON DELETE SET NULL cascade) is always allowed.
+  if tg_op = 'UPDATE' and new.assigned_to is not distinct from old.assigned_to then
+    return new;
+  end if;
+
+  if new.assigned_to is not null and not exists (
+    select 1
+    from public.organization_members m
+    where m.organization_id = new.organization_id
+      and m.user_id = new.assigned_to
+      and m.role = 'agronomist'
+  ) then
+    raise exception
+      'assigned_to (%) must reference an agronomist member of organization %',
+      new.assigned_to, new.organization_id
+      using errcode = 'check_violation';
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function public.assert_organization_client_assignee_is_agronomist() from public;
+
+drop trigger if exists trg_assignment_targets_agronomist on public.organization_clients;
+
+create trigger trg_assignment_targets_agronomist
+  before insert or update of assigned_to on public.organization_clients
+  for each row
+  execute function public.assert_organization_client_assignee_is_agronomist();

--- a/supabase/migrations/202606190002_join_organization_by_slug_unassigned.sql
+++ b/supabase/migrations/202606190002_join_organization_by_slug_unassigned.sql
@@ -1,0 +1,146 @@
+-- Bring join_organization_by_slug under version control and make it consistent
+-- with the "an Assignment must target an Agronomist" invariant
+-- (202606190001_assignment_targets_agronomist + docs/adr/0001).
+--
+-- This RPC is the farmer-facing Self-join: a logged-in farmer enters an
+-- Organization's Join code (slug) in the app and is linked as an active Client.
+-- It previously lived ONLY in the live database (never in a migration) and set
+-- assigned_to = the org owner. Under the new trigger that owner assignment is
+-- rejected (an owner is not an agronomist), which would break every Self-join.
+--
+-- Fix: a Self-join lands the Client UNASSIGNED (assigned_to / assigned_by = null),
+-- exactly like an owner/admin invite-accept. An Owner/Admin then makes the
+-- Assignment from Team -> Assignments. Every other guard (staff-exclusion,
+-- one-active-org, removed-farmer, idempotency, TOCTOU race handling) is preserved
+-- verbatim from the live definition.
+
+create or replace function public.join_organization_by_slug(p_slug text)
+returns jsonb
+language plpgsql
+security definer
+set search_path to 'public'
+as $function$
+declare
+  v_org_id uuid;
+  v_org_name text;
+  v_existing_status text;
+  v_row_count int;
+begin
+  -- Must be called by a logged-in user. auth.uid() reads the caller's JWT; null under anon.
+  if auth.uid() is null then
+    return jsonb_build_object('ok', false, 'status', 'unauthenticated');
+  end if;
+
+  -- Resolve the org by slug. Trim + lowercase for typing tolerance (slugs are stored
+  -- lowercased already, but farmers mistype). Org must be active.
+  select id, name into v_org_id, v_org_name
+  from public.organizations
+  where lower(slug) = lower(btrim(p_slug))
+    and is_active = true
+  limit 1;
+
+  if v_org_id is null then
+    return jsonb_build_object('ok', false, 'status', 'not_found');
+  end if;
+
+  -- Staff/client roles are mutually exclusive GLOBALLY, not per-org. A consultant who is a
+  -- team member of ANY organization must not be inserted as another org's client: doing so
+  -- would (a) mix their staff and client roles and (b) have the profile-mirror update below
+  -- rewrite profiles.consultant_organization_id and sever their existing staff affiliation.
+  if exists (
+    select 1 from public.organization_members
+    where user_id = auth.uid()
+  ) then
+    return jsonb_build_object('ok', false, 'status', 'is_staff');
+  end if;
+
+  -- Is there already a client row for this farmer in THIS org (any status)?
+  select status into v_existing_status
+  from public.organization_clients
+  where organization_id = v_org_id and client_user_id = auth.uid()
+  limit 1;
+
+  -- Already an active client -> idempotent success (re-typing the code is a no-op).
+  -- Keep the profile mirror in sync in case it drifted.
+  if v_existing_status = 'active' then
+    update public.profiles set consultant_organization_id = v_org_id where id = auth.uid();
+    return jsonb_build_object(
+      'ok', true, 'status', 'already_joined',
+      'organization_name', v_org_name, 'organization_id', v_org_id
+    );
+  end if;
+
+  -- A deliberately-removed client must not reactivate themselves with the shared code.
+  -- Re-admitting a removed farmer is the consultant's decision, not the farmer's.
+  if v_existing_status = 'inactive' then
+    return jsonb_build_object('ok', false, 'status', 'removed');
+  end if;
+
+  -- A farmer can be an active client of only ONE org at a time. The partial unique index
+  -- idx_organization_clients_one_active_per_client enforces this at insert time; this check
+  -- gives a clean, specific message instead of a raw constraint violation.
+  if exists (
+    select 1 from public.organization_clients
+    where client_user_id = auth.uid()
+      and status = 'active'
+      and organization_id <> v_org_id
+  ) then
+    return jsonb_build_object('ok', false, 'status', 'already_in_other_org');
+  end if;
+
+  -- Insert a fresh active client, or reactivate a pre-existing 'pending' row for this org.
+  -- A Self-join lands UNASSIGNED: assigned_to / assigned_by are null so the farmer shows as
+  -- "Unassigned" in the directory and an Owner/Admin assigns an agronomist deliberately. This
+  -- keeps the row valid under trg_assignment_targets_agronomist (null is always allowed).
+  --
+  -- Race hardening (review M2/M3):
+  --  * The ON CONFLICT arm is guarded by `WHERE status <> 'inactive'` so an admin removal
+  --    that lands between our pre-check and this write cannot be clobbered back to 'active'
+  --    (TOCTOU on the removed-farmer path). If the guard rejects the update, no row is
+  --    modified and we return 'removed'.
+  --  * On reactivation we PRESERVE any existing assignment (coalesce keeps a non-null
+  --    assigned_to/assigned_by that an admin set earlier — already agronomist-valid).
+  --  * The whole write is wrapped in a unique_violation sub-block: a concurrent join / admin
+  --    add that creates an active client row in ANOTHER org between our pre-check and this
+  --    insert would otherwise throw raw SQLSTATE 23505 to the client; we translate it to a
+  --    clean 'already_in_other_org' status instead of a 500.
+  begin
+    insert into public.organization_clients
+      (organization_id, client_user_id, assigned_to, assigned_by, status)
+    values
+      (v_org_id, auth.uid(), null, null, 'active')
+    on conflict (organization_id, client_user_id) do update
+      set status = 'active',
+          assigned_to = coalesce(public.organization_clients.assigned_to, excluded.assigned_to),
+          assigned_by = coalesce(public.organization_clients.assigned_by, excluded.assigned_by),
+          updated_at = now()
+      where public.organization_clients.status <> 'inactive';
+
+    -- 0 rows affected means the ON CONFLICT guard rejected a reactivation of an 'inactive'
+    -- row that a concurrent admin removal created between our read and write.
+    get diagnostics v_row_count = row_count;
+    if v_row_count = 0 then
+      return jsonb_build_object('ok', false, 'status', 'removed');
+    end if;
+  exception
+    when unique_violation then
+      -- idx_organization_clients_one_active_per_client fired: a concurrent transaction
+      -- made this farmer an active client of another org between our pre-check and here.
+      return jsonb_build_object('ok', false, 'status', 'already_in_other_org');
+  end;
+
+  -- Sync the legacy profiles.consultant_organization_id mirror that older screens read.
+  update public.profiles
+  set consultant_organization_id = v_org_id
+  where id = auth.uid();
+
+  return jsonb_build_object(
+    'ok', true, 'status', 'joined',
+    'organization_name', v_org_name, 'organization_id', v_org_id
+  );
+end;
+$function$;
+
+-- Farmer-callable RPC: authenticated only (the function gates further on auth.uid()).
+revoke all on function public.join_organization_by_slug(text) from public, anon;
+grant execute on function public.join_organization_by_slug(text) to authenticated;


### PR DESCRIPTION
## What & why

The agronomist↔farmer **Assignment** already worked end-to-end (query scoping, `farm-access`, RLS), but:

1. **The management screen was orphaned** — nothing linked to `/consultant/team/assignments`, so an owner/admin had no clickable path to assign farmers.
2. **`assigned_to` could point at a non-agronomist** — `invite/accept` inherited *whoever sent the invite*, so an owner/admin invite produced a client "assigned" to a non-agronomist, making the **Unassigned** signal on the screen untrustworthy.

This PR surfaces the screen and makes an Assignment provably target an Agronomist.

## Changes

- **Surface:** Team page is now `Members | Assignments` tabs (`TeamTabs`), owner/admin only; agronomists are unchanged. Reuses the existing route.
- **Invariant — assignee must be an agronomist**, enforced in all three write paths via a shared guard `assertAssigneeIsAgronomist` (`assign`, `add-client`, `invite/accept`) and backstopped by a Postgres trigger. Owner/admin invites now land the client **Unassigned**.
- **Telemetry:** `consultant_farmer_assigned` / `consultant_farmer_unassigned`.
- **Docs:** `CONTEXT.md` glossary + `docs/adr/0001-assignment-targets-agronomist.md`.

## ⚠️ Deploy ordering

The migration **must apply with (not before) this code**. The old `invite/accept` writes `assigned_to = invited_by`; if the trigger goes live before this code deploys, an owner/admin-invited farmer accepting would be rejected by the trigger. Since the migration is in this PR, merging + deploying them together is the correct atomic unit. No data backfill needed (the one existing assignment already targets the agronomist).

## Testing

- `bun run test` — 130 passed (incl. 5 new guard tests)
- `bun run typecheck` — clean
- `eslint` on changed files — clean
- Not yet done: in-browser QA of the tab + a live invite flow.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces the Team → Assignments screen and enforces agronomist-only client assignments across all write paths. Owner/admin invites and farmer Self-join now land clients Unassigned; a Postgres trigger with a safety backfill and org-change revalidation guarantees the rule.

- **New Features**
  - Team page adds Members | Assignments tabs; Assignments is owner/admin-only.
  - Shared guard and invite resolver enforce agronomist-only assignees in `assign`, `add-client`, and `invite/accept`; invite acceptance inherits the inviter only if they are an agronomist.
  - Telemetry for assign/unassign; tests cover the guard and invite assignee resolution; guard logs DB errors for clearer failures.

- **Migration**
  - Postgres trigger ensures `organization_clients.assigned_to` is an agronomist in the same org (or NULL) and re-validates on updates to `assigned_to` or `organization_id`; includes a one-time backfill that nulls any non-agronomist assignments.
  - Version-controls and updates `join_organization_by_slug` to land Self-join clients Unassigned; ships alongside the trigger to avoid Self-join failures (ADR-0002).

<sup>Written for commit af0be7ae4005b96fd30f2590041fb6b454a97558. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ashish921998/Vinesight/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes
* **New Features**
  * Added Members/Assignments segmented tab navigation on consultant Team settings, including an Assignments view where permitted.
* **Bug Fixes**
  * Enforced agronomist-only client assignment targets.
  * Invite acceptance now auto-assigns only when the inviter is an agronomist; otherwise clients remain **Unassigned**.
  * Self-join now lands clients as **Unassigned** (with existing data reconciled to restore the signal).
* **Improvements**
  * Added analytics tracking for assignment and unassignment actions.
* **Tests**
  * Added coverage for agronomist assignee validation and invite-accept assignment decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->