### PR TITLE
Cache consultant server state with TanStack Query

### DIFF
--- a/docs/adr/0003-server-state-with-tanstack-query.md
+++ b/docs/adr/0003-server-state-with-tanstack-query.md
@@ -1,0 +1,41 @@
+---
+status: accepted
+---
+
+# Server state uses TanStack Query
+
+## Context
+
+The consultant workspace reads Supabase-backed data from several client pages: access, farmer
+clients, farmer profiles, farms, farm detail, and visits. Those pages had been hand-rolling
+`useState` plus `useEffect` fetches, so navigation through the consultant section repeated the
+same access and farmer queries and left each page responsible for its own loading, error, and
+refresh behavior.
+
+That pattern also created stale UI state. For example, toggling a farmer's paid status updated the
+button's local state, but the directory row still held the previous `isPaid` value in its local
+farmers array, so any re-render could restore stale data.
+
+## Decision
+
+Use `@tanstack/react-query` for Supabase-backed server state, starting with the consultant
+section. Query keys live in one factory under `src/lib/consultant-query-keys.ts`, and consultant
+hooks wrap the existing service functions rather than replacing the service layer.
+
+`AuthProvider` remains the owner of authentication/client context. We are not adding Redux,
+Zustand, Jotai, or another global client-state store. Revisit a client-state store only when the
+app needs an offline write queue or another genuinely global mutable client workflow.
+
+## Consequences
+
+- Consultant access is cached and shared by layout and pages, while preserving the deliberate
+  denied-vs-error distinction: a resolved non-consultant result is not treated as a transient
+  outage.
+- Farmer lists, profile data, farm data, and visits can be reused across consultant navigation and
+  precisely invalidated by key.
+- Recording a visit invalidates the farmer visits query instead of also prepending local state,
+  avoiding duplicate temporary rows.
+- Paid-status changes patch the cached farmer list after confirmation so directory rows do not
+  revert on re-render.
+- Farmer-facing pages, `/dashboard`, `/farms/*`, and broad `SupabaseService` call sites remain
+  out of scope for this rollout even though the provider is mounted globally.

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.89.0",
     "@supermemory/tools": "^1.3.64",
+    "@tanstack/react-query": "^5.0.0",
     "@tensorflow/tfjs": "^4.22.0",
     "@vercel/analytics": "^1.6.1",
     "ai": "^5.0.116",
@@ -80,6 +81,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.3",
     "@tailwindcss/postcss": "^4.1.18",
+    "@tanstack/react-query-devtools": "^5.0.0",
     "@types/bun": "^1.3.5",
     "@types/jspdf": "^1.3.3",
     "@types/node": "^20.19.27",

--- a/src/app/consultant/farmers/[farmerId]/farms/[farmId]/page.tsx
+++ b/src/app/consultant/farmers/[farmerId]/farms/[farmId]/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
-import { useParams, useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -18,7 +19,9 @@ import {
 } from 'lucide-react'
 import Image from 'next/image'
 import { toast } from 'sonner'
+import * as Sentry from '@sentry/nextjs'
 import type { LabTestRecord } from '@/types/lab-tests'
+import type { FarmDetail } from '@/lib/consultant-query-service'
 import {
   useConsultantAccess,
   useFarmDetail,
@@ -29,7 +32,6 @@ import { SupabaseService } from '@/lib/supabase-service'
 
 export default function ConsultantFarmPage() {
   const params = useParams()
-  const router = useRouter()
   const farmerId = params.farmerId as string
   const rawFarmId = parseInt(params.farmId as string, 10)
   const farmId = isNaN(rawFarmId) ? null : rawFarmId
@@ -44,42 +46,23 @@ export default function ConsultantFarmPage() {
   const isValidClient = validationQuery.data?.isValid ?? false
   const farmQuery = useFarmDetail(farmId, isValidClient)
   const profileQuery = useFarmerProfile(farmerId, isValidClient)
-  const farm = farmQuery.data ?? null
+  const farm = farmQuery.data?.user_id === farmerId ? farmQuery.data : null
   const farmerName = profileQuery.data?.full_name || 'Farmer'
-
-  useEffect(() => {
-    if (farmId !== null) return
-
-    toast.error('Invalid farm ID')
-    router.push(`/consultant/farmers/${farmerId}`)
-  }, [farmerId, farmId, router])
-
-  useEffect(() => {
-    if (!validationQuery.data || validationQuery.data.isValid) return
-
-    toast.error('Farmer not found or not authorized')
-    router.push('/consultant/farmers')
-  }, [router, validationQuery.data])
-
-  useEffect(() => {
-    if (!farmQuery.isSuccess || !farmId) return
-
-    if (!farmQuery.data || farmQuery.data.user_id !== farmerId) {
-      toast.error('Farm not found or does not belong to this farmer')
-      router.push(`/consultant/farmers/${farmerId}`)
-    }
-  }, [farmerId, farmId, farmQuery.data, farmQuery.isSuccess, router])
 
   useEffect(() => {
     const error = accessQuery.error ?? validationQuery.error ?? farmQuery.error ?? profileQuery.error
     if (!error) return
 
     console.error('Error loading farm data:', error)
+    Sentry.captureException(error, {
+      tags: { context: 'loadFarmDetail' },
+      extra: { farmerId, farmId }
+    })
     toast.error(error instanceof Error ? error.message : 'Failed to load farm data')
-  }, [accessQuery.error, validationQuery.error, farmQuery.error, profileQuery.error])
+  }, [accessQuery.error, validationQuery.error, farmQuery.error, profileQuery.error, farmerId, farmId])
 
   useEffect(() => {
-    if (!farmId || !isValidClient || !farm || farm.user_id !== farmerId) return
+    if (!farmId || !isValidClient || !farm) return
 
     let cancelled = false
 
@@ -108,12 +91,14 @@ export default function ConsultantFarmPage() {
     return () => {
       cancelled = true
     }
-  }, [farmerId, farmId, farm, isValidClient])
+  }, [farmId, farm, isValidClient])
 
   const loading =
     accessQuery.isPending ||
     validationQuery.isPending ||
-    (isValidClient && (farmQuery.isPending || profileQuery.isPending || labTestsLoading))
+    (isValidClient &&
+      farmId != null &&
+      (farmQuery.isPending || profileQuery.isPending || labTestsLoading))
 
   if (loading) {
     return (
@@ -127,206 +112,271 @@ export default function ConsultantFarmPage() {
   }
 
   if (!farm) {
-    return (
-      <div className="space-y-6">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => router.push(`/consultant/farmers/${farmerId}`)}
-          className="flex items-center gap-2 -ml-2"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Back to Farmer
-        </Button>
-        <Card>
-          <CardContent className="flex flex-col items-center justify-center py-12">
-            <MapPin className="h-12 w-12 text-muted-foreground mb-4" />
-            <h2 className="text-xl font-semibold mb-2">Farm Not Found</h2>
-            <p className="text-muted-foreground">
-              This farm could not be found or does not belong to this farmer.
-            </p>
-          </CardContent>
-        </Card>
-      </div>
-    )
+    return <FarmNotFound farmerId={farmerId} />
   }
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="space-y-2">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => router.push(`/consultant/farmers/${farmerId}`)}
-          className="flex items-center gap-2 -ml-2"
-        >
+      <FarmHeader farm={farm} farmerId={farmerId} farmerName={farmerName} />
+      <FarmInfoCard farm={farm} farmerName={farmerName} />
+      <SoilPropertiesCard farm={farm} />
+      <LabTestsSection petioleTests={petioleTests} soilTests={soilTests} />
+    </div>
+  )
+}
+
+function FarmNotFound({ farmerId }: { farmerId: string }) {
+  return (
+    <div className="space-y-6">
+      <Button asChild variant="ghost" size="sm" className="flex items-center gap-2 -ml-2">
+        <Link href={`/consultant/farmers/${farmerId}`}>
+          <ArrowLeft className="h-4 w-4" />
+          Back to Farmer
+        </Link>
+      </Button>
+      <Card>
+        <CardContent className="flex flex-col items-center justify-center py-12">
+          <MapPin className="h-12 w-12 text-muted-foreground mb-4" />
+          <h2 className="text-xl font-semibold mb-2">Farm Not Found</h2>
+          <p className="text-muted-foreground">
+            This farm could not be found or does not belong to this farmer.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function FarmHeader({
+  farm,
+  farmerId,
+  farmerName
+}: {
+  farm: FarmDetail
+  farmerId: string
+  farmerName: string
+}) {
+  return (
+    <div className="space-y-2">
+      <Button asChild variant="ghost" size="sm" className="flex items-center gap-2 -ml-2">
+        <Link href={`/consultant/farmers/${farmerId}`}>
           <ArrowLeft className="h-4 w-4" />
           Back to {farmerName}
-        </Button>
-        <div className="flex items-center gap-3">
-          <Grape className="h-8 w-8 text-purple-600" />
+        </Link>
+      </Button>
+      <div className="flex items-center gap-3">
+        <Grape className="h-8 w-8 text-purple-600" />
+        <div>
+          <h1 className="text-2xl sm:text-3xl font-bold">{farm.name}</h1>
+          <p className="text-muted-foreground flex items-center gap-1">
+            <MapPin className="h-4 w-4" />
+            {farm.region}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function FarmInfoCard({ farm, farmerName }: { farm: FarmDetail; farmerName: string }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Farm Details</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
           <div>
-            <h1 className="text-2xl sm:text-3xl font-bold">{farm.name}</h1>
-            <p className="text-muted-foreground flex items-center gap-1">
-              <MapPin className="h-4 w-4" />
-              {farm.region}
+            <p className="text-sm text-muted-foreground">Variety</p>
+            <p className="font-medium">{farm.crop_variety || 'N/A'}</p>
+          </div>
+          <div>
+            <p className="text-sm text-muted-foreground">Area</p>
+            <p className="font-medium">{farm.area ? `${farm.area} acres` : 'N/A'}</p>
+          </div>
+          <div>
+            <p className="text-sm text-muted-foreground">Last Pruning</p>
+            <p className="font-medium flex items-center gap-1">
+              <Calendar className="h-3.5 w-3.5" />
+              {farm.date_of_pruning ? new Date(farm.date_of_pruning).toLocaleDateString() : 'N/A'}
+            </p>
+          </div>
+          <div>
+            <p className="text-sm text-muted-foreground">Owner</p>
+            <p className="font-medium">{farmerName}</p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function SoilPropertiesCard({ farm }: { farm: FarmDetail }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <TestTube className="h-5 w-5 text-amber-600" />
+          Soil Properties
+        </CardTitle>
+        <CardDescription>Physical and chemical soil characteristics</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+          <div>
+            <p className="text-sm text-muted-foreground">Texture Class</p>
+            <p className="font-medium">{farm.soil_texture_class || 'N/A'}</p>
+          </div>
+          <div>
+            <p className="text-sm text-muted-foreground">Bulk Density</p>
+            <p className="font-medium">
+              {farm.bulk_density ? `${farm.bulk_density} g/ml` : 'N/A'}
+            </p>
+          </div>
+          <div>
+            <p className="text-sm text-muted-foreground">CEC</p>
+            <p className="font-medium">
+              {farm.cation_exchange_capacity
+                ? `${farm.cation_exchange_capacity} meq/100g`
+                : 'N/A'}
+            </p>
+          </div>
+          <div>
+            <p className="text-sm text-muted-foreground">Water Retention</p>
+            <p className="font-medium">
+              {farm.soil_water_retention ? `${farm.soil_water_retention} mm/m` : 'N/A'}
             </p>
           </div>
         </div>
-      </div>
 
-      {/* Farm Info Card */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Farm Details</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-            <div>
-              <p className="text-sm text-muted-foreground">Variety</p>
-              <p className="font-medium">{farm.crop_variety || 'N/A'}</p>
-            </div>
-            <div>
-              <p className="text-sm text-muted-foreground">Area</p>
-              <p className="font-medium">{farm.area ? `${farm.area} acres` : 'N/A'}</p>
-            </div>
-            <div>
-              <p className="text-sm text-muted-foreground">Last Pruning</p>
-              <p className="font-medium flex items-center gap-1">
-                <Calendar className="h-3.5 w-3.5" />
-                {farm.date_of_pruning ? new Date(farm.date_of_pruning).toLocaleDateString() : 'N/A'}
-              </p>
-            </div>
-            <div>
-              <p className="text-sm text-muted-foreground">Owner</p>
-              <p className="font-medium">{farmerName}</p>
+        {(farm.sand_percentage || farm.silt_percentage || farm.clay_percentage) && (
+          <div className="mt-6">
+            <p className="text-sm font-medium text-muted-foreground mb-3">Soil Composition</p>
+            <div className="grid grid-cols-3 gap-4">
+              <SoilCompositionValue
+                label="Sand"
+                value={farm.sand_percentage}
+                className="bg-amber-50 text-amber-700"
+                labelClassName="text-amber-600"
+              />
+              <SoilCompositionValue
+                label="Silt"
+                value={farm.silt_percentage}
+                className="bg-stone-100 text-stone-700"
+                labelClassName="text-stone-600"
+              />
+              <SoilCompositionValue
+                label="Clay"
+                value={farm.clay_percentage}
+                className="bg-orange-50 text-orange-700"
+                labelClassName="text-orange-600"
+              />
             </div>
           </div>
-        </CardContent>
-      </Card>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
 
-      {/* Soil Properties Card */}
+function SoilCompositionValue({
+  className,
+  label,
+  labelClassName,
+  value
+}: {
+  className: string
+  label: string
+  labelClassName: string
+  value: number | null
+}) {
+  return (
+    <div className={`rounded-lg p-3 text-center ${className}`}>
+      <p className="text-2xl font-bold">{value ?? '-'}%</p>
+      <p className={`text-sm ${labelClassName}`}>{label}</p>
+    </div>
+  )
+}
+
+function LabTestsSection({
+  petioleTests,
+  soilTests
+}: {
+  petioleTests: LabTestRecord[]
+  soilTests: LabTestRecord[]
+}) {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold">Lab Test Analysis</h2>
+
+      <Tabs defaultValue="soil" className="w-full">
+        <TabsList className="grid w-full grid-cols-2">
+          <TabsTrigger value="soil" className="flex items-center gap-2">
+            <TestTube className="h-4 w-4" />
+            Soil Tests ({soilTests.length})
+          </TabsTrigger>
+          <TabsTrigger value="petiole" className="flex items-center gap-2">
+            <Leaf className="h-4 w-4" />
+            Petiole Tests ({petioleTests.length})
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="soil" className="space-y-4">
+          <TestList
+            emptyIcon="soil"
+            emptyText="No soil test records found for this farm."
+            emptyTitle="No Soil Tests"
+            tests={soilTests}
+            type="soil"
+          />
+        </TabsContent>
+
+        <TabsContent value="petiole" className="space-y-4">
+          <TestList
+            emptyIcon="petiole"
+            emptyText="No petiole test records found for this farm."
+            emptyTitle="No Petiole Tests"
+            tests={petioleTests}
+            type="petiole"
+          />
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}
+
+function TestList({
+  emptyIcon,
+  emptyText,
+  emptyTitle,
+  tests,
+  type
+}: {
+  emptyIcon: 'soil' | 'petiole'
+  emptyText: string
+  emptyTitle: string
+  tests: LabTestRecord[]
+  type: 'soil' | 'petiole'
+}) {
+  const EmptyIcon = emptyIcon === 'soil' ? TestTube : Leaf
+
+  if (tests.length === 0) {
+    return (
       <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <TestTube className="h-5 w-5 text-amber-600" />
-            Soil Properties
-          </CardTitle>
-          <CardDescription>Physical and chemical soil characteristics</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-            <div>
-              <p className="text-sm text-muted-foreground">Texture Class</p>
-              <p className="font-medium">{farm.soil_texture_class || 'N/A'}</p>
-            </div>
-            <div>
-              <p className="text-sm text-muted-foreground">Bulk Density</p>
-              <p className="font-medium">
-                {farm.bulk_density ? `${farm.bulk_density} g/ml` : 'N/A'}
-              </p>
-            </div>
-            <div>
-              <p className="text-sm text-muted-foreground">CEC</p>
-              <p className="font-medium">
-                {farm.cation_exchange_capacity
-                  ? `${farm.cation_exchange_capacity} meq/100g`
-                  : 'N/A'}
-              </p>
-            </div>
-            <div>
-              <p className="text-sm text-muted-foreground">Water Retention</p>
-              <p className="font-medium">
-                {farm.soil_water_retention ? `${farm.soil_water_retention} mm/m` : 'N/A'}
-              </p>
-            </div>
-          </div>
-
-          {/* Soil Composition */}
-          {(farm.sand_percentage || farm.silt_percentage || farm.clay_percentage) && (
-            <div className="mt-6">
-              <p className="text-sm font-medium text-muted-foreground mb-3">Soil Composition</p>
-              <div className="grid grid-cols-3 gap-4">
-                <div className="bg-amber-50 rounded-lg p-3 text-center">
-                  <p className="text-2xl font-bold text-amber-700">
-                    {farm.sand_percentage ?? '-'}%
-                  </p>
-                  <p className="text-sm text-amber-600">Sand</p>
-                </div>
-                <div className="bg-stone-100 rounded-lg p-3 text-center">
-                  <p className="text-2xl font-bold text-stone-700">
-                    {farm.silt_percentage ?? '-'}%
-                  </p>
-                  <p className="text-sm text-stone-600">Silt</p>
-                </div>
-                <div className="bg-orange-50 rounded-lg p-3 text-center">
-                  <p className="text-2xl font-bold text-orange-700">
-                    {farm.clay_percentage ?? '-'}%
-                  </p>
-                  <p className="text-sm text-orange-600">Clay</p>
-                </div>
-              </div>
-            </div>
-          )}
+        <CardContent className="flex flex-col items-center justify-center py-12">
+          <EmptyIcon className="h-12 w-12 text-muted-foreground mb-4" />
+          <h3 className="text-lg font-semibold mb-2">{emptyTitle}</h3>
+          <p className="text-muted-foreground">{emptyText}</p>
         </CardContent>
       </Card>
+    )
+  }
 
-      {/* Lab Tests Section */}
-      <div className="space-y-4">
-        <h2 className="text-xl font-semibold">Lab Test Analysis</h2>
-
-        <Tabs defaultValue="soil" className="w-full">
-          <TabsList className="grid w-full grid-cols-2">
-            <TabsTrigger value="soil" className="flex items-center gap-2">
-              <TestTube className="h-4 w-4" />
-              Soil Tests ({soilTests.length})
-            </TabsTrigger>
-            <TabsTrigger value="petiole" className="flex items-center gap-2">
-              <Leaf className="h-4 w-4" />
-              Petiole Tests ({petioleTests.length})
-            </TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="soil" className="space-y-4">
-            {soilTests.length === 0 ? (
-              <Card>
-                <CardContent className="flex flex-col items-center justify-center py-12">
-                  <TestTube className="h-12 w-12 text-muted-foreground mb-4" />
-                  <h3 className="text-lg font-semibold mb-2">No Soil Tests</h3>
-                  <p className="text-muted-foreground">No soil test records found for this farm.</p>
-                </CardContent>
-              </Card>
-            ) : (
-              <div className="grid gap-4">
-                {soilTests.map((test) => (
-                  <TestCard key={test.id} test={test} type="soil" />
-                ))}
-              </div>
-            )}
-          </TabsContent>
-
-          <TabsContent value="petiole" className="space-y-4">
-            {petioleTests.length === 0 ? (
-              <Card>
-                <CardContent className="flex flex-col items-center justify-center py-12">
-                  <Leaf className="h-12 w-12 text-muted-foreground mb-4" />
-                  <h3 className="text-lg font-semibold mb-2">No Petiole Tests</h3>
-                  <p className="text-muted-foreground">
-                    No petiole test records found for this farm.
-                  </p>
-                </CardContent>
-              </Card>
-            ) : (
-              <div className="grid gap-4">
-                {petioleTests.map((test) => (
-                  <TestCard key={test.id} test={test} type="petiole" />
-                ))}
-              </div>
-            )}
-          </TabsContent>
-        </Tabs>
-      </div>
+  return (
+    <div className="grid gap-4">
+      {tests.map((test) => (
+        <TestCard key={test.id} test={test} type={type} />
+      ))}
     </div>
   )
 }

--- a/src/app/consultant/farmers/[farmerId]/farms/[farmId]/page.tsx
+++ b/src/app/consultant/farmers/[farmerId]/farms/[farmId]/page.tsx
@@ -19,12 +19,12 @@ import {
 import Image from 'next/image'
 import { toast } from 'sonner'
 import type { LabTestRecord } from '@/types/lab-tests'
-import { getConsultantAccess } from '@/lib/consultant-access'
 import {
-  validateFarmerClient,
-  getFarmDetail,
-  type FarmDetail
-} from '@/lib/consultant-query-service'
+  useConsultantAccess,
+  useFarmDetail,
+  useFarmerProfile,
+  useValidatedFarmerClient
+} from '@/hooks/consultant/useConsultantQueries'
 import { SupabaseService } from '@/lib/supabase-service'
 
 export default function ConsultantFarmPage() {
@@ -34,67 +34,86 @@ export default function ConsultantFarmPage() {
   const rawFarmId = parseInt(params.farmId as string, 10)
   const farmId = isNaN(rawFarmId) ? null : rawFarmId
 
-  const [loading, setLoading] = useState(true)
-  const [farm, setFarm] = useState<FarmDetail | null>(null)
   const [soilTests, setSoilTests] = useState<LabTestRecord[]>([])
   const [petioleTests, setPetioleTests] = useState<LabTestRecord[]>([])
-  const [farmerName, setFarmerName] = useState<string>('')
+  const [labTestsLoading, setLabTestsLoading] = useState(false)
 
-  const loadData = useCallback(async () => {
-    try {
-      setLoading(true)
+  const accessQuery = useConsultantAccess()
+  const access = accessQuery.data ?? null
+  const validationQuery = useValidatedFarmerClient(access, farmerId)
+  const isValidClient = validationQuery.data?.isValid ?? false
+  const farmQuery = useFarmDetail(farmId, isValidClient)
+  const profileQuery = useFarmerProfile(farmerId, isValidClient)
+  const farm = farmQuery.data ?? null
+  const farmerName = profileQuery.data?.full_name || 'Farmer'
 
-      const access = await getConsultantAccess()
-      if (!access) {
-        toast.error('Not authenticated')
-        return
-      }
+  useEffect(() => {
+    if (farmId !== null) return
 
-      // Validate farmer belongs to org through organization_clients
-      const validation = await validateFarmerClient(access, farmerId)
-      if (!validation.isValid) {
-        toast.error('Farmer not found or not authorized')
-        router.push('/consultant/farmers')
-        return
-      }
-
-      // Validate farm belongs to farmer through farms.user_id
-      if (farmId === null) {
-        toast.error('Invalid farm ID')
-        router.push(`/consultant/farmers/${farmerId}`)
-        return
-      }
-
-      const farmData = await getFarmDetail(farmId)
-      if (!farmData || farmData.user_id !== farmerId) {
-        toast.error('Farm not found or does not belong to this farmer')
-        router.push(`/consultant/farmers/${farmerId}`)
-        return
-      }
-
-      setFarm(farmData)
-
-      // Fetch lab test records that are already safe to display
-      const [soilTestsData, petioleTestsData, profile] = await Promise.all([
-        SupabaseService.getSoilTestRecords(farmId),
-        SupabaseService.getPetioleTestRecords(farmId),
-        supabaseGetFarmerProfile(farmerId)
-      ])
-
-      setSoilTests((soilTestsData || []) as LabTestRecord[])
-      setPetioleTests((petioleTestsData || []) as LabTestRecord[])
-      setFarmerName(profile?.full_name || 'Farmer')
-    } catch (error) {
-      console.error('Error loading farm data:', error)
-      toast.error(error instanceof Error ? error.message : 'Failed to load farm data')
-    } finally {
-      setLoading(false)
-    }
+    toast.error('Invalid farm ID')
+    router.push(`/consultant/farmers/${farmerId}`)
   }, [farmerId, farmId, router])
 
   useEffect(() => {
-    loadData()
-  }, [loadData])
+    if (!validationQuery.data || validationQuery.data.isValid) return
+
+    toast.error('Farmer not found or not authorized')
+    router.push('/consultant/farmers')
+  }, [router, validationQuery.data])
+
+  useEffect(() => {
+    if (!farmQuery.isSuccess || !farmId) return
+
+    if (!farmQuery.data || farmQuery.data.user_id !== farmerId) {
+      toast.error('Farm not found or does not belong to this farmer')
+      router.push(`/consultant/farmers/${farmerId}`)
+    }
+  }, [farmerId, farmId, farmQuery.data, farmQuery.isSuccess, router])
+
+  useEffect(() => {
+    const error = accessQuery.error ?? validationQuery.error ?? farmQuery.error ?? profileQuery.error
+    if (!error) return
+
+    console.error('Error loading farm data:', error)
+    toast.error(error instanceof Error ? error.message : 'Failed to load farm data')
+  }, [accessQuery.error, validationQuery.error, farmQuery.error, profileQuery.error])
+
+  useEffect(() => {
+    if (!farmId || !isValidClient || !farm || farm.user_id !== farmerId) return
+
+    let cancelled = false
+
+    async function loadLabTests() {
+      try {
+        setLabTestsLoading(true)
+        const [soilTestsData, petioleTestsData] = await Promise.all([
+          SupabaseService.getSoilTestRecords(farmId as number),
+          SupabaseService.getPetioleTestRecords(farmId as number)
+        ])
+
+        if (cancelled) return
+        setSoilTests((soilTestsData || []) as LabTestRecord[])
+        setPetioleTests((petioleTestsData || []) as LabTestRecord[])
+      } catch (error) {
+        if (cancelled) return
+        console.error('Error loading lab tests:', error)
+        toast.error(error instanceof Error ? error.message : 'Failed to load lab tests')
+      } finally {
+        if (!cancelled) setLabTestsLoading(false)
+      }
+    }
+
+    loadLabTests()
+
+    return () => {
+      cancelled = true
+    }
+  }, [farmerId, farmId, farm, isValidClient])
+
+  const loading =
+    accessQuery.isPending ||
+    validationQuery.isPending ||
+    (isValidClient && (farmQuery.isPending || profileQuery.isPending || labTestsLoading))
 
   if (loading) {
     return (
@@ -480,16 +499,4 @@ function TestCard({ test, type }: { test: LabTestRecord; type: 'soil' | 'petiole
       </CardContent>
     </Card>
   )
-}
-
-// Inline helper to fetch farmer profile for the farm page header
-async function supabaseGetFarmerProfile(farmerId: string) {
-  const { getTypedSupabaseClient } = await import('@/lib/supabase')
-  const supabase = await getTypedSupabaseClient()
-  const { data } = await supabase
-    .from('profiles')
-    .select('full_name')
-    .eq('id', farmerId)
-    .maybeSingle()
-  return data
 }

--- a/src/app/consultant/farmers/[farmerId]/farms/[farmId]/page.tsx
+++ b/src/app/consultant/farmers/[farmerId]/farms/[farmId]/page.tsx
@@ -38,15 +38,16 @@ export default function ConsultantFarmPage() {
 
   const [soilTests, setSoilTests] = useState<LabTestRecord[]>([])
   const [petioleTests, setPetioleTests] = useState<LabTestRecord[]>([])
+  const [labTestsFarmId, setLabTestsFarmId] = useState<number | null>(null)
   const [labTestsLoading, setLabTestsLoading] = useState(false)
 
   const accessQuery = useConsultantAccess()
   const access = accessQuery.data ?? null
   const validationQuery = useValidatedFarmerClient(access, farmerId)
   const isValidClient = validationQuery.data?.isValid ?? false
-  const farmQuery = useFarmDetail(farmId, isValidClient)
+  const farmQuery = useFarmDetail(farmId, isValidClient, access)
   const profileQuery = useFarmerProfile(farmerId, isValidClient)
-  const farm = farmQuery.data?.user_id === farmerId ? farmQuery.data : null
+  const farm = isValidClient && farmQuery.data?.user_id === farmerId ? farmQuery.data : null
   const farmerName = profileQuery.data?.full_name || 'Farmer'
 
   useEffect(() => {
@@ -62,13 +63,20 @@ export default function ConsultantFarmPage() {
   }, [accessQuery.error, validationQuery.error, farmQuery.error, profileQuery.error, farmerId, farmId])
 
   useEffect(() => {
-    if (!farmId || !isValidClient || !farm) return
+    if (!farmId || !isValidClient || !farm) {
+      setSoilTests([])
+      setPetioleTests([])
+      setLabTestsFarmId(null)
+      setLabTestsLoading(false)
+      return
+    }
 
     let cancelled = false
 
     async function loadLabTests() {
       try {
         setLabTestsLoading(true)
+        setLabTestsFarmId(null)
         const [soilTestsData, petioleTestsData] = await Promise.all([
           SupabaseService.getSoilTestRecords(farmId as number),
           SupabaseService.getPetioleTestRecords(farmId as number)
@@ -77,8 +85,12 @@ export default function ConsultantFarmPage() {
         if (cancelled) return
         setSoilTests((soilTestsData || []) as LabTestRecord[])
         setPetioleTests((petioleTestsData || []) as LabTestRecord[])
+        setLabTestsFarmId(farm.id)
       } catch (error) {
         if (cancelled) return
+        setSoilTests([])
+        setPetioleTests([])
+        setLabTestsFarmId(null)
         console.error('Error loading lab tests:', error)
         toast.error(error instanceof Error ? error.message : 'Failed to load lab tests')
       } finally {
@@ -115,12 +127,15 @@ export default function ConsultantFarmPage() {
     return <FarmNotFound farmerId={farmerId} />
   }
 
+  const visibleSoilTests = labTestsFarmId === farm.id ? soilTests : []
+  const visiblePetioleTests = labTestsFarmId === farm.id ? petioleTests : []
+
   return (
     <div className="space-y-6">
       <FarmHeader farm={farm} farmerId={farmerId} farmerName={farmerName} />
       <FarmInfoCard farm={farm} farmerName={farmerName} />
       <SoilPropertiesCard farm={farm} />
-      <LabTestsSection petioleTests={petioleTests} soilTests={soilTests} />
+      <LabTestsSection petioleTests={visiblePetioleTests} soilTests={visibleSoilTests} />
     </div>
   )
 }

--- a/src/app/consultant/farmers/[farmerId]/page.tsx
+++ b/src/app/consultant/farmers/[farmerId]/page.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import type { ReactNode } from 'react'
 import { useParams } from 'next/navigation'
 import Link from 'next/link'
+import { useQueryClient } from '@tanstack/react-query'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -24,6 +25,7 @@ import {
   XCircle
 } from 'lucide-react'
 import {
+  farmerScope,
   useConsultantAccess,
   useFarmerFarms,
   useFarmerProfile,
@@ -37,11 +39,15 @@ import {
 } from '@/lib/consultant-visit-service'
 import { RecordVisitDialog } from '@/components/consultant/RecordVisitDialog'
 import { PaidToggleButton } from '@/components/consultant/PaidToggleButton'
+import { consultantKeys } from '@/lib/consultant-query-keys'
+import type { FarmerWithFarms, ValidatedFarmerClient } from '@/lib/consultant-query-service'
 import * as Sentry from '@sentry/nextjs'
 import posthog from 'posthog-js'
 
 export default function FarmerProfilePage() {
   const params = useParams()
+  const queryClient = useQueryClient()
+  const trackedProfileViewKeyRef = useRef<string | null>(null)
   const farmerId = params.farmerId as string
 
   const accessQuery = useConsultantAccess()
@@ -84,6 +90,10 @@ export default function FarmerProfilePage() {
   useEffect(() => {
     if (!access || !farmerQuery.data || !farmsQuery.data || !visitsQuery.data) return
 
+    const viewKey = `${access.userId}:${access.organizationId}:${farmerId}`
+    if (trackedProfileViewKeyRef.current === viewKey) return
+    trackedProfileViewKeyRef.current = viewKey
+
     posthog.capture('consultant_farmer_profile_viewed', {
       farmer_id: farmerId,
       org_id: access.organizationId,
@@ -92,6 +102,22 @@ export default function FarmerProfilePage() {
       visit_count: visitsQuery.data.length
     })
   }, [access, farmerId, farmerQuery.data, farmsQuery.data, visitsQuery.data])
+
+  const updateCachedPaymentStatus = (isPaid: boolean) => {
+    if (!access) return
+
+    const scope = farmerScope(access)
+
+    queryClient.setQueryData<ValidatedFarmerClient>(
+      consultantKeys.farmerValidation(farmerId, access.organizationId, scope),
+      (current) => (current ? { ...current, isPaid } : current)
+    )
+    queryClient.setQueryData<FarmerWithFarms[]>(
+      consultantKeys.farmers(access.organizationId, scope),
+      (current) =>
+        current?.map((farmer) => (farmer.id === farmerId ? { ...farmer, isPaid } : farmer))
+    )
+  }
 
   if (loading) {
     return (
@@ -164,6 +190,7 @@ export default function FarmerProfilePage() {
               clientRecordId={validation.clientRecordId}
               isPaid={validation.isPaid}
               size="default"
+              onChange={updateCachedPaymentStatus}
             />
           )}
           {access && (

--- a/src/app/consultant/farmers/[farmerId]/page.tsx
+++ b/src/app/consultant/farmers/[farmerId]/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect } from 'react'
+import type { ReactNode } from 'react'
 import { useParams } from 'next/navigation'
 import Link from 'next/link'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -22,15 +23,14 @@ import {
   MinusCircle,
   XCircle
 } from 'lucide-react'
-import { getConsultantAccess, type ConsultantAccess } from '@/lib/consultant-access'
 import {
-  validateFarmerClient,
-  getFarmerProfile,
-  getFarmerFarms,
-  type FarmerFarm
-} from '@/lib/consultant-query-service'
+  useConsultantAccess,
+  useFarmerFarms,
+  useFarmerProfile,
+  useFarmerVisits,
+  useValidatedFarmerClient
+} from '@/hooks/consultant/useConsultantQueries'
 import {
-  getVisitsForFarmer,
   followedStatusLabels,
   type Visit,
   type FollowedStatus
@@ -40,83 +40,58 @@ import { PaidToggleButton } from '@/components/consultant/PaidToggleButton'
 import * as Sentry from '@sentry/nextjs'
 import posthog from 'posthog-js'
 
-interface FarmerProfile {
-  id: string
-  full_name: string | null
-  email: string | null
-  phone: string | null
-}
-
 export default function FarmerProfilePage() {
   const params = useParams()
   const farmerId = params.farmerId as string
 
-  const [farmer, setFarmer] = useState<FarmerProfile | null>(null)
-  const [farms, setFarms] = useState<FarmerFarm[]>([])
-  const [loading, setLoading] = useState(true)
-  const [notFound, setNotFound] = useState(false)
-  const [access, setAccess] = useState<ConsultantAccess | null>(null)
-  const [clientRecordId, setClientRecordId] = useState<string | null>(null)
-  const [isPaid, setIsPaid] = useState(false)
-  const [visits, setVisits] = useState<Visit[]>([])
+  const accessQuery = useConsultantAccess()
+  const access = accessQuery.data ?? null
+  const validationQuery = useValidatedFarmerClient(access, farmerId)
+  const validation = validationQuery.data
+  const isValidClient = validation?.isValid ?? false
+  const farmerQuery = useFarmerProfile(farmerId, isValidClient)
+  const farmsQuery = useFarmerFarms(farmerId, isValidClient)
+  const visitsQuery = useFarmerVisits(isValidClient ? access : null, farmerId)
 
-  const loadFarmerProfile = useCallback(async () => {
-    try {
-      setLoading(true)
-      setNotFound(false)
-
-      const currentAccess = await getConsultantAccess()
-      if (!currentAccess) {
-        toast.error('Not authenticated')
-        return
-      }
-      setAccess(currentAccess)
-
-      // Validate farmer is an active client of the organization
-      // Validate agronomist assignment if current user is agronomist
-      const validation = await validateFarmerClient(currentAccess, farmerId)
-      if (!validation.isValid) {
-        setNotFound(true)
-        return
-      }
-      setClientRecordId(validation.clientRecordId)
-      setIsPaid(validation.isPaid)
-
-      const [profile, farmsData, visitsData] = await Promise.all([
-        getFarmerProfile(farmerId),
-        getFarmerFarms(farmerId),
-        getVisitsForFarmer(currentAccess, farmerId)
-      ])
-
-      if (!profile) {
-        setNotFound(true)
-        return
-      }
-
-      setFarmer(profile)
-      setFarms(farmsData)
-      setVisits(visitsData)
-      posthog.capture('consultant_farmer_profile_viewed', {
-        farmer_id: farmerId,
-        org_id: currentAccess.organizationId,
-        role: currentAccess.role,
-        farm_count: farmsData.length,
-        visit_count: visitsData.length
-      })
-    } catch (error) {
-      Sentry.captureException(error, {
-        tags: { context: 'loadFarmerProfile' },
-        extra: { farmerId }
-      })
-      toast.error(error instanceof Error ? error.message : 'Failed to load farmer profile')
-    } finally {
-      setLoading(false)
-    }
-  }, [farmerId])
+  const farmer = farmerQuery.data ?? null
+  const farms = farmsQuery.data ?? []
+  const visits = visitsQuery.data ?? []
+  const loading =
+    accessQuery.isPending ||
+    validationQuery.isPending ||
+    (isValidClient && (farmerQuery.isPending || farmsQuery.isPending || visitsQuery.isPending))
+  const notFound =
+    (!accessQuery.isPending && !accessQuery.isError && !access) ||
+    validation?.isValid === false ||
+    (isValidClient && farmerQuery.isSuccess && !farmer)
 
   useEffect(() => {
-    loadFarmerProfile()
-  }, [loadFarmerProfile])
+    const error =
+      accessQuery.error ??
+      validationQuery.error ??
+      farmerQuery.error ??
+      farmsQuery.error ??
+      visitsQuery.error
+    if (!error) return
+
+    Sentry.captureException(error, {
+      tags: { context: 'loadFarmerProfile' },
+      extra: { farmerId }
+    })
+    toast.error(error instanceof Error ? error.message : 'Failed to load farmer profile')
+  }, [accessQuery.error, validationQuery.error, farmerQuery.error, farmsQuery.error, visitsQuery.error, farmerId])
+
+  useEffect(() => {
+    if (!access || !farmerQuery.data || !farmsQuery.data || !visitsQuery.data) return
+
+    posthog.capture('consultant_farmer_profile_viewed', {
+      farmer_id: farmerId,
+      org_id: access.organizationId,
+      role: access.role,
+      farm_count: farmsQuery.data.length,
+      visit_count: visitsQuery.data.length
+    })
+  }, [access, farmerId, farmerQuery.data, farmsQuery.data, visitsQuery.data])
 
   if (loading) {
     return (
@@ -184,12 +159,11 @@ export default function FarmerProfilePage() {
           </div>
         </div>
         <div className="flex flex-wrap items-center gap-2">
-          {clientRecordId && (
+          {validation?.clientRecordId && (
             <PaidToggleButton
-              clientRecordId={clientRecordId}
-              isPaid={isPaid}
+              clientRecordId={validation.clientRecordId}
+              isPaid={validation.isPaid}
               size="default"
-              onChange={setIsPaid}
             />
           )}
           {access && (
@@ -197,7 +171,6 @@ export default function FarmerProfilePage() {
               access={access}
               farmerId={farmerId}
               farms={farms.map((f) => ({ id: f.id, name: f.name }))}
-              onRecorded={(visit) => setVisits((prev) => [visit, ...prev])}
             />
           )}
         </div>
@@ -257,7 +230,7 @@ export default function FarmerProfilePage() {
   )
 }
 
-const followedStatusIcon: Record<FollowedStatus, React.ReactNode> = {
+const followedStatusIcon: Record<FollowedStatus, ReactNode> = {
   followed: <CheckCircle2 className="h-4 w-4 text-green-600" />,
   partially_followed: <MinusCircle className="h-4 w-4 text-amber-600" />,
   not_followed: <XCircle className="h-4 w-4 text-red-600" />

--- a/src/app/consultant/farmers/page.tsx
+++ b/src/app/consultant/farmers/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { useQueryClient } from '@tanstack/react-query'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -31,7 +31,11 @@ import { JoinCodeCard } from '@/components/consultant/JoinCodeCard'
 import { PaidToggleButton } from '@/components/consultant/PaidToggleButton'
 import * as Sentry from '@sentry/nextjs'
 import posthog from 'posthog-js'
-import { useConsultantAccess, useFarmerClients } from '@/hooks/consultant/useConsultantQueries'
+import {
+  farmerScope,
+  useConsultantAccess,
+  useFarmerClients
+} from '@/hooks/consultant/useConsultantQueries'
 import { consultantKeys } from '@/lib/consultant-query-keys'
 import type { FarmerWithFarms } from '@/lib/consultant-query-service'
 
@@ -41,6 +45,7 @@ const ALL_REGIONS = '__all__'
 
 export default function FarmerDirectoryPage() {
   const queryClient = useQueryClient()
+  const trackedViewKeyRef = useRef<string | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
   const [regionFilter, setRegionFilter] = useState(ALL_REGIONS)
   const [unassignedOnly, setUnassignedOnly] = useState(false)
@@ -72,6 +77,10 @@ export default function FarmerDirectoryPage() {
   useEffect(() => {
     if (!access || !farmersQuery.data) return
 
+    const viewKey = `${access.userId}:${access.organizationId}`
+    if (trackedViewKeyRef.current === viewKey) return
+    trackedViewKeyRef.current = viewKey
+
     posthog.capture('consultant_farmer_list_viewed', {
       org_id: access.organizationId,
       role: access.role,
@@ -82,9 +91,8 @@ export default function FarmerDirectoryPage() {
   const updateCachedPaymentStatus = (clientRecordId: string, isPaid: boolean) => {
     if (!access) return
 
-    const scope = access.canViewAllFarmers ? 'all' : access.userId
     queryClient.setQueryData<FarmerWithFarms[]>(
-      consultantKeys.farmers(access.organizationId, scope),
+      consultantKeys.farmers(access.organizationId, farmerScope(access)),
       (current) =>
         current?.map((farmer) =>
           farmer.clientRecordId === clientRecordId ? { ...farmer, isPaid } : farmer
@@ -93,16 +101,14 @@ export default function FarmerDirectoryPage() {
   }
 
   // Unique regions across all farmers' farms, for the region filter dropdown.
-  const regions = useMemo(() => {
-    const set = new Set<string>()
-    for (const farmer of farmers) {
-      for (const farm of farmer.farms) {
-        const region = farm.region?.trim()
-        if (region && region !== ALL_REGIONS) set.add(region)
-      }
+  const regionSet = new Set<string>()
+  for (const farmer of farmers) {
+    for (const farm of farmer.farms) {
+      const region = farm.region?.trim()
+      if (region && region !== ALL_REGIONS) regionSet.add(region)
     }
-    return Array.from(set).sort((a, b) => a.localeCompare(b))
-  }, [farmers])
+  }
+  const regions = Array.from(regionSet).sort((a, b) => a.localeCompare(b))
 
   // Derive the effective region during render: if the selected region is no
   // longer present (e.g. the only farmer in it was removed or reassigned), fall
@@ -113,10 +119,7 @@ export default function FarmerDirectoryPage() {
   // Count of org clients with no agronomist assigned. Only meaningful for
   // owner/admin, whose directory includes the whole org; agronomists only ever
   // see their own assigned farmers, so the control below is gated on access.
-  const unassignedCount = useMemo(
-    () => farmers.filter((farmer) => !farmer.assigned_to).length,
-    [farmers]
-  )
+  const unassignedCount = farmers.filter((farmer) => !farmer.assigned_to).length
 
   // Owner/admin only, and only worth showing when there's at least one.
   const showUnassignedFilter = Boolean(access?.canViewAllFarmers) && unassignedCount > 0
@@ -127,30 +130,28 @@ export default function FarmerDirectoryPage() {
   const effectiveUnassignedOnly = showUnassignedFilter && unassignedOnly
 
   // Filtered farmers
-  const filteredFarmers = useMemo(() => {
-    return farmers.filter((farmer) => {
-      // Search filter
-      if (searchQuery) {
-        const query = searchQuery.toLowerCase()
-        const nameMatch = farmer.full_name?.toLowerCase().includes(query)
-        const farmMatch = farmer.farms.some((f) => f.name?.toLowerCase().includes(query))
-        if (!nameMatch && !farmMatch) return false
-      }
+  const filteredFarmers = farmers.filter((farmer) => {
+    // Search filter
+    if (searchQuery) {
+      const query = searchQuery.toLowerCase()
+      const nameMatch = farmer.full_name?.toLowerCase().includes(query)
+      const farmMatch = farmer.farms.some((f) => f.name?.toLowerCase().includes(query))
+      if (!nameMatch && !farmMatch) return false
+    }
 
-      // Region filter — keep the farmer if any of their farms is in the region
-      if (effectiveRegion !== ALL_REGIONS) {
-        const regionMatch = farmer.farms.some((f) => f.region?.trim() === effectiveRegion)
-        if (!regionMatch) return false
-      }
+    // Region filter — keep the farmer if any of their farms is in the region
+    if (effectiveRegion !== ALL_REGIONS) {
+      const regionMatch = farmer.farms.some((f) => f.region?.trim() === effectiveRegion)
+      if (!regionMatch) return false
+    }
 
-      // Unassigned filter — restrict to farmers with no agronomist assigned
-      if (effectiveUnassignedOnly && farmer.assigned_to) {
-        return false
-      }
+    // Unassigned filter — restrict to farmers with no agronomist assigned
+    if (effectiveUnassignedOnly && farmer.assigned_to) {
+      return false
+    }
 
-      return true
-    })
-  }, [farmers, searchQuery, effectiveRegion, effectiveUnassignedOnly])
+    return true
+  })
 
   if (loading) {
     return (

--- a/src/app/consultant/farmers/page.tsx
+++ b/src/app/consultant/farmers/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useEffect, useState, useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
+import { useQueryClient } from '@tanstack/react-query'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Input } from '@/components/ui/input'
@@ -25,52 +26,70 @@ import {
   ChevronRight,
   MapPin
 } from 'lucide-react'
-import { getConsultantAccess, type ConsultantAccess } from '@/lib/consultant-access'
-import { getFarmerClients, type FarmerWithFarms } from '@/lib/consultant-query-service'
 import { InviteFarmerDialog } from '@/components/consultant/InviteFarmerDialog'
 import { JoinCodeCard } from '@/components/consultant/JoinCodeCard'
 import { PaidToggleButton } from '@/components/consultant/PaidToggleButton'
 import * as Sentry from '@sentry/nextjs'
 import posthog from 'posthog-js'
+import { useConsultantAccess, useFarmerClients } from '@/hooks/consultant/useConsultantQueries'
+import { consultantKeys } from '@/lib/consultant-query-keys'
+import type { FarmerWithFarms } from '@/lib/consultant-query-service'
 
 // Sentinel for the "All regions" option. Uses a non-region-like value so it can't
 // collide with a real farm region (e.g. a region literally named "all").
 const ALL_REGIONS = '__all__'
 
 export default function FarmerDirectoryPage() {
-  const [farmers, setFarmers] = useState<FarmerWithFarms[]>([])
-  const [loading, setLoading] = useState(true)
+  const queryClient = useQueryClient()
   const [searchQuery, setSearchQuery] = useState('')
   const [regionFilter, setRegionFilter] = useState(ALL_REGIONS)
   const [unassignedOnly, setUnassignedOnly] = useState(false)
-  const [access, setAccess] = useState<ConsultantAccess | null>(null)
+
+  const accessQuery = useConsultantAccess()
+  const access = accessQuery.data ?? null
+  const farmersQuery = useFarmerClients(access)
+  const farmers = farmersQuery.data ?? []
+  const loading = accessQuery.isPending || farmersQuery.isPending
 
   useEffect(() => {
-    loadFarmers()
-  }, [])
-
-  const loadFarmers = async () => {
-    try {
-      setLoading(true)
-      const currentAccess = await getConsultantAccess()
-      if (!currentAccess) {
-        toast.error('Not authenticated')
-        return
-      }
-      setAccess(currentAccess)
-      const data = await getFarmerClients(currentAccess)
-      setFarmers(data)
-      posthog.capture('consultant_farmer_list_viewed', {
-        org_id: currentAccess.organizationId,
-        role: currentAccess.role,
-        farmer_count: data.length
-      })
-    } catch (error) {
-      Sentry.captureException(error, { tags: { context: 'getFarmerClients' } })
-      toast.error(error instanceof Error ? error.message : 'Failed to load farmer directory')
-    } finally {
-      setLoading(false)
+    if (accessQuery.error) {
+      Sentry.captureException(accessQuery.error, { tags: { context: 'getConsultantAccess' } })
+      toast.error('Not authenticated')
     }
+  }, [accessQuery.error])
+
+  useEffect(() => {
+    if (farmersQuery.error) {
+      Sentry.captureException(farmersQuery.error, { tags: { context: 'getFarmerClients' } })
+      toast.error(
+        farmersQuery.error instanceof Error
+          ? farmersQuery.error.message
+          : 'Failed to load farmer directory'
+      )
+    }
+  }, [farmersQuery.error])
+
+  useEffect(() => {
+    if (!access || !farmersQuery.data) return
+
+    posthog.capture('consultant_farmer_list_viewed', {
+      org_id: access.organizationId,
+      role: access.role,
+      farmer_count: farmersQuery.data.length
+    })
+  }, [access, farmersQuery.data])
+
+  const updateCachedPaymentStatus = (clientRecordId: string, isPaid: boolean) => {
+    if (!access) return
+
+    const scope = access.canViewAllFarmers ? 'all' : access.userId
+    queryClient.setQueryData<FarmerWithFarms[]>(
+      consultantKeys.farmers(access.organizationId, scope),
+      (current) =>
+        current?.map((farmer) =>
+          farmer.clientRecordId === clientRecordId ? { ...farmer, isPaid } : farmer
+        )
+    )
   }
 
   // Unique regions across all farmers' farms, for the region filter dropdown.
@@ -261,6 +280,7 @@ export default function FarmerDirectoryPage() {
                       <PaidToggleButton
                         clientRecordId={farmer.clientRecordId}
                         isPaid={farmer.isPaid}
+                        onChange={(isPaid) => updateCachedPaymentStatus(farmer.clientRecordId, isPaid)}
                       />
                     </div>
                     <Badge variant="secondary" className="hidden sm:flex items-center gap-1">

--- a/src/app/consultant/layout.tsx
+++ b/src/app/consultant/layout.tsx
@@ -85,7 +85,7 @@ export default function ConsultantLayout({ children }: ConsultantLayoutProps) {
     isError,
     error
   } = useConsultantAccess()
-  const accessState = getConsultantAccessState(isPending, isError, access)
+  const accessState = getConsultantAccessState(isPending, isError && !access, access)
 
   useEffect(() => {
     if (accessState === 'denied') {

--- a/src/app/consultant/layout.tsx
+++ b/src/app/consultant/layout.tsx
@@ -19,7 +19,11 @@ import {
   UsersRound
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { ConsultantAccess, getConsultantAccess, roleLabels } from '@/lib/consultant-access'
+import { roleLabels } from '@/lib/consultant-access'
+import {
+  getConsultantAccessState,
+  useConsultantAccess
+} from '@/hooks/consultant/useConsultantQueries'
 import posthog from 'posthog-js'
 import { toast } from 'sonner'
 
@@ -75,36 +79,34 @@ export default function ConsultantLayout({ children }: ConsultantLayoutProps) {
   // 'loading' → checking access; 'ok' → admitted; 'denied' → not a consultant;
   // 'error' → couldn’t verify (transient). Kept distinct so an outage isn’t shown
   // to a valid consultant as an authorization denial.
-  const [accessState, setAccessState] = useState<'loading' | 'ok' | 'denied' | 'error'>('loading')
-  const [access, setAccess] = useState<ConsultantAccess | null>(null)
+  const {
+    data: access,
+    isPending,
+    isError,
+    error
+  } = useConsultantAccess()
+  const accessState = getConsultantAccessState(isPending, isError, access)
 
   useEffect(() => {
-    async function checkAccess() {
-      try {
-        const access = await getConsultantAccess()
-
-        if (!access) {
-          toast.error('Access denied. Consultant team members only.')
-          setAccessState('denied')
-          return
-        }
-
-        setAccess(access)
-        setAccessState('ok')
-        posthog.identify(access.userId, {
-          role: access.role,
-          org_id: access.organizationId,
-          can_view_all_farmers: access.canViewAllFarmers
-        })
-      } catch (error) {
-        console.error('Access check failed:', error)
-        toast.error('Unable to verify consultant access. Please try again.')
-        setAccessState('error')
-      }
+    if (accessState === 'denied') {
+      toast.error('Access denied. Consultant team members only.')
+      return
     }
 
-    checkAccess()
-  }, [])
+    if (accessState === 'error') {
+      console.error('Access check failed:', error)
+      toast.error('Unable to verify consultant access. Please try again.')
+      return
+    }
+
+    if (!access) return
+
+    posthog.identify(access.userId, {
+      role: access.role,
+      org_id: access.organizationId,
+      can_view_all_farmers: access.canViewAllFarmers
+    })
+  }, [access, accessState, error])
 
   if (accessState === 'loading') {
     return (

--- a/src/app/consultant/page.tsx
+++ b/src/app/consultant/page.tsx
@@ -1,15 +1,15 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo } from 'react'
 import Link from 'next/link'
 import { ArrowRight, ClipboardList, Loader2, UserPlus, Users } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { ConsultantAccess, getConsultantAccess, roleLabels } from '@/lib/consultant-access'
-import { getFarmerClients } from '@/lib/consultant-query-service'
+import { roleLabels } from '@/lib/consultant-access'
 import { InviteFarmerDialog } from '@/components/consultant/InviteFarmerDialog'
 import { JoinCodeCard } from '@/components/consultant/JoinCodeCard'
+import { useConsultantAccess, useFarmerClients } from '@/hooks/consultant/useConsultantQueries'
 
 const workspaceLinks = [
   {
@@ -29,47 +29,24 @@ const workspaceLinks = [
 ]
 
 export default function ConsultantOverviewPage() {
-  const [access, setAccess] = useState<ConsultantAccess | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [accessError, setAccessError] = useState(false)
-  // Active org clients with no agronomist assigned. Only loaded for owner/admin
-  // (canViewAllFarmers); null until/unless that count has been resolved.
-  const [unassignedCount, setUnassignedCount] = useState<number | null>(null)
+  const accessQuery = useConsultantAccess()
+  const access = accessQuery.data ?? null
+  const farmerAccess = access?.canViewAllFarmers ? access : null
+  const farmersQuery = useFarmerClients(farmerAccess)
 
   useEffect(() => {
-    async function loadAccess() {
-      try {
-        const result = await getConsultantAccess()
-        if (!result) {
-          setAccessError(true)
-          return
-        }
-        setAccess(result)
-
-        // Owner/admin only: surface farmers who self-joined the org but have no
-        // agronomist yet. getFarmerClients already scopes to active clients, so
-        // counting !assigned_to over its result is the unassigned count.
-        if (result.canViewAllFarmers) {
-          try {
-            const clients = await getFarmerClients(result)
-            setUnassignedCount(clients.filter((client) => !client.assigned_to).length)
-          } catch (clientError) {
-            // The count is a non-critical nudge; never block the workspace on it.
-            console.error('Failed to load unassigned farmer count:', clientError)
-          }
-        }
-      } catch (error) {
-        console.error('Failed to load consultant access:', error)
-        setAccessError(true)
-      } finally {
-        setLoading(false)
-      }
+    if (farmersQuery.error) {
+      // The count is a non-critical nudge; never block the workspace on it.
+      console.error('Failed to load unassigned farmer count:', farmersQuery.error)
     }
+  }, [farmersQuery.error])
 
-    loadAccess()
-  }, [])
+  const unassignedCount = useMemo(() => {
+    if (!access?.canViewAllFarmers || !farmersQuery.data) return null
+    return farmersQuery.data.filter((client) => !client.assigned_to).length
+  }, [access?.canViewAllFarmers, farmersQuery.data])
 
-  if (loading) {
+  if (accessQuery.isPending) {
     return (
       <div className="flex min-h-[50vh] items-center justify-center">
         <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -77,7 +54,7 @@ export default function ConsultantOverviewPage() {
     )
   }
 
-  if (accessError || !access) {
+  if (accessQuery.isError || !access) {
     return (
       <div className="flex min-h-[50vh] items-center justify-center">
         <p className="text-sm text-muted-foreground">

--- a/src/app/consultant/team/assignments/page.tsx
+++ b/src/app/consultant/team/assignments/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -30,7 +30,6 @@ export default function FarmerAssignmentsPage() {
   const access = accessQuery.data ?? null
   const farmerAccess = access?.canViewAllFarmers ? access : null
   const farmersQuery = useFarmerClients(farmerAccess)
-  const [farmers, setFarmers] = useState<FarmerWithFarms[]>([])
   const [members, setMembers] = useState<OrgMember[]>([])
   const [loading, setLoading] = useState(true)
   const [submitting, setSubmitting] = useState(false)
@@ -38,6 +37,31 @@ export default function FarmerAssignmentsPage() {
   const [targetAgronomist, setTargetAgronomist] = useState<string>('')
   const [search, setSearch] = useState('')
   const [selected, setSelected] = useState<Set<string>>(new Set())
+
+  const loadData = useCallback(
+    async (currentAccess = access) => {
+      if (!currentAccess) return
+
+      try {
+        setLoading(true)
+
+        // Agronomists are read-only here; skip the heavier loads.
+        if (!currentAccess.canViewAllFarmers) {
+          return
+        }
+
+        const memberData = await listOrgMembers(currentAccess.organizationId)
+        setMembers(memberData)
+        setSelected(new Set())
+      } catch (error) {
+        console.error('Failed to load assignments:', error)
+        toast.error(error instanceof Error ? error.message : 'Failed to load assignments')
+      } finally {
+        setLoading(false)
+      }
+    },
+    [access]
+  )
 
   useEffect(() => {
     if (accessQuery.isPending) return
@@ -47,30 +71,7 @@ export default function FarmerAssignmentsPage() {
       return
     }
     loadData(access)
-  }, [access, accessQuery.isError, accessQuery.isPending, farmersQuery.data])
-
-  const loadData = async (currentAccess = access) => {
-    if (!currentAccess) return
-
-    try {
-      setLoading(true)
-
-      // Agronomists are read-only here; skip the heavier loads.
-      if (!currentAccess.canViewAllFarmers) {
-        return
-      }
-
-      const memberData = await listOrgMembers(currentAccess.organizationId)
-      setFarmers(farmersQuery.data ?? [])
-      setMembers(memberData)
-      setSelected(new Set())
-    } catch (error) {
-      console.error('Failed to load assignments:', error)
-      toast.error(error instanceof Error ? error.message : 'Failed to load assignments')
-    } finally {
-      setLoading(false)
-    }
-  }
+  }, [access, accessQuery.isError, accessQuery.isPending, loadData])
 
   // Only agronomists can be assignment targets.
   const agronomists = useMemo(() => members.filter((m) => m.role === 'agronomist'), [members])
@@ -89,6 +90,8 @@ export default function FarmerAssignmentsPage() {
     if (access && farmer.assigned_to === access.userId) return 'You'
     return memberNameById.get(farmer.assigned_to) || 'Assigned'
   }
+
+  const farmers = farmersQuery.data ?? []
 
   const filteredFarmers = useMemo(() => {
     const query = search.trim().toLowerCase()
@@ -169,7 +172,9 @@ export default function FarmerAssignmentsPage() {
         }
       )
       const refreshedFarmers = await farmersQuery.refetch()
-      setFarmers(refreshedFarmers.data ?? [])
+      if (refreshedFarmers.error) {
+        throw refreshedFarmers.error
+      }
       const refreshedMembers = await listOrgMembers(access.organizationId)
       setMembers(refreshedMembers)
       setSelected(new Set())
@@ -188,6 +193,22 @@ export default function FarmerAssignmentsPage() {
           <Loader2 className="h-8 w-8 animate-spin text-primary mx-auto" />
           <p className="text-sm text-muted-foreground">Loading assignments...</p>
         </div>
+      </div>
+    )
+  }
+
+  if (access?.canViewAllFarmers && farmersQuery.isError) {
+    return (
+      <div className="space-y-6">
+        <TeamTabs canViewAllFarmers />
+        <Alert variant="destructive">
+          <AlertTitle>Unable to load farmers</AlertTitle>
+          <AlertDescription>
+            {farmersQuery.error instanceof Error
+              ? farmersQuery.error.message
+              : 'Failed to load farmer assignments.'}
+          </AlertDescription>
+        </Alert>
       </div>
     )
   }

--- a/src/app/consultant/team/assignments/page.tsx
+++ b/src/app/consultant/team/assignments/page.tsx
@@ -19,14 +19,17 @@ import {
 } from '@/components/ui/select'
 import { toast } from 'sonner'
 import { Loader2, Lock, Search, UserCog, Users } from 'lucide-react'
-import { getConsultantAccess, type ConsultantAccess } from '@/lib/consultant-access'
-import { getFarmerClients, type FarmerWithFarms } from '@/lib/consultant-query-service'
+import { useConsultantAccess, useFarmerClients } from '@/hooks/consultant/useConsultantQueries'
+import { type FarmerWithFarms } from '@/lib/consultant-query-service'
 import { listOrgMembers, type OrgMember } from '@/lib/team-service'
 import { TeamTabs } from '@/components/consultant/TeamTabs'
 import posthog from 'posthog-js'
 
 export default function FarmerAssignmentsPage() {
-  const [access, setAccess] = useState<ConsultantAccess | null>(null)
+  const accessQuery = useConsultantAccess()
+  const access = accessQuery.data ?? null
+  const farmerAccess = access?.canViewAllFarmers ? access : null
+  const farmersQuery = useFarmerClients(farmerAccess)
   const [farmers, setFarmers] = useState<FarmerWithFarms[]>([])
   const [members, setMembers] = useState<OrgMember[]>([])
   const [loading, setLoading] = useState(true)
@@ -37,29 +40,28 @@ export default function FarmerAssignmentsPage() {
   const [selected, setSelected] = useState<Set<string>>(new Set())
 
   useEffect(() => {
-    loadData()
-  }, [])
+    if (accessQuery.isPending) return
+    if (!access) {
+      if (accessQuery.isError) toast.error('Not authenticated')
+      setLoading(false)
+      return
+    }
+    loadData(access)
+  }, [access, accessQuery.isError, accessQuery.isPending, farmersQuery.data])
 
-  const loadData = async () => {
+  const loadData = async (currentAccess = access) => {
+    if (!currentAccess) return
+
     try {
       setLoading(true)
-      const currentAccess = await getConsultantAccess()
-      if (!currentAccess) {
-        toast.error('Not authenticated')
-        return
-      }
-      setAccess(currentAccess)
 
       // Agronomists are read-only here; skip the heavier loads.
       if (!currentAccess.canViewAllFarmers) {
         return
       }
 
-      const [farmerData, memberData] = await Promise.all([
-        getFarmerClients(currentAccess),
-        listOrgMembers(currentAccess.organizationId)
-      ])
-      setFarmers(farmerData)
+      const memberData = await listOrgMembers(currentAccess.organizationId)
+      setFarmers(farmersQuery.data ?? [])
       setMembers(memberData)
       setSelected(new Set())
     } catch (error) {
@@ -166,7 +168,11 @@ export default function FarmerAssignmentsPage() {
           agronomist_id: agronomistUserId ?? null
         }
       )
-      await loadData()
+      const refreshedFarmers = await farmersQuery.refetch()
+      setFarmers(refreshedFarmers.data ?? [])
+      const refreshedMembers = await listOrgMembers(access.organizationId)
+      setMembers(refreshedMembers)
+      setSelected(new Set())
     } catch (error) {
       console.error('Assignment failed:', error)
       toast.error(error instanceof Error ? error.message : 'Failed to update assignments')
@@ -175,7 +181,7 @@ export default function FarmerAssignmentsPage() {
     }
   }
 
-  if (loading) {
+  if (loading || (Boolean(access?.canViewAllFarmers) && farmersQuery.isPending)) {
     return (
       <div className="flex items-center justify-center min-h-[60vh]">
         <div className="text-center space-y-3">

--- a/src/app/consultant/team/page.tsx
+++ b/src/app/consultant/team/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -84,42 +84,47 @@ export default function TeamSettingsPage() {
 
   const isAdmin = access?.canViewAllFarmers ?? false
 
+  const loadTeam = useCallback(
+    async (currentAccess = access) => {
+      if (!currentAccess) return
+
+      try {
+        setLoading(true)
+
+        const orgId = currentAccess.organizationId
+        const memberRows = await listOrgMembers(orgId)
+        setMembers(memberRows)
+        posthog.capture('consultant_team_viewed', {
+          org_id: orgId,
+          role: currentAccess.role,
+          member_count: memberRows.length
+        })
+
+        if (currentAccess.canViewAllFarmers) {
+          const inviteRows = await listPendingInvites(orgId)
+          setInvites(inviteRows)
+        }
+      } catch (error) {
+        console.error('Failed to load team:', error)
+        toast.error(error instanceof Error ? error.message : 'Failed to load team')
+      } finally {
+        setLoading(false)
+      }
+    },
+    [access]
+  )
+
   useEffect(() => {
     if (accessQuery.isPending) return
     if (!access) {
+      setMembers([])
+      setInvites([])
       if (accessQuery.isError) toast.error('Not authenticated')
       setLoading(false)
       return
     }
     loadTeam(access)
-  }, [access, accessQuery.isError, accessQuery.isPending])
-
-  const loadTeam = async (currentAccess = access) => {
-    if (!currentAccess) return
-
-    try {
-      setLoading(true)
-
-      const orgId = currentAccess.organizationId
-      const memberRows = await listOrgMembers(orgId)
-      setMembers(memberRows)
-      posthog.capture('consultant_team_viewed', {
-        org_id: orgId,
-        role: currentAccess.role,
-        member_count: memberRows.length
-      })
-
-      if (currentAccess.canViewAllFarmers) {
-        const inviteRows = await listPendingInvites(orgId)
-        setInvites(inviteRows)
-      }
-    } catch (error) {
-      console.error('Failed to load team:', error)
-      toast.error(error instanceof Error ? error.message : 'Failed to load team')
-    } finally {
-      setLoading(false)
-    }
-  }
+  }, [access, accessQuery.isError, accessQuery.isPending, loadTeam])
 
   const reloadMembers = async () => {
     if (!access) return

--- a/src/app/consultant/team/page.tsx
+++ b/src/app/consultant/team/page.tsx
@@ -33,7 +33,8 @@ import {
 } from '@/components/ui/alert-dialog'
 import { toast } from 'sonner'
 import { Loader2, UserPlus, Users, Mail, Copy, Trash2, Clock } from 'lucide-react'
-import { getConsultantAccess, roleLabels, type ConsultantAccess } from '@/lib/consultant-access'
+import { roleLabels } from '@/lib/consultant-access'
+import { useConsultantAccess } from '@/hooks/consultant/useConsultantQueries'
 import posthog from 'posthog-js'
 import {
   listOrgMembers,
@@ -59,7 +60,8 @@ async function copyLink(token: string) {
 }
 
 export default function TeamSettingsPage() {
-  const [access, setAccess] = useState<ConsultantAccess | null>(null)
+  const accessQuery = useConsultantAccess()
+  const access = accessQuery.data ?? null
   const [members, setMembers] = useState<OrgMember[]>([])
   const [invites, setInvites] = useState<PendingInvite[]>([])
   const [loading, setLoading] = useState(true)
@@ -83,18 +85,20 @@ export default function TeamSettingsPage() {
   const isAdmin = access?.canViewAllFarmers ?? false
 
   useEffect(() => {
-    loadTeam()
-  }, [])
+    if (accessQuery.isPending) return
+    if (!access) {
+      if (accessQuery.isError) toast.error('Not authenticated')
+      setLoading(false)
+      return
+    }
+    loadTeam(access)
+  }, [access, accessQuery.isError, accessQuery.isPending])
 
-  const loadTeam = async () => {
+  const loadTeam = async (currentAccess = access) => {
+    if (!currentAccess) return
+
     try {
       setLoading(true)
-      const currentAccess = await getConsultantAccess()
-      if (!currentAccess) {
-        toast.error('Not authenticated')
-        return
-      }
-      setAccess(currentAccess)
 
       const orgId = currentAccess.organizationId
       const memberRows = await listOrgMembers(orgId)

--- a/src/app/consultant/triage/page.tsx
+++ b/src/app/consultant/triage/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -109,6 +109,29 @@ export default function TriagePage() {
   const [formRecommendation, setFormRecommendation] = useState('')
   const [formReviewNotes, setFormReviewNotes] = useState('')
 
+  const loadTriage = useCallback(
+    async (currentAccess = access) => {
+      if (!currentAccess) return
+
+      try {
+        setLoading(true)
+        const data = await getTriageItems(currentAccess)
+        setItems(data)
+        posthog.capture('consultant_triage_viewed', {
+          org_id: currentAccess.organizationId,
+          role: currentAccess.role,
+          item_count: data.length
+        })
+      } catch (error) {
+        console.error('Failed to load triage:', error)
+        toast.error('Failed to load triage queue')
+      } finally {
+        setLoading(false)
+      }
+    },
+    [access]
+  )
+
   useEffect(() => {
     if (accessQuery.isPending) return
     if (!access) {
@@ -117,27 +140,7 @@ export default function TriagePage() {
       return
     }
     loadTriage(access)
-  }, [access, accessQuery.isError, accessQuery.isPending])
-
-  const loadTriage = async (currentAccess = access) => {
-    if (!currentAccess) return
-
-    try {
-      setLoading(true)
-      const data = await getTriageItems(currentAccess)
-      setItems(data)
-      posthog.capture('consultant_triage_viewed', {
-        org_id: currentAccess.organizationId,
-        role: currentAccess.role,
-        item_count: data.length
-      })
-    } catch (error) {
-      console.error('Failed to load triage:', error)
-      toast.error('Failed to load triage queue')
-    } finally {
-      setLoading(false)
-    }
-  }
+  }, [access, accessQuery.isError, accessQuery.isPending, loadTriage])
 
   const counts = useMemo(() => {
     let pending = 0

--- a/src/app/consultant/triage/page.tsx
+++ b/src/app/consultant/triage/page.tsx
@@ -24,7 +24,7 @@ import {
 } from '@/components/ui/sheet'
 import { toast } from 'sonner'
 import { Search, Loader2, ClipboardList, ChevronRight, FlaskConical } from 'lucide-react'
-import { getConsultantAccess, type ConsultantAccess } from '@/lib/consultant-access'
+import { useConsultantAccess } from '@/hooks/consultant/useConsultantQueries'
 import posthog from 'posthog-js'
 import {
   getTriageItems,
@@ -87,9 +87,10 @@ function formatDate(value: string | null) {
 }
 
 export default function TriagePage() {
+  const accessQuery = useConsultantAccess()
+  const access = accessQuery.data ?? null
   const [items, setItems] = useState<TriageItem[]>([])
   const [loading, setLoading] = useState(true)
-  const [access, setAccess] = useState<ConsultantAccess | null>(null)
 
   const [searchQuery, setSearchQuery] = useState('')
   const [statusFilter, setStatusFilter] = useState<string>('all')
@@ -109,18 +110,20 @@ export default function TriagePage() {
   const [formReviewNotes, setFormReviewNotes] = useState('')
 
   useEffect(() => {
-    loadTriage()
-  }, [])
+    if (accessQuery.isPending) return
+    if (!access) {
+      if (accessQuery.isError) toast.error('Not authenticated')
+      setLoading(false)
+      return
+    }
+    loadTriage(access)
+  }, [access, accessQuery.isError, accessQuery.isPending])
 
-  const loadTriage = async () => {
+  const loadTriage = async (currentAccess = access) => {
+    if (!currentAccess) return
+
     try {
       setLoading(true)
-      const currentAccess = await getConsultantAccess()
-      if (!currentAccess) {
-        toast.error('Not authenticated')
-        return
-      }
-      setAccess(currentAccess)
       const data = await getTriageItems(currentAccess)
       setItems(data)
       posthog.capture('consultant_triage_viewed', {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import './globals.css'
 import { I18nProvider } from '@/components/providers/I18nProvider'
 import { MotionConfigProvider } from '@/components/providers/MotionConfigProvider'
 import { AuthProvider } from '@/components/providers/AuthProvider'
+import { QueryProvider } from '@/components/providers/QueryProvider'
 import { SentryErrorBoundary } from '@/components/SentryErrorBoundary'
 import { Suspense } from 'react'
 import { GlobalAuthErrorHandler } from '@/components/auth/GlobalAuthErrorHandler'
@@ -163,14 +164,16 @@ export default function RootLayout({
               </div>
             }
           >
-            <GlobalAuthErrorHandler />
-            <AuthProvider>
-              <MotionConfigProvider>
-                <I18nProvider>
-                  <LayoutContent>{children}</LayoutContent>
-                </I18nProvider>
-              </MotionConfigProvider>
-            </AuthProvider>
+            <QueryProvider>
+              <GlobalAuthErrorHandler />
+              <AuthProvider>
+                <MotionConfigProvider>
+                  <I18nProvider>
+                    <LayoutContent>{children}</LayoutContent>
+                  </I18nProvider>
+                </MotionConfigProvider>
+              </AuthProvider>
+            </QueryProvider>
           </Suspense>
         </SentryErrorBoundary>
         <GoogleAnalytics />

--- a/src/components/consultant/JoinCodeCard.tsx
+++ b/src/components/consultant/JoinCodeCard.tsx
@@ -17,14 +17,16 @@ interface JoinCodeCardProps {
   access?: ConsultantAccess | null
 }
 
-export function JoinCodeCard({ access: providedAccess = null }: JoinCodeCardProps = {}) {
-  const fallbackAccessQuery = useConsultantAccess(providedAccess === null)
+export function JoinCodeCard(props: JoinCodeCardProps = {}) {
+  const hasProvidedAccess = Object.prototype.hasOwnProperty.call(props, 'access')
+  const providedAccess = props.access ?? null
+  const fallbackAccessQuery = useConsultantAccess(!hasProvidedAccess)
 
   // Derive the effective state: a parent-provided access is authoritative and is
   // never loading or errored; otherwise fall back to the cached access query.
-  const access = providedAccess ?? fallbackAccessQuery.data ?? null
-  const loading = providedAccess === null && fallbackAccessQuery.isPending
-  const error = providedAccess === null && fallbackAccessQuery.isError
+  const access = hasProvidedAccess ? providedAccess : (fallbackAccessQuery.data ?? null)
+  const loading = !hasProvidedAccess && fallbackAccessQuery.isPending
+  const error = !hasProvidedAccess && fallbackAccessQuery.isError
 
   if (loading) {
     return (

--- a/src/components/consultant/JoinCodeCard.tsx
+++ b/src/components/consultant/JoinCodeCard.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import { useEffect, useState } from 'react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { toast } from 'sonner'
 import { Copy, Loader2, MessageSquareShare } from 'lucide-react'
-import { getConsultantAccess, type ConsultantAccess } from '@/lib/consultant-access'
+import { type ConsultantAccess } from '@/lib/consultant-access'
+import { useConsultantAccess } from '@/hooks/consultant/useConsultantQueries'
 import { buildJoinMessage } from '@/lib/join-message'
 import posthog from 'posthog-js'
 
@@ -18,39 +18,13 @@ interface JoinCodeCardProps {
 }
 
 export function JoinCodeCard({ access: providedAccess = null }: JoinCodeCardProps = {}) {
-  // Only the fallback fetch owns state. When the parent supplies access we read
-  // it directly, so the prop is never mirrored into state.
-  const [fetchedAccess, setFetchedAccess] = useState<ConsultantAccess | null>(null)
-  const [fetchLoading, setFetchLoading] = useState(true)
-  const [fetchError, setFetchError] = useState(false)
-
-  useEffect(() => {
-    // Parent already has access — skip the redundant round-trip entirely.
-    if (providedAccess !== null) return
-
-    let active = true
-    const load = async () => {
-      try {
-        const currentAccess = await getConsultantAccess()
-        if (active) setFetchedAccess(currentAccess)
-      } catch (err) {
-        console.error('Failed to load join code:', err)
-        if (active) setFetchError(true)
-      } finally {
-        if (active) setFetchLoading(false)
-      }
-    }
-    load()
-    return () => {
-      active = false
-    }
-  }, [providedAccess])
+  const fallbackAccessQuery = useConsultantAccess(providedAccess === null)
 
   // Derive the effective state: a parent-provided access is authoritative and is
-  // never loading or errored; otherwise fall back to the fetch result.
-  const access = providedAccess ?? fetchedAccess
-  const loading = providedAccess === null && fetchLoading
-  const error = providedAccess === null && fetchError
+  // never loading or errored; otherwise fall back to the cached access query.
+  const access = providedAccess ?? fallbackAccessQuery.data ?? null
+  const loading = providedAccess === null && fallbackAccessQuery.isPending
+  const error = providedAccess === null && fallbackAccessQuery.isError
 
   if (loading) {
     return (

--- a/src/components/consultant/RecordVisitDialog.tsx
+++ b/src/components/consultant/RecordVisitDialog.tsx
@@ -29,13 +29,13 @@ import posthog from 'posthog-js'
 import { type ConsultantAccess } from '@/lib/consultant-access'
 import {
   getVisitableRecommendations,
-  createVisit,
   FOLLOWED_STATUSES,
   followedStatusLabels,
   type FollowedStatus,
   type VisitableRecommendation,
   type Visit
 } from '@/lib/consultant-visit-service'
+import { useCreateVisit } from '@/hooks/consultant/useConsultantQueries'
 
 interface RecordVisitDialogProps {
   access: ConsultantAccess
@@ -60,13 +60,14 @@ function todayLocal(): string {
 export function RecordVisitDialog({ access, farmerId, farms, onRecorded }: RecordVisitDialogProps) {
   const [open, setOpen] = useState(false)
   const [loading, setLoading] = useState(false)
-  const [submitting, setSubmitting] = useState(false)
   const [recommendations, setRecommendations] = useState<VisitableRecommendation[]>([])
 
   const [visitDate, setVisitDate] = useState(todayLocal())
   const [farmId, setFarmId] = useState<string>('none')
   const [summary, setSummary] = useState('')
   const [drafts, setDrafts] = useState<Record<string, FollowupDraft>>({})
+  const createVisitMutation = useCreateVisit(access, farmerId)
+  const submitting = createVisitMutation.isPending
 
   const reset = useCallback(() => {
     setVisitDate(todayLocal())
@@ -126,8 +127,7 @@ export function RecordVisitDialog({ access, farmerId, farms, onRecorded }: Recor
     }
 
     try {
-      setSubmitting(true)
-      const visit = await createVisit(access, {
+      const visit = await createVisitMutation.mutateAsync({
         farmerId,
         farmId: farmId === 'none' ? null : Number(farmId),
         visitDate,
@@ -155,8 +155,6 @@ export function RecordVisitDialog({ access, farmerId, farms, onRecorded }: Recor
         extra: { farmerId }
       })
       toast.error(err instanceof Error ? err.message : 'Failed to record visit')
-    } finally {
-      setSubmitting(false)
     }
   }
 

--- a/src/components/providers/QueryProvider.tsx
+++ b/src/components/providers/QueryProvider.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useState, type ReactNode } from 'react'
+
+export function QueryProvider({ children }: { children: ReactNode }) {
+  const [client] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 30_000,
+            gcTime: 5 * 60_000,
+            retry: 1,
+            refetchOnWindowFocus: false
+          }
+        }
+      })
+  )
+
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}

--- a/src/components/providers/QueryProvider.tsx
+++ b/src/components/providers/QueryProvider.tsx
@@ -1,9 +1,14 @@
 'use client'
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { useState, type ReactNode } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { createClient } from '@/lib/supabase'
 
-export function QueryProvider({ children }: { children: ReactNode }) {
+interface QueryProviderProps {
+  children: ReactNode
+}
+
+export function QueryProvider({ children }: QueryProviderProps) {
   const [client] = useState(
     () =>
       new QueryClient({
@@ -17,6 +22,32 @@ export function QueryProvider({ children }: { children: ReactNode }) {
         }
       })
   )
+  const currentUserIdRef = useRef<string | null | undefined>(undefined)
+
+  useEffect(() => {
+    const supabase = createClient()
+
+    supabase.auth.getUser().then(({ data }) => {
+      currentUserIdRef.current = data.user?.id ?? null
+    })
+
+    const {
+      data: { subscription }
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      const nextUserId = session?.user?.id ?? null
+      const previousUserId = currentUserIdRef.current
+
+      if (previousUserId !== undefined && previousUserId !== nextUserId) {
+        client.clear()
+      }
+
+      currentUserIdRef.current = nextUserId
+    })
+
+    return () => {
+      subscription.unsubscribe()
+    }
+  }, [client])
 
   return <QueryClientProvider client={client}>{children}</QueryClientProvider>
 }

--- a/src/hooks/consultant/useConsultantQueries.ts
+++ b/src/hooks/consultant/useConsultantQueries.ts
@@ -3,6 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { getConsultantAccess, type ConsultantAccess } from '@/lib/consultant-access'
 import { consultantKeys } from '@/lib/consultant-query-keys'
+import { useSupabaseAuth } from '@/hooks/useSupabaseAuth'
 import {
   getFarmerClients,
   getFarmerFarms,
@@ -28,15 +29,18 @@ export function getConsultantAccessState(
   return access ? 'ok' : 'denied'
 }
 
-function farmerScope(access: ConsultantAccess) {
+export function farmerScope(access: ConsultantAccess) {
   return access.canViewAllFarmers ? 'all' : access.userId
 }
 
 export function useConsultantAccess(enabled = true) {
+  const { loading, user } = useSupabaseAuth()
+  const userId = user?.id ?? 'anonymous'
+
   return useQuery({
-    queryKey: consultantKeys.access(),
+    queryKey: consultantKeys.access(userId),
     queryFn: getConsultantAccess,
-    enabled
+    enabled: Boolean(enabled && !loading && user)
   })
 }
 
@@ -56,7 +60,7 @@ export function useValidatedFarmerClient(
 ) {
   return useQuery({
     queryKey: access
-      ? ['consultant', 'farmer', farmerId, 'validation', access.organizationId, farmerScope(access)]
+      ? consultantKeys.farmerValidation(farmerId, access.organizationId, farmerScope(access))
       : ['consultant', 'farmer', farmerId, 'validation', 'disabled'],
     queryFn: () => validateFarmerClient(access as ConsultantAccess, farmerId),
     enabled: Boolean(access && farmerId)
@@ -92,7 +96,9 @@ export function useFarmerVisits(
   farmerId: string
 ) {
   return useQuery({
-    queryKey: consultantKeys.farmerVisits(farmerId),
+    queryKey: access
+      ? consultantKeys.farmerVisits(farmerId, access.organizationId, farmerScope(access))
+      : ['consultant', 'farmer', farmerId, 'visits', 'disabled'],
     queryFn: () => getVisitsForFarmer(access as ConsultantAccess, farmerId),
     enabled: Boolean(access && farmerId)
   })
@@ -109,7 +115,10 @@ export function useCreateVisit(access: ConsultantAccess | null | undefined, farm
       return createVisit(access, input)
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: consultantKeys.farmerVisits(farmerId) })
+      if (!access) return
+      queryClient.invalidateQueries({
+        queryKey: consultantKeys.farmerVisits(farmerId, access.organizationId, farmerScope(access))
+      })
     }
   })
 }

--- a/src/hooks/consultant/useConsultantQueries.ts
+++ b/src/hooks/consultant/useConsultantQueries.ts
@@ -1,0 +1,115 @@
+'use client'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { getConsultantAccess, type ConsultantAccess } from '@/lib/consultant-access'
+import { consultantKeys } from '@/lib/consultant-query-keys'
+import {
+  getFarmerClients,
+  getFarmerFarms,
+  getFarmerProfile,
+  getFarmDetail,
+  validateFarmerClient
+} from '@/lib/consultant-query-service'
+import {
+  createVisit,
+  getVisitsForFarmer,
+  type CreateVisitInput
+} from '@/lib/consultant-visit-service'
+
+export type ConsultantAccessState = 'loading' | 'ok' | 'denied' | 'error'
+
+export function getConsultantAccessState(
+  isPending: boolean,
+  isError: boolean,
+  access: ConsultantAccess | null | undefined
+): ConsultantAccessState {
+  if (isPending) return 'loading'
+  if (isError) return 'error'
+  return access ? 'ok' : 'denied'
+}
+
+function farmerScope(access: ConsultantAccess) {
+  return access.canViewAllFarmers ? 'all' : access.userId
+}
+
+export function useConsultantAccess(enabled = true) {
+  return useQuery({
+    queryKey: consultantKeys.access(),
+    queryFn: getConsultantAccess,
+    enabled
+  })
+}
+
+export function useFarmerClients(access: ConsultantAccess | null | undefined) {
+  return useQuery({
+    queryKey: access
+      ? consultantKeys.farmers(access.organizationId, farmerScope(access))
+      : ['consultant', 'farmers', 'disabled'],
+    queryFn: () => getFarmerClients(access as ConsultantAccess),
+    enabled: Boolean(access)
+  })
+}
+
+export function useValidatedFarmerClient(
+  access: ConsultantAccess | null | undefined,
+  farmerId: string
+) {
+  return useQuery({
+    queryKey: access
+      ? ['consultant', 'farmer', farmerId, 'validation', access.organizationId, farmerScope(access)]
+      : ['consultant', 'farmer', farmerId, 'validation', 'disabled'],
+    queryFn: () => validateFarmerClient(access as ConsultantAccess, farmerId),
+    enabled: Boolean(access && farmerId)
+  })
+}
+
+export function useFarmerProfile(farmerId: string, enabled = true) {
+  return useQuery({
+    queryKey: consultantKeys.farmerProfile(farmerId),
+    queryFn: () => getFarmerProfile(farmerId),
+    enabled: Boolean(farmerId && enabled)
+  })
+}
+
+export function useFarmerFarms(farmerId: string, enabled = true) {
+  return useQuery({
+    queryKey: consultantKeys.farmerFarms(farmerId),
+    queryFn: () => getFarmerFarms(farmerId),
+    enabled: Boolean(farmerId && enabled)
+  })
+}
+
+export function useFarmDetail(farmId: number | null, enabled = true) {
+  return useQuery({
+    queryKey: farmId != null ? consultantKeys.farmDetail(farmId) : ['consultant', 'farm', 'disabled'],
+    queryFn: () => getFarmDetail(farmId as number),
+    enabled: Boolean(farmId != null && enabled)
+  })
+}
+
+export function useFarmerVisits(
+  access: ConsultantAccess | null | undefined,
+  farmerId: string
+) {
+  return useQuery({
+    queryKey: consultantKeys.farmerVisits(farmerId),
+    queryFn: () => getVisitsForFarmer(access as ConsultantAccess, farmerId),
+    enabled: Boolean(access && farmerId)
+  })
+}
+
+export function useCreateVisit(access: ConsultantAccess | null | undefined, farmerId: string) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (input: CreateVisitInput) => {
+      if (!access) {
+        throw new Error('Consultant access is required to record a visit')
+      }
+      return createVisit(access, input)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: consultantKeys.farmerVisits(farmerId) })
+    }
+  })
+}

--- a/src/hooks/consultant/useConsultantQueries.ts
+++ b/src/hooks/consultant/useConsultantQueries.ts
@@ -83,11 +83,19 @@ export function useFarmerFarms(farmerId: string, enabled = true) {
   })
 }
 
-export function useFarmDetail(farmId: number | null, enabled = true) {
+export function useFarmDetail(
+  farmId: number | null,
+  enabled = true,
+  access: ConsultantAccess | null | undefined = null
+) {
+  const canLoad = Boolean(farmId != null && enabled && access)
+
   return useQuery({
-    queryKey: farmId != null ? consultantKeys.farmDetail(farmId) : ['consultant', 'farm', 'disabled'],
+    queryKey: canLoad
+      ? consultantKeys.farmDetail(farmId as number, access!.organizationId, farmerScope(access!))
+      : ['consultant', 'farm', 'disabled', farmId],
     queryFn: () => getFarmDetail(farmId as number),
-    enabled: Boolean(farmId != null && enabled)
+    enabled: canLoad
   })
 }
 

--- a/src/lib/consultant-query-keys.ts
+++ b/src/lib/consultant-query-keys.ts
@@ -1,8 +1,11 @@
 export const consultantKeys = {
-  access: () => ['consultant', 'access'] as const,
+  access: (userId: string) => ['consultant', 'access', userId] as const,
   farmers: (orgId: string, scope: string) => ['consultant', 'farmers', orgId, scope] as const,
   farmerProfile: (farmerId: string) => ['consultant', 'farmer', farmerId, 'profile'] as const,
   farmerFarms: (farmerId: string) => ['consultant', 'farmer', farmerId, 'farms'] as const,
   farmDetail: (farmId: number) => ['consultant', 'farm', farmId, 'detail'] as const,
-  farmerVisits: (farmerId: string) => ['consultant', 'farmer', farmerId, 'visits'] as const
+  farmerValidation: (farmerId: string, orgId: string, scope: string) =>
+    ['consultant', 'farmer', farmerId, 'validation', orgId, scope] as const,
+  farmerVisits: (farmerId: string, orgId: string, scope: string) =>
+    ['consultant', 'farmer', farmerId, 'visits', orgId, scope] as const
 }

--- a/src/lib/consultant-query-keys.ts
+++ b/src/lib/consultant-query-keys.ts
@@ -1,0 +1,8 @@
+export const consultantKeys = {
+  access: () => ['consultant', 'access'] as const,
+  farmers: (orgId: string, scope: string) => ['consultant', 'farmers', orgId, scope] as const,
+  farmerProfile: (farmerId: string) => ['consultant', 'farmer', farmerId, 'profile'] as const,
+  farmerFarms: (farmerId: string) => ['consultant', 'farmer', farmerId, 'farms'] as const,
+  farmDetail: (farmId: number) => ['consultant', 'farm', farmId, 'detail'] as const,
+  farmerVisits: (farmerId: string) => ['consultant', 'farmer', farmerId, 'visits'] as const
+}

--- a/src/lib/consultant-query-keys.ts
+++ b/src/lib/consultant-query-keys.ts
@@ -3,7 +3,8 @@ export const consultantKeys = {
   farmers: (orgId: string, scope: string) => ['consultant', 'farmers', orgId, scope] as const,
   farmerProfile: (farmerId: string) => ['consultant', 'farmer', farmerId, 'profile'] as const,
   farmerFarms: (farmerId: string) => ['consultant', 'farmer', farmerId, 'farms'] as const,
-  farmDetail: (farmId: number) => ['consultant', 'farm', farmId, 'detail'] as const,
+  farmDetail: (farmId: number, orgId: string, scope: string) =>
+    ['consultant', 'farm', farmId, 'detail', orgId, scope] as const,
   farmerValidation: (farmerId: string, orgId: string, scope: string) =>
     ['consultant', 'farmer', farmerId, 'validation', orgId, scope] as const,
   farmerVisits: (farmerId: string, orgId: string, scope: string) =>


### PR DESCRIPTION
## Summary
- add a global TanStack Query provider plus consultant query key/hook helpers
- migrate consultant access, farmer, farm, and visit reads to shared cached queries
- invalidate visit history after recording visits and patch paid-status cache from the existing toggle callback
- document the server-state decision in an ADR

## Validation
- git diff --check
- not run: bun install / bun run typecheck / bun run lint / bun run build because bun is unavailable in this container, so bun.lock was not regenerated here

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds shared caching for consultant server state using `@tanstack/react-query`, scoped by user/org and access level, and cleared on auth changes. Farm detail queries are now guard-railed by scope to prevent stale or leaked data; lab tests stay bound to the validated farm.

- **New Features**
  - Global `QueryProvider` with sane defaults and auth-aware cache clearing.
  - Scoped query keys and hooks for access, farmer lists/profile/farms/farm detail/visits, and visit creation.
  - Precise cache updates: invalidate farmer visits on record; patch paid status in directory/profile; access state helper and ADR; consistent Sentry-backed errors.

- **Refactors**
  - Migrated consultant layout, overview, directory, farmer profile, farm detail, triage, team settings/assignments, `JoinCodeCard`, and `RecordVisitDialog` to shared queries with unified loading and analytics.
  - Guarded farm detail cache by org/access scope; disabled queries no longer show old data; lab tests tied to the active farm.
  - Dependencies: added `@tanstack/react-query` and `@tanstack/react-query-devtools`; provider mounted in the root layout.

<sup>Written for commit 15dc94a9d4811bfeb5151085dd562b6aa25a3d8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ashish921998/Vinesight/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Performance & Reliability**
  * Improved consultant page responsiveness by switching to shared cached “server state” across the workspace.
  * Visit recording now reliably refreshes related visit data to prevent duplicates and stale entries.
  * Paid status updates now immediately update cached farmer lists to avoid incorrect re-renders.

* **Error Handling & UX**
  * More consistent loading and error handling for consultant access, farmer lists, and profiles.
  * Clearer authentication/denied states with unified toast feedback.

* **Stability**
  * Cached query data resets when the signed-in user changes to prevent cross-user mixing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->