### PR TITLE
refactor(ui): adopt shadcn components across the app

### DIFF
--- a/src/app/calculators/page.tsx
+++ b/src/app/calculators/page.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react'
 import { ArrowLeft, ArrowRight, Beaker, Calculator, Droplets, Leaf } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
 import { ETcCalculatorComponent } from '@/components/calculators/ETcCalculator'
 import { LAICalculatorComponent } from '@/components/calculators/LAICalculator'
 import { NutrientCalculatorComponent } from '@/components/calculators/NutrientCalculator'
@@ -103,20 +105,21 @@ export default function CalculatorsPage() {
       <div className="min-h-screen bg-background text-foreground">
         <div className="sticky top-0 z-20 border-b border-border bg-background">
           <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
-            <button
+            <Button
               type="button"
+              variant="outline"
               onClick={() => setSelectedCalculator(null)}
-              className="inline-flex h-12 items-center gap-2 rounded-lg border border-border bg-card px-4 text-meta font-medium text-accent transition hover:border-accent/40 hover:bg-muted"
+              className="h-12 gap-2 rounded-lg text-meta font-medium text-accent hover:border-accent/40 hover:bg-muted"
             >
               <ArrowLeft className="h-4 w-4 text-accent" />
               Back
-            </button>
+            </Button>
             <span className="text-meta text-muted-foreground">Calculators</span>
           </div>
         </div>
 
         <div className="mx-auto flex max-w-6xl flex-col gap-6 px-4 py-6 sm:px-6">
-          <div className="rounded-3xl border border-border bg-card p-6 shadow-sm">
+          <Card className="gap-0 rounded-3xl p-6 shadow-sm">
             <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
               <div className="space-y-2">
                 <p className="text-meta text-muted-foreground">
@@ -129,11 +132,11 @@ export default function CalculatorsPage() {
                 <Calculator className="h-5 w-5 text-accent" />
               </div>
             </div>
-          </div>
+          </Card>
 
-          <div className="rounded-3xl border border-border bg-card p-6 shadow-sm">
+          <Card className="gap-0 rounded-3xl p-6 shadow-sm">
             <CalculatorComponent />
-          </div>
+          </Card>
         </div>
       </div>
     )
@@ -160,19 +163,20 @@ export default function CalculatorsPage() {
           {categoryOptions.map((category) => {
             const isActive = activeCategory === category
             return (
-              <button
+              <Button
                 key={category}
                 type="button"
+                variant={isActive ? 'default' : 'outline'}
                 onClick={() => setActiveCategory(category)}
                 aria-pressed={isActive}
-                className={`inline-flex h-12 shrink-0 items-center rounded-full border px-4 text-meta font-medium transition ${
+                className={`h-12 shrink-0 rounded-full px-4 text-meta font-medium ${
                   isActive
                     ? 'border-accent bg-accent text-accent-foreground'
-                    : 'border-border bg-card text-accent hover:border-accent/40 hover:bg-accent/10'
+                    : 'text-accent hover:border-accent/40 hover:bg-accent/10'
                 }`}
               >
                 {category}
-              </button>
+              </Button>
             )
           })}
         </div>

--- a/src/app/consultant/layout.tsx
+++ b/src/app/consultant/layout.tsx
@@ -111,13 +111,13 @@ export default function ConsultantLayout({ children }: ConsultantLayoutProps) {
                 : 'You don’t have access to the organization workspace.'}
             </p>
             {accessState === 'error' ? (
-              <button
-                type="button"
-                className="text-sm underline text-primary"
+              <Button
+                variant="link"
+                className="h-auto p-0 text-sm text-primary"
                 onClick={() => window.location.reload()}
               >
                 Retry
-              </button>
+              </Button>
             ) : (
               <Link href="/dashboard" className="text-sm underline text-primary">
                 Go to dashboard

--- a/src/app/delete-account/page.tsx
+++ b/src/app/delete-account/page.tsx
@@ -5,6 +5,8 @@ import { useRouter } from 'next/navigation'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Checkbox } from '@/components/ui/checkbox'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { AlertTriangle, ArrowLeft } from 'lucide-react'
 import { useSupabaseAuth } from '@/hooks/useSupabaseAuth'
@@ -179,9 +181,9 @@ export default function DeleteAccountPage() {
                   <label htmlFor="reason" className="text-sm font-medium">
                     Reason for deletion (optional)
                   </label>
-                  <textarea
+                  <Textarea
                     id="reason"
-                    className="w-full min-h-[80px] rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                    className="min-h-[80px]"
                     placeholder="Tell us why you're leaving..."
                     value={reason}
                     onChange={(e) => setReason(e.target.value)}
@@ -191,12 +193,10 @@ export default function DeleteAccountPage() {
 
                 <div className="space-y-2">
                   <label className="flex items-start gap-3 cursor-pointer">
-                    <input
-                      type="checkbox"
+                    <Checkbox
                       checked={confirmed}
-                      onChange={(e) => setConfirmed(e.target.checked)}
-                      className="mt-0.5 h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-500"
-                      required
+                      onCheckedChange={(checked) => setConfirmed(checked === true)}
+                      className="mt-0.5"
                     />
                     <span className="text-sm text-gray-700">
                       I understand that my account and all associated data will be{' '}
@@ -216,12 +216,13 @@ export default function DeleteAccountPage() {
           <div className="text-center text-sm text-gray-500">
             <p>
               Changed your mind?{' '}
-              <button
+              <Button
+                variant="link"
                 onClick={() => router.push('/settings')}
-                className="text-blue-600 hover:underline"
+                className="h-auto p-0 text-blue-600"
               >
                 Go back to settings
-              </button>
+              </Button>
             </p>
           </div>
         </div>

--- a/src/app/farms/[id]/page.tsx
+++ b/src/app/farms/[id]/page.tsx
@@ -18,6 +18,16 @@ import {
   DialogHeader,
   DialogTitle
 } from '@/components/ui/dialog'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -141,6 +151,11 @@ export default function FarmDetailsPage() {
   const [deletingRecord, setDeletingRecord] = useState<any>(null)
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
+  const [pendingDateGroupDelete, setPendingDateGroupDelete] = useState<{
+    date: string
+    activities: any[]
+  } | null>(null)
+  const [pendingFarmDelete, setPendingFarmDelete] = useState<number | null>(null)
 
   // Edit mode state for UnifiedDataLogsModal
   const [editModeLogs, setEditModeLogs] = useState<any[]>([])
@@ -1250,15 +1265,14 @@ export default function FarmDetailsPage() {
     }
   }
 
-  // New handler for deleting date groups
-  const handleDeleteDateGroup = async (date: string, activities: any[]) => {
-    if (
-      !confirm(
-        `Are you sure you want to delete all ${activities.length} logs from ${date}? This action cannot be undone.`
-      )
-    ) {
-      return
-    }
+  // New handler for deleting date groups — opens confirmation dialog
+  const handleDeleteDateGroup = (date: string, activities: any[]) => {
+    setPendingDateGroupDelete({ date, activities })
+  }
+
+  const confirmDeleteDateGroup = async () => {
+    if (!pendingDateGroupDelete) return
+    const { activities } = pendingDateGroupDelete
 
     try {
       setIsDeleting(true)
@@ -1298,6 +1312,7 @@ export default function FarmDetailsPage() {
       logger.error('Error deleting date group:', error)
     } finally {
       setIsDeleting(false)
+      setPendingDateGroupDelete(null)
     }
   }
 
@@ -1350,18 +1365,20 @@ export default function FarmDetailsPage() {
     setShowFarmModal(true)
   }
 
-  const handleDeleteFarm = async (farmId: number) => {
-    if (
-      confirm(
-        'Are you sure you want to delete this farm? This will also delete all associated records.'
-      )
-    ) {
-      try {
-        await SupabaseService.deleteFarm(farmId)
-        router.push('/farms') // Navigate back to farms list
-      } catch (error) {
-        logger.error('Error deleting farm:', error)
-      }
+  const handleDeleteFarm = (farmId: number) => {
+    setPendingFarmDelete(farmId)
+  }
+
+  const confirmDeleteFarm = async () => {
+    if (pendingFarmDelete === null) return
+    const farmIdToDelete = pendingFarmDelete
+    try {
+      await SupabaseService.deleteFarm(farmIdToDelete)
+      router.push('/farms') // Navigate back to farms list
+    } catch (error) {
+      logger.error('Error deleting farm:', error)
+    } finally {
+      setPendingFarmDelete(null)
     }
   }
 
@@ -1631,10 +1648,11 @@ export default function FarmDetailsPage() {
             {moduleShortcuts.map((link) => {
               const Icon = link.icon
               return (
-                <button
+                <Button
                   key={link.label}
                   type="button"
-                  className="group flex flex-col items-center gap-1 rounded-xl border border-border/40 bg-card px-1.5 py-2.5 shadow-sm transition active:scale-95 active:shadow-none hover:border-accent/50 hover:bg-accent/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+                  variant="ghost"
+                  className="group flex h-auto flex-col items-center gap-1 rounded-xl border border-border/40 bg-card px-1.5 py-2.5 shadow-sm transition active:scale-95 active:shadow-none hover:border-accent/50 hover:bg-accent/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
                   onClick={() => router.push(link.href)}
                   aria-label={`Open ${link.label}`}
                 >
@@ -1642,7 +1660,7 @@ export default function FarmDetailsPage() {
                   <span className="text-[10px] font-medium text-foreground w-full text-center truncate">
                     {link.label}
                   </span>
-                </button>
+                </Button>
               )
             })}
           </div>
@@ -2105,6 +2123,62 @@ export default function FarmDetailsPage() {
             </DialogFooter>
           </DialogContent>
         </Dialog>
+
+        {/* Delete Date Group Confirmation */}
+        <AlertDialog
+          open={pendingDateGroupDelete !== null}
+          onOpenChange={(open) => {
+            if (!open && !isDeleting) setPendingDateGroupDelete(null)
+          }}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete logs?</AlertDialogTitle>
+              <AlertDialogDescription>
+                Are you sure you want to delete all {pendingDateGroupDelete?.activities.length} logs
+                from {pendingDateGroupDelete?.date}? This action cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={(e) => {
+                  e.preventDefault()
+                  confirmDeleteDateGroup()
+                }}
+                disabled={isDeleting}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                {isDeleting ? 'Deleting...' : 'Delete'}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+
+        {/* Delete Farm Confirmation */}
+        <AlertDialog
+          open={pendingFarmDelete !== null}
+          onOpenChange={(open) => !open && setPendingFarmDelete(null)}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete farm?</AlertDialogTitle>
+              <AlertDialogDescription>
+                Are you sure you want to delete this farm? This will also delete all associated
+                records.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={confirmDeleteFarm}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
 
         {/* Farm Modal (Create/Edit) */}
         <FarmModal

--- a/src/app/farms/[id]/page.tsx
+++ b/src/app/farms/[id]/page.tsx
@@ -1372,13 +1372,16 @@ export default function FarmDetailsPage() {
   const confirmDeleteFarm = async () => {
     if (pendingFarmDelete === null) return
     const farmIdToDelete = pendingFarmDelete
+    setIsDeleting(true)
     try {
       await SupabaseService.deleteFarm(farmIdToDelete)
       router.push('/farms') // Navigate back to farms list
     } catch (error) {
       logger.error('Error deleting farm:', error)
-    } finally {
+      toast.error('Failed to delete farm. Please try again.')
       setPendingFarmDelete(null)
+    } finally {
+      setIsDeleting(false)
     }
   }
 
@@ -2158,7 +2161,9 @@ export default function FarmDetailsPage() {
         {/* Delete Farm Confirmation */}
         <AlertDialog
           open={pendingFarmDelete !== null}
-          onOpenChange={(open) => !open && setPendingFarmDelete(null)}
+          onOpenChange={(open) => {
+            if (!open && !isDeleting) setPendingFarmDelete(null)
+          }}
         >
           <AlertDialogContent>
             <AlertDialogHeader>
@@ -2169,12 +2174,16 @@ export default function FarmDetailsPage() {
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
               <AlertDialogAction
-                onClick={confirmDeleteFarm}
+                onClick={(e) => {
+                  e.preventDefault()
+                  confirmDeleteFarm()
+                }}
+                disabled={isDeleting}
                 className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
               >
-                Delete
+                {isDeleting ? 'Deleting...' : 'Delete'}
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>

--- a/src/app/farms/[id]/soil-profiling/page.tsx
+++ b/src/app/farms/[id]/soil-profiling/page.tsx
@@ -33,6 +33,16 @@ import {
   DialogHeader,
   DialogTitle
 } from '@/components/ui/dialog'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog'
 import { Badge } from '@/components/ui/badge'
 import { toast } from 'sonner'
 import { SoilProfileService } from '@/lib/soil-profile-service'
@@ -186,6 +196,7 @@ export default function SoilProfilingPage() {
   const [activeTab, setActiveTab] = useState<'history' | 'trends'>('history')
   const [editingProfileId, setEditingProfileId] = useState<number | null>(null)
   const [focusedSection, setFocusedSection] = useState<SoilSectionName | null>(null)
+  const [pendingDeleteProfileId, setPendingDeleteProfileId] = useState<number | null>(null)
   const previewUrlsRef = useRef<Record<SoilSectionName, string | null>>({
     top: null,
     bottom: null,
@@ -384,6 +395,19 @@ export default function SoilProfilingPage() {
       toast.error(error instanceof Error ? error.message : 'Failed to save soil profile')
     } finally {
       setSavingProfile(false)
+    }
+  }
+
+  const confirmDeleteProfile = async () => {
+    if (pendingDeleteProfileId === null) return
+    try {
+      await SoilProfileService.deleteProfile(pendingDeleteProfileId)
+      await loadSoilProfiles()
+      toast.success('Profile deleted')
+    } catch (error: unknown) {
+      toast.error(error instanceof Error ? error.message : 'Failed to delete profile')
+    } finally {
+      setPendingDeleteProfileId(null)
     }
   }
 
@@ -732,8 +756,9 @@ export default function SoilProfilingPage() {
           </label>
           {state.photoPreview && (
             <div className="space-y-2">
-              <button
+              <Button
                 type="button"
+                variant="link"
                 onClick={() =>
                   setSections((prev) => ({
                     ...prev,
@@ -743,10 +768,10 @@ export default function SoilProfilingPage() {
                     }
                   }))
                 }
-                className="text-xs font-semibold text-foreground underline-offset-4 hover:underline"
+                className="h-auto p-0 text-xs font-semibold text-foreground underline-offset-4 hover:underline"
               >
                 {state.showPreview ? 'Hide preview' : 'Show preview'}
-              </button>
+              </Button>
               {state.showPreview && (
                 <div className="aspect-[16/9] w-full overflow-hidden rounded-xl border border-border/60 bg-muted">
                   {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -985,27 +1010,16 @@ export default function SoilProfilingPage() {
                                 size="icon"
                                 variant="ghost"
                                 className="h-8 w-8 text-destructive"
-                                onClick={async () => {
-                                  try {
-                                    if (!profile.id) return
-                                    if (!window.confirm('Delete this soil profile?')) return
-                                    await SoilProfileService.deleteProfile(profile.id)
-                                    await loadSoilProfiles()
-                                    toast.success('Profile deleted')
-                                  } catch (error: unknown) {
-                                    toast.error(
-                                      error instanceof Error
-                                        ? error.message
-                                        : 'Failed to delete profile'
-                                    )
-                                  }
+                                onClick={() => {
+                                  if (!profile.id) return
+                                  setPendingDeleteProfileId(profile.id)
                                 }}
                               >
                                 <Trash2 className="h-4 w-4" />
                               </Button>
-                              <span className="rounded-full bg-green-100 px-3 py-1 text-xs font-semibold text-green-700">
+                              <Badge className="h-auto bg-green-100 px-3 py-1 text-xs font-semibold text-green-700 hover:bg-green-100">
                                 Avg {average ?? '—'}%
-                              </span>
+                              </Badge>
                             </div>
                           </div>
                           <div className="mt-2 flex flex-wrap gap-2 text-[11px] text-muted-foreground">
@@ -1167,16 +1181,17 @@ export default function SoilProfilingPage() {
                               Record this section to start a trend.
                             </p>
                           )}
-                          <button
+                          <Button
                             type="button"
+                            variant="link"
                             onClick={() =>
                               setFocusedSection((prev) => (prev === trend.name ? null : trend.name))
                             }
-                            className="mt-3 inline-flex items-center gap-1 text-xs font-semibold text-primary underline-offset-4 hover:underline"
+                            className="mt-3 inline-flex h-auto items-center gap-1 p-0 text-xs font-semibold text-primary underline-offset-4 hover:underline"
                           >
                             {focusedSection === trend.name ? 'Hide details' : 'View details'}
                             <ArrowRight className="h-3 w-3" />
-                          </button>
+                          </Button>
                           {focusedSection === trend.name && (
                             <div className="mt-3 space-y-2 rounded-2xl border border-border/60 bg-muted/40 p-3 text-xs">
                               {sectionHistory[trend.name].length ? (
@@ -1395,18 +1410,19 @@ export default function SoilProfilingPage() {
                                   {formatDisplayValue(averageEc, ' dS/m')}
                                 </p>
                               </div>
-                              <span className="rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-700">
+                              <Badge className="h-auto bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-700 hover:bg-emerald-50">
                                 Fusarium {fusariumValue}
-                              </span>
+                              </Badge>
                             </div>
-                            <button
+                            <Button
                               type="button"
+                              variant="link"
                               onClick={() => setActiveTab('history')}
-                              className="mt-3 inline-flex items-center gap-1 text-xs font-semibold text-primary underline-offset-4 hover:underline"
+                              className="mt-3 inline-flex h-auto items-center gap-1 p-0 text-xs font-semibold text-primary underline-offset-4 hover:underline"
                             >
                               View profile
                               <ArrowRight className="h-3 w-3" />
-                            </button>
+                            </Button>
                           </div>
                         )
                       })
@@ -1478,6 +1494,29 @@ export default function SoilProfilingPage() {
               </div>
             </DialogContent>
           </Dialog>
+
+          <AlertDialog
+            open={pendingDeleteProfileId !== null}
+            onOpenChange={(open) => !open && setPendingDeleteProfileId(null)}
+          >
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Delete this soil profile?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This will permanently remove the profile and its recorded sections.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={confirmDeleteProfile}
+                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                >
+                  Delete
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
         </div>
       </div>
     </ProtectedRoute>

--- a/src/app/farms/page.tsx
+++ b/src/app/farms/page.tsx
@@ -17,6 +17,16 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog'
 import { capitalize } from '@/lib/utils'
 
 export default function FarmsPage() {
@@ -25,6 +35,7 @@ export default function FarmsPage() {
   const [submitLoading, setSubmitLoading] = useState(false)
   const [showModal, setShowModal] = useState(false)
   const [editingFarm, setEditingFarm] = useState<Farm | null>(null)
+  const [pendingDelete, setPendingDelete] = useState<number | null>(null)
 
   useEffect(() => {
     loadFarms()
@@ -73,18 +84,16 @@ export default function FarmsPage() {
     setShowModal(true)
   }
 
-  const handleDelete = async (id: number) => {
-    if (
-      confirm(
-        'Are you sure you want to delete this farm? This will also delete all associated records.'
-      )
-    ) {
-      try {
-        await SupabaseService.deleteFarm(id)
-        await loadFarms()
-      } catch (error) {
-        console.error('Error deleting farm:', error)
-      }
+  const confirmDelete = async () => {
+    if (pendingDelete === null) return
+    const id = pendingDelete
+    try {
+      await SupabaseService.deleteFarm(id)
+      await loadFarms()
+    } catch (error) {
+      console.error('Error deleting farm:', error)
+    } finally {
+      setPendingDelete(null)
     }
   }
 
@@ -244,7 +253,7 @@ export default function FarmsPage() {
                                   <DropdownMenuItem
                                     onClick={(e) => {
                                       e.preventDefault()
-                                      handleDelete(farm.id!)
+                                      setPendingDelete(farm.id!)
                                     }}
                                     className="text-red-600 focus:text-red-600"
                                   >
@@ -322,6 +331,31 @@ export default function FarmsPage() {
           editingFarm={editingFarm}
           isSubmitting={submitLoading}
         />
+
+        {/* Delete Farm Confirmation */}
+        <AlertDialog
+          open={pendingDelete !== null}
+          onOpenChange={(open) => !open && setPendingDelete(null)}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete farm?</AlertDialogTitle>
+              <AlertDialogDescription>
+                Are you sure you want to delete this farm? This will also delete all associated
+                records.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={confirmDelete}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </div>
     </ProtectedRoute>
   )

--- a/src/app/farms/page.tsx
+++ b/src/app/farms/page.tsx
@@ -92,6 +92,7 @@ export default function FarmsPage() {
       await loadFarms()
     } catch (error) {
       console.error('Error deleting farm:', error)
+      toast.error('Failed to delete farm. Please try again.')
     } finally {
       setPendingDelete(null)
     }

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/nextjs'
 import { useEffect } from 'react'
 import { AlertTriangle, RefreshCw, Home } from 'lucide-react'
 import Link from 'next/link'
+import { Button } from '@/components/ui/button'
 
 export default function GlobalError({
   error,
@@ -107,26 +108,14 @@ export default function GlobalError({
                 flexWrap: 'wrap'
               }}
             >
-              <button
+              <Button
                 type="button"
                 onClick={reset}
-                style={{
-                  padding: '0.5rem 1rem',
-                  backgroundColor: '#37a765',
-                  color: 'white',
-                  border: 'none',
-                  borderRadius: '0.375rem',
-                  cursor: 'pointer',
-                  fontSize: '0.875rem',
-                  fontWeight: '500',
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '0.5rem'
-                }}
+                className="gap-2 bg-[#37a765] text-white hover:bg-[#2f9159]"
               >
                 <RefreshCw style={{ width: '1rem', height: '1rem' }} />
                 Try again
-              </button>
+              </Button>
               <Link
                 href="/"
                 style={{

--- a/src/app/help/page.tsx
+++ b/src/app/help/page.tsx
@@ -101,10 +101,10 @@ export default function HelpCenter() {
           </CardHeader>
           <CardContent className="space-y-4 text-slate-700">
             {quickFaqs.map((faq) => (
-              <div key={faq.question} className="rounded-lg border border-slate-200 p-4">
+              <Card key={faq.question} className="gap-0 border-slate-200 p-4">
                 <p className="font-semibold text-slate-900">{faq.question}</p>
                 <p className="mt-2 text-sm leading-relaxed text-slate-600">{faq.answer}</p>
-              </div>
+              </Card>
             ))}
           </CardContent>
         </Card>

--- a/src/app/help/page.tsx
+++ b/src/app/help/page.tsx
@@ -101,7 +101,7 @@ export default function HelpCenter() {
           </CardHeader>
           <CardContent className="space-y-4 text-slate-700">
             {quickFaqs.map((faq) => (
-              <Card key={faq.question} className="gap-0 border-slate-200 p-4">
+              <Card key={faq.question} className="gap-0 border border-slate-200 p-4">
                 <p className="font-semibold text-slate-900">{faq.question}</p>
                 <p className="mt-2 text-sm leading-relaxed text-slate-600">{faq.answer}</p>
               </Card>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -6,6 +6,10 @@ import { useState, useEffect, useRef, Suspense } from 'react'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Checkbox } from '@/components/ui/checkbox'
 import { useSupabaseAuth } from '@/hooks/useSupabaseAuth'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { LoginButton } from '@/components/auth/LoginButton'
@@ -111,7 +115,7 @@ function LoginPageContent() {
         </div>
 
         {/* Login Form */}
-        <div className="bg-card rounded-lg shadow-[0px_0px_0px_1px_rgba(55,50,47,0.08)] p-8">
+        <Card className="p-8">
           {/* Error Alert */}
           {showError && error && (
             <Alert className="mb-4 border-red-200 bg-red-50">
@@ -121,28 +125,22 @@ function LoginPageContent() {
 
           {/* Email / Phone method switch */}
           <div className="mb-6 grid grid-cols-2 gap-1 rounded-lg bg-muted p-1">
-            <button
+            <Button
               type="button"
+              variant={method === 'email' ? 'default' : 'ghost'}
               onClick={() => setMethod('email')}
-              className={`rounded-md py-2 text-sm font-medium transition-colors ${
-                method === 'email'
-                  ? 'bg-card text-foreground shadow-sm'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
+              className="py-2 text-sm font-medium"
             >
               Email
-            </button>
-            <button
+            </Button>
+            <Button
               type="button"
+              variant={method === 'phone' ? 'default' : 'ghost'}
               onClick={() => setMethod('phone')}
-              className={`rounded-md py-2 text-sm font-medium transition-colors ${
-                method === 'phone'
-                  ? 'bg-card text-foreground shadow-sm'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
+              className="py-2 text-sm font-medium"
             >
               Phone
-            </button>
+            </Button>
           </div>
 
           {method === 'phone' ? (
@@ -156,20 +154,15 @@ function LoginPageContent() {
             />
           ) : (
             <form onSubmit={handleSubmit} className="space-y-6">
-              <div>
-                <label
-                  htmlFor="email"
-                  className="block text-sm font-medium text-card-foreground mb-2"
-                >
-                  Email address
-                </label>
-                <input
+              <div className="space-y-2">
+                <Label htmlFor="email">Email address</Label>
+                <Input
                   id="email"
                   type="email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   required
-                  className="w-full px-3 py-2 border border-border rounded-md shadow-sm placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent min-h-[44px]"
+                  className="w-full min-h-[44px]"
                   placeholder="Enter your email"
                 />
               </div>
@@ -187,25 +180,23 @@ function LoginPageContent() {
 
               <div className="flex items-center justify-between">
                 <div className="flex items-center">
-                  <input
-                    id="remember-me"
-                    type="checkbox"
-                    className="h-4 w-4 text-primary focus:ring-primary border-border rounded"
-                  />
-                  <label htmlFor="remember-me" className="ml-2 block text-sm text-muted-foreground">
+                  <Checkbox id="remember-me" />
+                  <Label
+                    htmlFor="remember-me"
+                    className="ml-2 block text-sm font-normal text-muted-foreground"
+                  >
                     Remember me
-                  </label>
+                  </Label>
                 </div>
 
-                <div className="text-sm">
-                  <button
-                    type="button"
-                    onClick={handleForgotPassword}
-                    className="font-medium text-primary hover:text-primary/80"
-                  >
-                    Forgot your password?
-                  </button>
-                </div>
+                <Button
+                  type="button"
+                  variant="link"
+                  onClick={handleForgotPassword}
+                  className="h-auto p-0 text-sm font-medium"
+                >
+                  Forgot your password?
+                </Button>
               </div>
 
               <Button type="submit" disabled={loading} className="w-full h-12 px-4">
@@ -261,7 +252,7 @@ function LoginPageContent() {
               Create Account for free
             </Link>
           </p>
-        </div>
+        </Card>
       </div>
     </div>
   )

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -127,17 +127,21 @@ function LoginPageContent() {
           <div className="mb-6 grid grid-cols-2 gap-1 rounded-lg bg-muted p-1">
             <Button
               type="button"
-              variant={method === 'email' ? 'default' : 'ghost'}
+              variant="ghost"
               onClick={() => setMethod('email')}
-              className="py-2 text-sm font-medium"
+              className={`py-2 text-sm font-medium ${
+                method === 'email' ? 'bg-white text-foreground shadow-sm hover:bg-white' : ''
+              }`}
             >
               Email
             </Button>
             <Button
               type="button"
-              variant={method === 'phone' ? 'default' : 'ghost'}
+              variant="ghost"
               onClick={() => setMethod('phone')}
-              className="py-2 text-sm font-medium"
+              className={`py-2 text-sm font-medium ${
+                method === 'phone' ? 'bg-white text-foreground shadow-sm hover:bg-white' : ''
+              }`}
             >
               Phone
             </Button>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   AlertTriangle,
@@ -102,10 +103,10 @@ export default function PrivacyPolicyPage() {
 
       <main className="max-w-5xl mx-auto px-4 py-12 space-y-10">
         <section className="space-y-4 text-center">
-          <div className="inline-flex items-center gap-2 rounded-full border border-border bg-secondary px-3 py-1 text-xs font-semibold text-foreground">
+          <Badge variant="outline" className="mx-auto gap-2 bg-secondary px-3 py-1 font-semibold">
             <Shield className="h-4 w-4 text-primary" />
             Data you own, protected by design
-          </div>
+          </Badge>
           <h1 className="text-3xl md:text-4xl font-bold tracking-tight">Privacy Policy</h1>
           <p className="text-muted-foreground text-lg max-w-3xl mx-auto">
             We collect only what we need to operate VineSight. Your operational data is encrypted,

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -103,7 +103,10 @@ export default function PrivacyPolicyPage() {
 
       <main className="max-w-5xl mx-auto px-4 py-12 space-y-10">
         <section className="space-y-4 text-center">
-          <Badge variant="outline" className="mx-auto gap-2 bg-secondary px-3 py-1 font-semibold">
+          <Badge
+            variant="outline"
+            className="mx-auto h-auto gap-2 bg-secondary px-3 py-1 font-semibold"
+          >
             <Shield className="h-4 w-4 text-primary" />
             Data you own, protected by design
           </Badge>

--- a/src/app/reminders/page.tsx
+++ b/src/app/reminders/page.tsx
@@ -481,10 +481,11 @@ export default function RemindersPage() {
                           value={formData.type}
                           onValueChange={(v) => handleInputChange('type', v)}
                         >
-                          <SelectTrigger id="type">
+                          <SelectTrigger id="type" className="w-full">
                             <SelectValue placeholder="Select type" />
                           </SelectTrigger>
                           <SelectContent>
+                            <SelectItem value="note">Note</SelectItem>
                             <SelectItem value="irrigation">Irrigation</SelectItem>
                             <SelectItem value="spray">Spray Treatment</SelectItem>
                             <SelectItem value="fertigation">Fertigation</SelectItem>
@@ -500,7 +501,7 @@ export default function RemindersPage() {
                           value={formData.priority}
                           onValueChange={(v) => handleInputChange('priority', v)}
                         >
-                          <SelectTrigger id="priority">
+                          <SelectTrigger id="priority" className="w-full">
                             <SelectValue placeholder="Select priority" />
                           </SelectTrigger>
                           <SelectContent>
@@ -716,7 +717,11 @@ export default function RemindersPage() {
 
         {/* Notification Settings Modal */}
         <Dialog open={showNotificationSettings} onOpenChange={setShowNotificationSettings}>
-          <DialogContent className="max-w-2xl max-h-[90vh] overflow-auto">
+          <DialogContent className="max-w-2xl max-h-[90vh] overflow-auto" showCloseButton={false}>
+            <DialogHeader className="sr-only">
+              <DialogTitle>Notification Settings</DialogTitle>
+              <DialogDescription>Configure task reminder notifications</DialogDescription>
+            </DialogHeader>
             <NotificationSettings onClose={() => setShowNotificationSettings(false)} />
           </DialogContent>
         </Dialog>

--- a/src/app/reminders/page.tsx
+++ b/src/app/reminders/page.tsx
@@ -7,6 +7,20 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription
+} from '@/components/ui/dialog'
+import {
   Bell,
   Plus,
   Calendar,
@@ -463,32 +477,38 @@ export default function RemindersPage() {
                       </div>
                       <div>
                         <Label htmlFor="type">Task Type</Label>
-                        <select
-                          id="type"
+                        <Select
                           value={formData.type}
-                          onChange={(e) => handleInputChange('type', e.target.value)}
-                          className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                          onValueChange={(v) => handleInputChange('type', v)}
                         >
-                          <option value="irrigation">Irrigation</option>
-                          <option value="spray">Spray Treatment</option>
-                          <option value="fertigation">Fertigation</option>
-                          <option value="training">Training/Pruning</option>
-                          <option value="harvest">Harvest</option>
-                          <option value="other">Other</option>
-                        </select>
+                          <SelectTrigger id="type">
+                            <SelectValue placeholder="Select type" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="irrigation">Irrigation</SelectItem>
+                            <SelectItem value="spray">Spray Treatment</SelectItem>
+                            <SelectItem value="fertigation">Fertigation</SelectItem>
+                            <SelectItem value="training">Training/Pruning</SelectItem>
+                            <SelectItem value="harvest">Harvest</SelectItem>
+                            <SelectItem value="other">Other</SelectItem>
+                          </SelectContent>
+                        </Select>
                       </div>
                       <div>
                         <Label htmlFor="priority">Priority</Label>
-                        <select
-                          id="priority"
+                        <Select
                           value={formData.priority}
-                          onChange={(e) => handleInputChange('priority', e.target.value)}
-                          className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                          onValueChange={(v) => handleInputChange('priority', v)}
                         >
-                          <option value="low">Low</option>
-                          <option value="medium">Medium</option>
-                          <option value="high">High</option>
-                        </select>
+                          <SelectTrigger id="priority">
+                            <SelectValue placeholder="Select priority" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="low">Low</SelectItem>
+                            <SelectItem value="medium">Medium</SelectItem>
+                            <SelectItem value="high">High</SelectItem>
+                          </SelectContent>
+                        </Select>
                       </div>
                     </div>
 
@@ -678,24 +698,28 @@ export default function RemindersPage() {
         ) : null}
 
         {/* Template Selector Modal */}
-        {showTemplateSelector && selectedFarm && (
-          <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4">
-            <div className="bg-white rounded-lg max-w-6xl w-full max-h-[90vh] overflow-auto">
+        {selectedFarm && (
+          <Dialog open={showTemplateSelector} onOpenChange={setShowTemplateSelector}>
+            <DialogContent className="max-w-6xl max-h-[90vh] overflow-auto">
+              <DialogHeader>
+                <DialogTitle>Smart Templates</DialogTitle>
+                <DialogDescription>Choose a pre-defined farming task template</DialogDescription>
+              </DialogHeader>
               <TaskTemplateSelector
                 selectedFarmName={selectedFarm.name}
                 onSelectTemplate={handleTemplateSelect}
                 onCancel={() => setShowTemplateSelector(false)}
               />
-            </div>
-          </div>
+            </DialogContent>
+          </Dialog>
         )}
 
         {/* Notification Settings Modal */}
-        {showNotificationSettings && (
-          <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4">
+        <Dialog open={showNotificationSettings} onOpenChange={setShowNotificationSettings}>
+          <DialogContent className="max-w-2xl max-h-[90vh] overflow-auto">
             <NotificationSettings onClose={() => setShowNotificationSettings(false)} />
-          </div>
-        )}
+          </DialogContent>
+        </Dialog>
       </div>
     </ProtectedRoute>
   )

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -37,6 +37,7 @@ import { capitalize } from '@/lib/utils'
 import { useSupabaseAuth } from '@/hooks/useSupabaseAuth'
 import { useUserPreferences } from '@/hooks/useUserPreferences'
 import { formatCurrency } from '@/lib/currency-utils'
+import { toast } from 'sonner'
 
 interface RecordData {
   irrigation: any[]
@@ -456,7 +457,7 @@ export default function UnifiedReportsPage() {
       if (process.env.NODE_ENV === 'development') {
         console.error(`Error exporting ${format.toUpperCase()}:`, error)
       }
-      alert(`Failed to export ${format.toUpperCase()}: ${error}`)
+      toast.error(`Failed to export ${format.toUpperCase()}: ${error}`)
     } finally {
       setLoading(false)
     }

--- a/src/app/signup/invite/[token]/page.tsx
+++ b/src/app/signup/invite/[token]/page.tsx
@@ -6,6 +6,9 @@ import { useParams, useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Badge } from '@/components/ui/badge'
+import { Card } from '@/components/ui/card'
 import { useSupabaseAuth } from '@/hooks/useSupabaseAuth'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { VALIDATION } from '@/lib/constants'
@@ -227,10 +230,13 @@ export default function InvitedFarmerSignupPage() {
           <Link href="/" className="inline-block mb-6">
             <div className="text-foreground text-2xl font-medium font-sans">Vinesight</div>
           </Link>
-          <div className="inline-flex items-center gap-2 bg-green-100 text-green-700 px-3 py-1 rounded-full text-sm mb-4">
+          <Badge
+            variant="secondary"
+            className="h-auto gap-2 bg-green-100 px-3 py-1 text-green-700 text-sm mb-4 [&>svg]:size-4!"
+          >
             <Sprout className="h-4 w-4" />
             Farmer Invitation
-          </div>
+          </Badge>
           <h1 className="text-foreground text-2xl font-semibold font-sans mb-2">
             {invite.organizationName ? `Join ${invite.organizationName}` : 'Create your account'}
           </h1>
@@ -245,7 +251,7 @@ export default function InvitedFarmerSignupPage() {
           </p>
         </div>
 
-        <div className="bg-card rounded-lg shadow-[0px_0px_0px_1px_rgba(55,50,47,0.08)] p-8">
+        <Card className="p-8">
           {showError && error && (
             <Alert className="mb-4 border-red-200 bg-red-50">
               <AlertDescription className="text-red-800">{error}</AlertDescription>
@@ -255,51 +261,42 @@ export default function InvitedFarmerSignupPage() {
           {mode === 'details' ? (
             <form onSubmit={handleSendOtp} className="space-y-6">
               <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label
-                    htmlFor="firstName"
-                    className="block text-sm font-medium text-card-foreground mb-2"
-                  >
+                <div className="space-y-2">
+                  <Label htmlFor="firstName">
                     First name <span className="text-red-500">*</span>
-                  </label>
-                  <input
+                  </Label>
+                  <Input
                     id="firstName"
                     type="text"
                     value={firstName}
                     onChange={(e) => setFirstName(e.target.value.trimStart())}
                     required
                     maxLength={VALIDATION.MAX_NAME_LENGTH}
-                    className="w-full px-3 py-2 border border-border rounded-md shadow-sm placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent min-h-[44px]"
+                    className="w-full min-h-[44px]"
                     placeholder="First name"
                   />
                 </div>
-                <div>
-                  <label
-                    htmlFor="lastName"
-                    className="block text-sm font-medium text-card-foreground mb-2"
-                  >
+                <div className="space-y-2">
+                  <Label htmlFor="lastName">
                     Last name <span className="text-red-500">*</span>
-                  </label>
-                  <input
+                  </Label>
+                  <Input
                     id="lastName"
                     type="text"
                     value={lastName}
                     onChange={(e) => setLastName(e.target.value.trimStart())}
                     required
                     maxLength={VALIDATION.MAX_NAME_LENGTH}
-                    className="w-full px-3 py-2 border border-border rounded-md shadow-sm placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent min-h-[44px]"
+                    className="w-full min-h-[44px]"
                     placeholder="Last name"
                   />
                 </div>
               </div>
 
-              <div>
-                <label
-                  htmlFor="phone"
-                  className="block text-sm font-medium text-card-foreground mb-2"
-                >
+              <div className="space-y-2">
+                <Label htmlFor="phone">
                   Phone number <span className="text-red-500">*</span>
-                </label>
+                </Label>
                 <Input
                   id="phone"
                   type="tel"
@@ -326,13 +323,10 @@ export default function InvitedFarmerSignupPage() {
             </form>
           ) : mode === 'otp' ? (
             <form onSubmit={handleVerify} className="space-y-6">
-              <div>
-                <label
-                  htmlFor="otp"
-                  className="block text-sm font-medium text-card-foreground mb-2"
-                >
+              <div className="space-y-2">
+                <Label htmlFor="otp">
                   Verification code <span className="text-red-500">*</span>
-                </label>
+                </Label>
                 <Input
                   id="otp"
                   type="text"
@@ -362,19 +356,21 @@ export default function InvitedFarmerSignupPage() {
               </Button>
 
               <div className="flex items-center justify-between text-sm">
-                <button
+                <Button
                   type="button"
+                  variant="ghost"
                   onClick={() => {
                     setStep('details')
                     setOtp('')
                     clearError()
                   }}
-                  className="text-muted-foreground hover:text-foreground"
+                  className="h-auto p-0 text-muted-foreground hover:bg-transparent hover:text-foreground"
                 >
                   Back
-                </button>
-                <button
+                </Button>
+                <Button
                   type="button"
+                  variant="link"
                   disabled={busy}
                   onClick={() => {
                     if (normalized) {
@@ -385,10 +381,10 @@ export default function InvitedFarmerSignupPage() {
                       })
                     }
                   }}
-                  className="font-medium text-primary hover:text-primary/80 disabled:opacity-50"
+                  className="h-auto p-0 font-medium"
                 >
                   Resend code
-                </button>
+                </Button>
               </div>
             </form>
           ) : mode === 'join-current' ? (
@@ -421,14 +417,15 @@ export default function InvitedFarmerSignupPage() {
                 )}
               </Button>
 
-              <button
+              <Button
                 type="button"
+                variant="ghost"
                 disabled={busy}
                 onClick={() => void signOut()}
-                className="w-full text-center text-sm text-muted-foreground hover:text-foreground disabled:opacity-50"
+                className="w-full text-sm text-muted-foreground hover:bg-transparent hover:text-foreground"
               >
                 Use a different account
-              </button>
+              </Button>
             </div>
           ) : (
             <div className="space-y-6">
@@ -470,7 +467,7 @@ export default function InvitedFarmerSignupPage() {
               </Link>
             </p>
           )}
-        </div>
+        </Card>
       </div>
     </div>
   )

--- a/src/app/signup/member/[token]/page.tsx
+++ b/src/app/signup/member/[token]/page.tsx
@@ -7,7 +7,10 @@ import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { useSupabaseAuth } from '@/hooks/useSupabaseAuth'
 import { PasswordInput } from '@/components/ui/password-input'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
+import { Card } from '@/components/ui/card'
 import { Loader2, Building2, Mail } from 'lucide-react'
 import { toast } from 'sonner'
 import { createClient } from '@/lib/supabase'
@@ -257,20 +260,19 @@ export default function InviteAcceptPage() {
             Set a password to finish setting up your account
           </p>
 
-          <div className="bg-card rounded-lg shadow-[0px_0px_0px_1px_rgba(55,50,47,0.08)] p-8">
+          <Card className="p-8">
             <form onSubmit={handleSetPassword} className="space-y-6">
-              <div>
-                <label className="block text-sm font-medium text-card-foreground mb-2">
-                  Email address
-                </label>
+              <div className="space-y-2">
+                <Label htmlFor="member-email">Email address</Label>
                 <div className="relative">
                   <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                  <input
+                  <Input
+                    id="member-email"
                     type="email"
                     value={invite.email}
                     readOnly
                     disabled
-                    className="w-full pl-9 pr-3 py-2 border border-border rounded-md shadow-sm bg-muted text-muted-foreground cursor-not-allowed focus:outline-none min-h-[44px]"
+                    className="w-full pl-9 min-h-[44px]"
                   />
                 </div>
               </div>
@@ -325,7 +327,7 @@ export default function InviteAcceptPage() {
                 )}
               </Button>
             </form>
-          </div>
+          </Card>
         </div>
       </div>
     )
@@ -337,7 +339,7 @@ export default function InviteAcceptPage() {
     <div className="min-h-screen bg-background flex flex-col justify-center items-center px-4">
       <div className="w-full max-w-md">
         {header}
-        <div className="bg-card rounded-lg shadow-[0px_0px_0px_1px_rgba(55,50,47,0.08)] p-8 text-center space-y-4">
+        <Card className="p-8 text-center space-y-4">
           <Mail className="h-10 w-10 text-primary mx-auto" />
           <p className="text-card-foreground">
             We&apos;ve emailed an invitation to <span className="font-medium">{invite.email}</span>.
@@ -353,7 +355,7 @@ export default function InviteAcceptPage() {
             </Link>{' '}
             to accept.
           </p>
-        </div>
+        </Card>
       </div>
     </div>
   )

--- a/src/app/signup/org/page.tsx
+++ b/src/app/signup/org/page.tsx
@@ -10,6 +10,8 @@ import { Alert, AlertDescription } from '@/components/ui/alert'
 import { PasswordInput } from '@/components/ui/password-input'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Badge } from '@/components/ui/badge'
+import { Card } from '@/components/ui/card'
 import { VALIDATION } from '@/lib/constants'
 import { isValidEmail } from '@/lib/validation'
 import { Loader2, Building2 } from 'lucide-react'
@@ -158,10 +160,13 @@ export default function OrganizationSignupPage() {
           <Link href="/" className="inline-block mb-6">
             <div className="text-foreground text-2xl font-medium font-sans">Vinesight</div>
           </Link>
-          <div className="inline-flex items-center gap-2 bg-accent/10 text-primary px-3 py-1 rounded-full text-sm mb-4">
+          <Badge
+            variant="secondary"
+            className="h-auto gap-2 bg-accent/10 px-3 py-1 text-primary text-sm mb-4 [&>svg]:size-4!"
+          >
             <Building2 className="h-4 w-4" />
             For Organizations
-          </div>
+          </Badge>
           <h1 className="text-foreground text-2xl font-semibold font-sans mb-2">
             Create your organization
           </h1>
@@ -170,7 +175,7 @@ export default function OrganizationSignupPage() {
           </p>
         </div>
 
-        <div className="bg-card rounded-lg shadow-[0px_0px_0px_1px_rgba(55,50,47,0.08)] p-8">
+        <Card className="p-8">
           {showError && error && (
             <Alert className="mb-4 border-red-200 bg-red-50">
               <AlertDescription className="text-red-800">{error}</AlertDescription>
@@ -325,7 +330,7 @@ export default function OrganizationSignupPage() {
               </Link>
             </p>
           </div>
-        </div>
+        </Card>
       </div>
     </div>
   )

--- a/src/app/signup/user/[org]/page.tsx
+++ b/src/app/signup/user/[org]/page.tsx
@@ -5,6 +5,10 @@ import { useState, useEffect, useCallback } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Badge } from '@/components/ui/badge'
+import { Card } from '@/components/ui/card'
 import { useSupabaseAuth } from '@/hooks/useSupabaseAuth'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { PasswordInput } from '@/components/ui/password-input'
@@ -172,10 +176,13 @@ export default function OrgUserSignupPage() {
           <Link href="/" className="inline-block mb-6">
             <div className="text-foreground text-2xl font-medium font-sans">Vinesight</div>
           </Link>
-          <div className="inline-flex items-center gap-2 bg-blue-100 text-blue-700 px-3 py-1 rounded-full text-sm mb-4">
+          <Badge
+            variant="secondary"
+            className="h-auto gap-2 bg-blue-100 px-3 py-1 text-blue-700 text-sm mb-4 [&>svg]:size-4!"
+          >
             <Users className="h-4 w-4" />
             Team Member
-          </div>
+          </Badge>
           <h1 className="text-foreground text-2xl font-semibold font-sans mb-2">
             Join {organization.name}
           </h1>
@@ -184,7 +191,7 @@ export default function OrgUserSignupPage() {
           </p>
         </div>
 
-        <div className="bg-card rounded-lg shadow-[0px_0px_0px_1px_rgba(55,50,47,0.08)] p-8">
+        <Card className="p-8">
           {showError && error && (
             <Alert className="mb-4 border-red-200 bg-red-50">
               <AlertDescription className="text-red-800">{error}</AlertDescription>
@@ -193,52 +200,37 @@ export default function OrgUserSignupPage() {
 
           <form onSubmit={handleSubmit} className="space-y-6">
             <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label
-                  htmlFor="firstName"
-                  className="block text-sm font-medium text-card-foreground mb-2"
-                >
-                  First name
-                </label>
-                <input
+              <div className="space-y-2">
+                <Label htmlFor="firstName">First name</Label>
+                <Input
                   id="firstName"
                   type="text"
                   value={firstName}
                   onChange={(e) => setFirstName(e.target.value.trimStart())}
                   required
                   maxLength={VALIDATION.MAX_NAME_LENGTH}
-                  className="w-full px-3 py-2 border border-border rounded-md shadow-sm placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent min-h-[44px]"
+                  className="w-full min-h-[44px]"
                   placeholder="First name"
                 />
               </div>
-              <div>
-                <label
-                  htmlFor="lastName"
-                  className="block text-sm font-medium text-card-foreground mb-2"
-                >
-                  Last name
-                </label>
-                <input
+              <div className="space-y-2">
+                <Label htmlFor="lastName">Last name</Label>
+                <Input
                   id="lastName"
                   type="text"
                   value={lastName}
                   onChange={(e) => setLastName(e.target.value.trimStart())}
                   required
                   maxLength={VALIDATION.MAX_NAME_LENGTH}
-                  className="w-full px-3 py-2 border border-border rounded-md shadow-sm placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent min-h-[44px]"
+                  className="w-full min-h-[44px]"
                   placeholder="Last name"
                 />
               </div>
             </div>
 
-            <div>
-              <label
-                htmlFor="email"
-                className="block text-sm font-medium text-card-foreground mb-2"
-              >
-                Email address
-              </label>
-              <input
+            <div className="space-y-2">
+              <Label htmlFor="email">Email address</Label>
+              <Input
                 id="email"
                 type="email"
                 value={email}
@@ -248,7 +240,7 @@ export default function OrgUserSignupPage() {
                 }}
                 required
                 aria-invalid={!!emailError}
-                className="w-full px-3 py-2 border border-border rounded-md shadow-sm placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent min-h-[44px]"
+                className="w-full min-h-[44px]"
                 placeholder="Enter your email"
               />
               {emailError && <p className="mt-1 text-xs text-red-600">{emailError}</p>}
@@ -314,7 +306,7 @@ export default function OrgUserSignupPage() {
               Sign in
             </Link>
           </p>
-        </div>
+        </Card>
       </div>
     </div>
   )

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   AlertTriangle,
@@ -146,10 +147,10 @@ export default function TermsOfServicePage() {
 
       <main className="max-w-5xl mx-auto px-4 py-12 space-y-10">
         <section className="space-y-4 text-center">
-          <div className="inline-flex items-center gap-2 rounded-full border border-border bg-secondary px-3 py-1 text-xs font-semibold text-foreground">
+          <Badge variant="outline" className="mx-auto gap-2 bg-secondary px-3 py-1 font-semibold">
             <Scale className="h-4 w-4 text-primary" />
             Clear rules for using VineSight
-          </div>
+          </Badge>
           <h1 className="text-3xl md:text-4xl font-bold tracking-tight">Terms of Service</h1>
           <p className="text-muted-foreground text-lg max-w-3xl mx-auto">
             Please read these terms carefully. Using VineSight means you agree to them and to our

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -147,7 +147,10 @@ export default function TermsOfServicePage() {
 
       <main className="max-w-5xl mx-auto px-4 py-12 space-y-10">
         <section className="space-y-4 text-center">
-          <Badge variant="outline" className="mx-auto gap-2 bg-secondary px-3 py-1 font-semibold">
+          <Badge
+            variant="outline"
+            className="mx-auto h-auto gap-2 bg-secondary px-3 py-1 font-semibold"
+          >
             <Scale className="h-4 w-4 text-primary" />
             Clear rules for using VineSight
           </Badge>

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -6,6 +6,7 @@ import { OrganizationService, type Organization } from '@/lib/organization-servi
 import { getTypedSupabaseClient } from '@/lib/supabase'
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute'
 import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   Dialog,
@@ -223,9 +224,9 @@ function UsersPage() {
                     </div>
                   </div>
                   {member.is_owner && (
-                    <span className="text-xs bg-amber-100 text-amber-800 px-2 py-1 rounded-full">
+                    <Badge variant="secondary" className="bg-amber-100 text-amber-800">
                       Owner
-                    </span>
+                    </Badge>
                   )}
                 </div>
               </CardHeader>

--- a/src/app/warehouse/page.tsx
+++ b/src/app/warehouse/page.tsx
@@ -20,6 +20,16 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog'
 
 export default function WarehousePage() {
   return (
@@ -38,6 +48,7 @@ function WarehousePageContent() {
   const [showAddModal, setShowAddModal] = useState(false)
   const [editingItem, setEditingItem] = useState<WarehouseItem | null>(null)
   const [addingStockItem, setAddingStockItem] = useState<WarehouseItem | null>(null)
+  const [deletingItem, setDeletingItem] = useState<WarehouseItem | null>(null)
 
   const loadItems = useCallback(async () => {
     try {
@@ -57,17 +68,18 @@ function WarehousePageContent() {
     loadItems()
   }, [loadItems])
 
-  const handleDelete = async (id: number, name: string) => {
-    const sanitizedName = name.replace(/[^a-zA-Z0-9\s]/g, '').trim()
-    if (!confirm(`Are you sure you want to delete "${sanitizedName}"?`)) return
+  const handleConfirmDelete = async () => {
+    if (!deletingItem) return
 
     try {
-      await warehouseService.deleteWarehouseItem(id)
+      await warehouseService.deleteWarehouseItem(deletingItem.id)
       toast.success('Item deleted successfully')
       loadItems()
     } catch (error) {
       console.error('Error deleting item:', error)
       toast.error('Failed to delete item')
+    } finally {
+      setDeletingItem(null)
     }
   }
 
@@ -313,7 +325,7 @@ function WarehousePageContent() {
                           Edit Item
                         </DropdownMenuItem>
                         <DropdownMenuItem
-                          onClick={() => handleDelete(item.id, item.name)}
+                          onClick={() => setDeletingItem(item)}
                           className="text-red-600 focus:text-red-600"
                         >
                           <Trash2 className="h-4 w-4 mr-2" />
@@ -423,6 +435,33 @@ function WarehousePageContent() {
           onSave={handleStockAdded}
         />
       )}
+
+      <AlertDialog
+        open={deletingItem !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeletingItem(null)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete item?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete &quot;
+              {(deletingItem?.name ?? '').replace(/[^a-zA-Z0-9\s]/g, '').trim()}
+              &quot;? This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirmDelete}
+              className="bg-red-600 text-white hover:bg-red-700"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/src/app/workers/page.tsx
+++ b/src/app/workers/page.tsx
@@ -813,13 +813,16 @@ export default function WorkersPage() {
           <div className="flex flex-wrap items-center gap-3 justify-between">
             <div className="flex rounded-full bg-muted p-1 mx-auto md:mx-0 w-full max-w-sm sm:max-w-md">
               {(['workers', 'attendance', 'analytics'] as const).map((mode) => (
-                <button
+                <Button
                   key={mode}
                   type="button"
+                  variant={viewMode === mode ? 'default' : 'ghost'}
                   onClick={() => setViewMode(mode)}
                   className={cn(
-                    'flex-1 px-4 py-2 text-sm font-medium rounded-full transition text-center',
-                    viewMode === mode ? 'bg-white shadow text-foreground' : 'text-muted-foreground'
+                    'flex-1 rounded-full',
+                    viewMode === mode
+                      ? 'bg-white shadow text-foreground hover:bg-white'
+                      : 'text-muted-foreground'
                   )}
                 >
                   {mode === 'workers'
@@ -827,7 +830,7 @@ export default function WorkersPage() {
                     : mode === 'attendance'
                       ? 'Attendance'
                       : 'Analytics'}
-                </button>
+                </Button>
               ))}
             </div>
             <div className="w-full max-w-sm sm:max-w-md mx-auto sm:mx-0">

--- a/src/components/SentryErrorBoundary.tsx
+++ b/src/components/SentryErrorBoundary.tsx
@@ -33,12 +33,12 @@ class SimpleErrorBoundary extends React.Component<{ children: ReactNode }, { has
             <p className="text-muted-foreground mb-4">
               An unexpected error occurred. Please refresh the page.
             </p>
-            <button
+            <Button
               onClick={() => window.location.reload()}
-              className="px-4 py-2 bg-accent text-accent-foreground rounded hover:bg-accent/90"
+              className="bg-accent text-accent-foreground hover:bg-accent/90"
             >
               Refresh Page
-            </button>
+            </Button>
           </div>
         </div>
       )

--- a/src/components/auth/PhoneLoginForm.tsx
+++ b/src/components/auth/PhoneLoginForm.tsx
@@ -74,17 +74,18 @@ export function PhoneLoginForm({ onSuccess }: PhoneLoginFormProps) {
         <Button type="submit" disabled={loading || token.length < 6} className="w-full h-12">
           {loading ? <Loader2 className="h-5 w-5 animate-spin" /> : 'Verify & sign in'}
         </Button>
-        <button
+        <Button
           type="button"
+          variant="ghost"
           onClick={() => {
             setStep('phone')
             setToken('')
           }}
-          className="flex items-center justify-center gap-1 w-full text-sm text-muted-foreground hover:text-foreground"
+          className="flex items-center justify-center gap-1 w-full text-sm text-muted-foreground hover:bg-transparent hover:text-foreground"
         >
           <ArrowLeft className="h-3 w-3" />
           Use a different number
-        </button>
+        </Button>
       </form>
     )
   }

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -5,6 +5,9 @@ import { useState, useEffect, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Card } from '@/components/ui/card'
 import { useSupabaseAuth } from '@/hooks/useSupabaseAuth'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { LoginButton } from '@/components/auth/LoginButton'
@@ -121,7 +124,7 @@ export default function SignupForm() {
           </p>
         </div>
 
-        <div className="bg-card rounded-lg shadow-[0px_0px_0px_1px_rgba(55,50,47,0.08)] p-8">
+        <Card className="p-8">
           {/* Success Alert */}
           {showSuccess && (
             <Alert className="mb-4 border-green-200 bg-green-50">
@@ -142,52 +145,37 @@ export default function SignupForm() {
 
           <form onSubmit={handleSubmit} className="space-y-6">
             <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label
-                  htmlFor="firstName"
-                  className="block text-sm font-medium text-card-foreground mb-2"
-                >
-                  First name
-                </label>
-                <input
+              <div className="space-y-2">
+                <Label htmlFor="firstName">First name</Label>
+                <Input
                   id="firstName"
                   type="text"
                   value={firstName}
                   onChange={(e) => setFirstName(e.target.value.trimStart())}
                   required
                   maxLength={VALIDATION.MAX_NAME_LENGTH}
-                  className="w-full px-3 py-2 border border-border rounded-md shadow-sm placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent min-h-[44px]"
+                  className="w-full min-h-[44px]"
                   placeholder="Enter your first name"
                 />
               </div>
-              <div>
-                <label
-                  htmlFor="lastName"
-                  className="block text-sm font-medium text-card-foreground mb-2"
-                >
-                  Last name
-                </label>
-                <input
+              <div className="space-y-2">
+                <Label htmlFor="lastName">Last name</Label>
+                <Input
                   id="lastName"
                   type="text"
                   value={lastName}
                   onChange={(e) => setLastName(e.target.value.trimStart())}
                   required
                   maxLength={VALIDATION.MAX_NAME_LENGTH}
-                  className="w-full px-3 py-2 border border-border rounded-md shadow-sm placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent min-h-[44px]"
+                  className="w-full min-h-[44px]"
                   placeholder="Enter your last name"
                 />
               </div>
             </div>
 
-            <div>
-              <label
-                htmlFor="email"
-                className="block text-sm font-medium text-card-foreground mb-2"
-              >
-                Email address
-              </label>
-              <input
+            <div className="space-y-2">
+              <Label htmlFor="email">Email address</Label>
+              <Input
                 id="email"
                 type="email"
                 value={email}
@@ -197,7 +185,7 @@ export default function SignupForm() {
                 }}
                 required
                 aria-invalid={!!emailError}
-                className="w-full px-3 py-2 border border-border rounded-md shadow-sm placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent min-h-[44px]"
+                className="w-full min-h-[44px]"
                 placeholder="Enter your email"
               />
               {emailError && <p className="mt-1 text-xs text-red-600">{emailError}</p>}
@@ -288,7 +276,7 @@ export default function SignupForm() {
               Sign in
             </Link>
           </p>
-        </div>
+        </Card>
       </div>
     </div>
   )

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -12,6 +12,7 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Button } from '@/components/ui/button'
 import { useSupabaseAuth } from '@/hooks/useSupabaseAuth'
 import { cn } from '@/lib/utils'
 
@@ -64,12 +65,13 @@ export function UserMenu({ collapsed = false }: UserMenuProps) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button
+        <Button
           type="button"
+          variant="ghost"
           aria-label={`User menu for ${displayName}`}
           aria-haspopup="menu"
           className={cn(
-            'group flex w-full items-center rounded-md p-2 text-left text-sm font-medium text-sidebar-foreground/80 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground',
+            'group flex h-auto w-full items-center justify-start rounded-md p-2 text-left text-sm font-medium text-sidebar-foreground/80 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground',
             collapsed ? 'justify-center' : 'gap-3'
           )}
         >
@@ -90,7 +92,7 @@ export function UserMenu({ collapsed = false }: UserMenuProps) {
               <ChevronsUpDown className="ml-auto h-4 w-4 text-sidebar-foreground/60 group-hover:text-sidebar-accent-foreground group-data-[state=open]:text-sidebar-accent-foreground" />
             </>
           )}
-        </button>
+        </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-56" align="start" side="top" forceMount>
         <DropdownMenuLabel className="font-normal">

--- a/src/components/consultant/JoinCodeCard.tsx
+++ b/src/components/consultant/JoinCodeCard.tsx
@@ -88,10 +88,10 @@ export function JoinCodeCard(props: JoinCodeCardProps = {}) {
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="rounded-lg border bg-muted/40 p-4">
+        <Card className="gap-0 bg-muted/40 p-4">
           <p className="mb-1 text-xs font-medium text-muted-foreground">Join code</p>
           <p className="font-mono text-2xl font-semibold tracking-wide break-all">{joinCode}</p>
-        </div>
+        </Card>
 
         <div className="flex flex-col gap-2 sm:flex-row">
           <Button variant="outline" onClick={handleCopyCode} className="gap-2">

--- a/src/components/dashboard/EmptyStateDashboard.tsx
+++ b/src/components/dashboard/EmptyStateDashboard.tsx
@@ -3,6 +3,8 @@
 import React from 'react'
 import { useRouter } from 'next/navigation'
 import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { toast } from 'sonner'
 import {
   ArrowRight,
   BookOpen,
@@ -30,7 +32,7 @@ export function EmptyStateDashboard({ onCreateFarm, userName }: EmptyStateDashbo
   }
 
   const handleExploreDemoData = () => {
-    alert('Demo data feature coming soon!')
+    toast('Demo data feature coming soon!')
   }
 
   const quickActions: Array<{
@@ -127,7 +129,7 @@ export function EmptyStateDashboard({ onCreateFarm, userName }: EmptyStateDashbo
 
       <main className="mx-auto max-w-4xl space-y-8 px-3 py-6 sm:px-4 md:px-6 md:py-10">
         <section className="grid gap-6 lg:grid-cols-2">
-          <div className="rounded-3xl border border-border bg-card p-6 shadow-sm">
+          <Card className="gap-0 rounded-3xl p-6 shadow-sm">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
                 <MessageSquare className="h-5 w-5 text-primary" />
@@ -161,9 +163,9 @@ export function EmptyStateDashboard({ onCreateFarm, userName }: EmptyStateDashbo
                 </button>
               ))}
             </div>
-          </div>
+          </Card>
 
-          <div className="rounded-3xl border border-border bg-card p-6 shadow-sm">
+          <Card className="gap-0 rounded-3xl p-6 shadow-sm">
             <div className="flex items-center gap-2">
               <CheckCircle className="h-5 w-5 text-primary" />
               <h2 className="text-base font-semibold text-foreground">Three simple steps</h2>
@@ -184,10 +186,10 @@ export function EmptyStateDashboard({ onCreateFarm, userName }: EmptyStateDashbo
                 </li>
               ))}
             </ol>
-          </div>
+          </Card>
         </section>
 
-        <section className="rounded-3xl border border-border bg-card p-6 shadow-sm">
+        <Card className="gap-0 rounded-3xl p-6 shadow-sm">
           <div className="flex items-center gap-2">
             <BookOpen className="h-5 w-5 text-primary" />
             <h2 className="text-base font-semibold text-foreground">Need guidance?</h2>
@@ -210,7 +212,7 @@ export function EmptyStateDashboard({ onCreateFarm, userName }: EmptyStateDashbo
               </Button>
             ))}
           </div>
-        </section>
+        </Card>
       </main>
     </div>
   )

--- a/src/components/dashboard/FarmSelector.tsx
+++ b/src/components/dashboard/FarmSelector.tsx
@@ -101,8 +101,9 @@ export function FarmSelector({
             <div className="space-y-1">
               {/* Portfolio Option */}
               {showPortfolio && (
-                <button
-                  className={`w-full p-3 text-left rounded-lg border-2 transition-all hover:bg-muted touch-manipulation ${
+                <Button
+                  variant="ghost"
+                  className={`w-full h-auto p-3 justify-start text-left rounded-lg border-2 transition-all hover:bg-muted touch-manipulation ${
                     !selectedFarmId
                       ? 'border-accent/20 bg-accent/10 text-primary'
                       : 'border-transparent'
@@ -121,14 +122,15 @@ export function FarmSelector({
                       </div>
                     </div>
                   </div>
-                </button>
+                </Button>
               )}
 
               {/* Farm Options */}
               {farms.map((farm) => (
-                <button
+                <Button
                   key={farm.id}
-                  className={`w-full p-3 text-left rounded-lg border-2 transition-all hover:bg-muted touch-manipulation ${
+                  variant="ghost"
+                  className={`w-full h-auto p-3 justify-start text-left rounded-lg border-2 transition-all hover:bg-muted touch-manipulation ${
                     selectedFarmId === farm.id
                       ? 'border-accent/20 bg-accent/10 text-primary'
                       : 'border-transparent'
@@ -138,7 +140,7 @@ export function FarmSelector({
                     setIsOpen(false)
                   }}
                 >
-                  <div className="flex items-center gap-3">
+                  <div className="flex items-center gap-3 w-full">
                     <div
                       className={`w-3 h-3 rounded-full flex-shrink-0 ${getStatusColor(farm.status)}`}
                     />
@@ -165,7 +167,7 @@ export function FarmSelector({
                       </div>
                     </div>
                   </div>
-                </button>
+                </Button>
               ))}
             </div>
           </CardContent>
@@ -219,9 +221,10 @@ export function FarmTabs({
   return (
     <div className="flex gap-2 overflow-x-auto pb-2 scrollbar-hide">
       {priorityFarms.map((farm) => (
-        <button
+        <Button
           key={farm.id}
-          className={`flex-shrink-0 p-2 rounded-lg border-2 transition-all touch-manipulation ${
+          variant="ghost"
+          className={`flex-shrink-0 h-auto p-2 rounded-lg border-2 transition-all touch-manipulation ${
             selectedFarmId === farm.id
               ? 'border-accent/20 bg-accent/10 text-primary'
               : `${getStatusColor(farm.status)} hover:shadow-md`
@@ -237,7 +240,7 @@ export function FarmTabs({
               <span className="text-xs font-bold">{farm.healthScore}</span>
             </div>
           </div>
-        </button>
+        </Button>
       ))}
     </div>
   )

--- a/src/components/farm-details/FarmHeader.tsx
+++ b/src/components/farm-details/FarmHeader.tsx
@@ -307,18 +307,19 @@ export function FarmHeader({
                             </div>
                             {onAddFarm && (
                               <div className="sticky bottom-0 border-t border-border bg-popover p-1">
-                                <button
+                                <Button
+                                  variant="ghost"
                                   onClick={(e) => {
                                     e.preventDefault()
                                     onAddFarm()
                                   }}
-                                  className="relative flex w-full cursor-pointer select-none items-center rounded-sm py-3 pl-2 pr-8 text-sm outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+                                  className="relative flex h-auto w-full cursor-pointer select-none items-center justify-start rounded-sm py-3 pl-2 pr-8 text-sm outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
                                 >
                                   <div className="flex items-center gap-3">
                                     <Plus className="h-5 w-5 flex-shrink-0 text-primary" />
                                     <div className="font-medium text-primary">Add New Farm</div>
                                   </div>
-                                </button>
+                                </Button>
                               </div>
                             )}
                           </SelectContent>

--- a/src/components/farm-details/forms/FarmModal.tsx
+++ b/src/components/farm-details/forms/FarmModal.tsx
@@ -493,8 +493,9 @@ export function FarmModal({
                       className="mt-1 h-11 w-full"
                       required
                     />
-                    <button
+                    <Button
                       type="button"
+                      variant="link"
                       onClick={() => {
                         setIsCustomVariety(false)
                         const varieties = getVarietiesForCrop(formData.crop)
@@ -502,10 +503,10 @@ export function FarmModal({
                           handleInputChange('cropVariety', varieties[0])
                         }
                       }}
-                      className="text-xs text-muted-foreground hover:text-foreground underline"
+                      className="h-auto p-0 text-xs text-muted-foreground hover:text-foreground"
                     >
                       ← Use predefined variety instead
-                    </button>
+                    </Button>
                   </div>
                 )}
               </div>

--- a/src/components/farm/CriticalAlertsBanner.tsx
+++ b/src/components/farm/CriticalAlertsBanner.tsx
@@ -73,13 +73,15 @@ function AlertCard({ alert, onAlertAction, onDismiss }: AlertCardProps) {
     <Alert className={`${colors.border} ${colors.background} border-l-4 mb-3 shadow-md relative`}>
       {/* Dismiss button */}
       {onDismiss && (
-        <button
+        <Button
+          variant="ghost"
+          size="icon"
           onClick={() => onDismiss(alert.id)}
-          className="absolute top-2 right-2 p-1 rounded-full hover:bg-black/10 transition-colors"
+          className="absolute top-2 right-2 h-7 w-7 rounded-full hover:bg-black/10"
           aria-label="Dismiss alert"
         >
           <X className="h-4 w-4 text-gray-500" />
-        </button>
+        </Button>
       )}
 
       <div className="flex items-start gap-3 pr-8">

--- a/src/components/fertilizer/FertilizerPlanView.tsx
+++ b/src/components/fertilizer/FertilizerPlanView.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
 import { FlaskConical, Calendar } from 'lucide-react'
 import type { FertilizerPlanWithItems } from '@/lib/fertilizer-plan-service'
 
@@ -53,9 +54,9 @@ export function FertilizerPlanView({ plans }: FertilizerPlanViewProps) {
                       </div>
                     </div>
                     {item.application_date && (
-                      <span className="text-xs text-green-600 bg-green-100 px-2 py-1 rounded">
+                      <Badge variant="secondary" className="bg-green-100 text-green-600">
                         {new Date(item.application_date).toLocaleDateString()}
-                      </span>
+                      </Badge>
                     )}
                   </div>
                 ))}

--- a/src/components/lab-tests/TestRecommendations.tsx
+++ b/src/components/lab-tests/TestRecommendations.tsx
@@ -73,8 +73,11 @@ export function TestRecommendations({ recommendations, testType }: TestRecommend
                 Priority Actions
               </h3>
               <div className="space-y-3">
-                {criticalAndHigh.map((rec, idx) => (
-                  <Card key={idx} className={`gap-0 p-4 ${getPriorityColor(rec.priority)}`}>
+                {criticalAndHigh.map((rec) => (
+                  <Card
+                    key={rec.parameter}
+                    className={`gap-0 p-4 ${getPriorityColor(rec.priority)}`}
+                  >
                     <div className="flex items-start gap-3">
                       <span className="text-2xl">{rec.icon}</span>
                       <div className="flex-1 space-y-2">
@@ -113,8 +116,8 @@ export function TestRecommendations({ recommendations, testType }: TestRecommend
                 Cost Savings Opportunities
               </h3>
               <div className="space-y-3">
-                {savings.map((rec, idx) => (
-                  <Card key={idx} className="gap-0 p-4 bg-green-50 border-green-200">
+                {savings.map((rec) => (
+                  <Card key={rec.parameter} className="gap-0 p-4 bg-green-50 border-green-200">
                     <div className="flex items-start gap-3">
                       <span className="text-2xl">{rec.icon}</span>
                       <div className="flex-1 space-y-2">
@@ -158,8 +161,11 @@ export function TestRecommendations({ recommendations, testType }: TestRecommend
                 Monitor These Parameters ({moderateAndLow.length})
               </summary>
               <div className="space-y-3 mt-3">
-                {moderateAndLow.map((rec, idx) => (
-                  <Card key={idx} className={`gap-0 p-4 ${getPriorityColor(rec.priority)}`}>
+                {moderateAndLow.map((rec) => (
+                  <Card
+                    key={rec.parameter}
+                    className={`gap-0 p-4 ${getPriorityColor(rec.priority)}`}
+                  >
                     <div className="flex items-start gap-3">
                       <span className="text-2xl">{rec.icon}</span>
                       <div className="flex-1 space-y-2">
@@ -198,8 +204,8 @@ export function TestRecommendations({ recommendations, testType }: TestRecommend
                 Optimal Parameters ({optimal.length})
               </summary>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-3">
-                {optimal.map((rec, idx) => (
-                  <Card key={idx} className="gap-0 p-3 bg-green-50 border-green-200">
+                {optimal.map((rec) => (
+                  <Card key={rec.parameter} className="gap-0 p-3 bg-green-50 border-green-200">
                     <div className="flex items-center gap-2">
                       <span className="text-lg">{rec.icon}</span>
                       <div className="flex-1">

--- a/src/components/lab-tests/TestRecommendations.tsx
+++ b/src/components/lab-tests/TestRecommendations.tsx
@@ -74,10 +74,7 @@ export function TestRecommendations({ recommendations, testType }: TestRecommend
               </h3>
               <div className="space-y-3">
                 {criticalAndHigh.map((rec, idx) => (
-                  <div
-                    key={idx}
-                    className={`rounded-lg border p-4 ${getPriorityColor(rec.priority)}`}
-                  >
+                  <Card key={idx} className={`gap-0 p-4 ${getPriorityColor(rec.priority)}`}>
                     <div className="flex items-start gap-3">
                       <span className="text-2xl">{rec.icon}</span>
                       <div className="flex-1 space-y-2">
@@ -102,7 +99,7 @@ export function TestRecommendations({ recommendations, testType }: TestRecommend
                         </div>
                       </div>
                     </div>
-                  </div>
+                  </Card>
                 ))}
               </div>
             </div>
@@ -117,7 +114,7 @@ export function TestRecommendations({ recommendations, testType }: TestRecommend
               </h3>
               <div className="space-y-3">
                 {savings.map((rec, idx) => (
-                  <div key={idx} className="rounded-lg border p-4 bg-green-50 border-green-200">
+                  <Card key={idx} className="gap-0 p-4 bg-green-50 border-green-200">
                     <div className="flex items-start gap-3">
                       <span className="text-2xl">{rec.icon}</span>
                       <div className="flex-1 space-y-2">
@@ -147,7 +144,7 @@ export function TestRecommendations({ recommendations, testType }: TestRecommend
                         </div>
                       </div>
                     </div>
-                  </div>
+                  </Card>
                 ))}
               </div>
             </div>
@@ -162,10 +159,7 @@ export function TestRecommendations({ recommendations, testType }: TestRecommend
               </summary>
               <div className="space-y-3 mt-3">
                 {moderateAndLow.map((rec, idx) => (
-                  <div
-                    key={idx}
-                    className={`rounded-lg border p-4 ${getPriorityColor(rec.priority)}`}
-                  >
+                  <Card key={idx} className={`gap-0 p-4 ${getPriorityColor(rec.priority)}`}>
                     <div className="flex items-start gap-3">
                       <span className="text-2xl">{rec.icon}</span>
                       <div className="flex-1 space-y-2">
@@ -190,7 +184,7 @@ export function TestRecommendations({ recommendations, testType }: TestRecommend
                         </div>
                       </div>
                     </div>
-                  </div>
+                  </Card>
                 ))}
               </div>
             </details>
@@ -205,7 +199,7 @@ export function TestRecommendations({ recommendations, testType }: TestRecommend
               </summary>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-3">
                 {optimal.map((rec, idx) => (
-                  <div key={idx} className="rounded-lg border p-3 bg-green-50 border-green-200">
+                  <Card key={idx} className="gap-0 p-3 bg-green-50 border-green-200">
                     <div className="flex items-center gap-2">
                       <span className="text-lg">{rec.icon}</span>
                       <div className="flex-1">
@@ -215,7 +209,7 @@ export function TestRecommendations({ recommendations, testType }: TestRecommend
                         <p className="text-xs text-green-800 leading-relaxed">{rec.simple}</p>
                       </div>
                     </div>
-                  </div>
+                  </Card>
                 ))}
               </div>
             </details>

--- a/src/components/reminders/NotificationSettings.tsx
+++ b/src/components/reminders/NotificationSettings.tsx
@@ -7,6 +7,13 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import {
   NotificationService,
   NotificationSettings as INotificationSettings
 } from '@/lib/notification-service'
@@ -209,17 +216,20 @@ export function NotificationSettings({ onClose }: NotificationSettingsProps) {
 
                 <div>
                   <Label htmlFor="daysAdvance">Days in Advance</Label>
-                  <select
-                    id="daysAdvance"
-                    value={settings.daysAdvance}
-                    onChange={(e) => handleSettingChange('daysAdvance', parseInt(e.target.value))}
-                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                  <Select
+                    value={String(settings.daysAdvance)}
+                    onValueChange={(v) => handleSettingChange('daysAdvance', parseInt(v))}
                   >
-                    <option value={1}>1 Day</option>
-                    <option value={2}>2 Days</option>
-                    <option value={3}>3 Days</option>
-                    <option value={7}>1 Week</option>
-                  </select>
+                    <SelectTrigger id="daysAdvance">
+                      <SelectValue placeholder="Select days" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="1">1 Day</SelectItem>
+                      <SelectItem value="2">2 Days</SelectItem>
+                      <SelectItem value="3">3 Days</SelectItem>
+                      <SelectItem value="7">1 Week</SelectItem>
+                    </SelectContent>
+                  </Select>
                 </div>
               </div>
             </>

--- a/src/components/reminders/NotificationSettings.tsx
+++ b/src/components/reminders/NotificationSettings.tsx
@@ -220,7 +220,7 @@ export function NotificationSettings({ onClose }: NotificationSettingsProps) {
                     value={String(settings.daysAdvance)}
                     onValueChange={(v) => handleSettingChange('daysAdvance', parseInt(v))}
                   >
-                    <SelectTrigger id="daysAdvance">
+                    <SelectTrigger id="daysAdvance" className="w-full">
                       <SelectValue placeholder="Select days" />
                     </SelectTrigger>
                     <SelectContent>

--- a/src/components/reminders/TaskTemplateSelector.tsx
+++ b/src/components/reminders/TaskTemplateSelector.tsx
@@ -314,7 +314,7 @@ export function TaskTemplateSelector({
                         value={formData.priority}
                         onValueChange={(v) => handleInputChange('priority', v)}
                       >
-                        <SelectTrigger id="priority">
+                        <SelectTrigger id="priority" className="w-full">
                           <SelectValue placeholder="Select priority" />
                         </SelectTrigger>
                         <SelectContent>
@@ -347,7 +347,7 @@ export function TaskTemplateSelector({
                             value={formData.frequency || 'weekly'}
                             onValueChange={(v) => handleInputChange('frequency', v)}
                           >
-                            <SelectTrigger id="frequency">
+                            <SelectTrigger id="frequency" className="w-full">
                               <SelectValue placeholder="Select frequency" />
                             </SelectTrigger>
                             <SelectContent>

--- a/src/components/reminders/TaskTemplateSelector.tsx
+++ b/src/components/reminders/TaskTemplateSelector.tsx
@@ -7,6 +7,14 @@ import { Badge } from '@/components/ui/badge'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
 import { TASK_TEMPLATES, TaskTemplate, getCurrentSeasonTemplates } from '@/lib/task-templates'
 import {
   Search,
@@ -193,12 +201,10 @@ export function TaskTemplateSelector({
 
           {/* Seasonal Filter */}
           <div className="flex items-center gap-2">
-            <input
-              type="checkbox"
+            <Checkbox
               id="seasonal"
               checked={showOnlySeasonal}
-              onChange={(e) => setShowOnlySeasonal(e.target.checked)}
-              className="rounded"
+              onCheckedChange={(checked) => setShowOnlySeasonal(checked === true)}
             />
             <Label htmlFor="seasonal">Show only current season tasks</Label>
           </div>
@@ -304,28 +310,31 @@ export function TaskTemplateSelector({
 
                     <div>
                       <Label htmlFor="priority">Priority</Label>
-                      <select
-                        id="priority"
+                      <Select
                         value={formData.priority}
-                        onChange={(e) => handleInputChange('priority', e.target.value)}
-                        className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                        onValueChange={(v) => handleInputChange('priority', v)}
                       >
-                        <option value="low">Low</option>
-                        <option value="medium">Medium</option>
-                        <option value="high">High</option>
-                      </select>
+                        <SelectTrigger id="priority">
+                          <SelectValue placeholder="Select priority" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="low">Low</SelectItem>
+                          <SelectItem value="medium">Medium</SelectItem>
+                          <SelectItem value="high">High</SelectItem>
+                        </SelectContent>
+                      </Select>
                     </div>
                   </div>
 
                   {/* Recurring Task Options */}
                   <div className="space-y-3">
                     <div className="flex items-center gap-2">
-                      <input
-                        type="checkbox"
+                      <Checkbox
                         id="recurring"
                         checked={formData.isRecurring}
-                        onChange={(e) => handleInputChange('isRecurring', e.target.checked)}
-                        className="rounded"
+                        onCheckedChange={(checked) =>
+                          handleInputChange('isRecurring', checked === true)
+                        }
                       />
                       <Label htmlFor="recurring">Make this a recurring task</Label>
                     </div>
@@ -334,17 +343,20 @@ export function TaskTemplateSelector({
                       <div className="grid grid-cols-2 gap-4">
                         <div>
                           <Label htmlFor="frequency">Frequency</Label>
-                          <select
-                            id="frequency"
+                          <Select
                             value={formData.frequency || 'weekly'}
-                            onChange={(e) => handleInputChange('frequency', e.target.value)}
-                            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                            onValueChange={(v) => handleInputChange('frequency', v)}
                           >
-                            <option value="weekly">Weekly</option>
-                            <option value="biweekly">Bi-weekly</option>
-                            <option value="monthly">Monthly</option>
-                            <option value="seasonal">Seasonal</option>
-                          </select>
+                            <SelectTrigger id="frequency">
+                              <SelectValue placeholder="Select frequency" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="weekly">Weekly</SelectItem>
+                              <SelectItem value="biweekly">Bi-weekly</SelectItem>
+                              <SelectItem value="monthly">Monthly</SelectItem>
+                              <SelectItem value="seasonal">Seasonal</SelectItem>
+                            </SelectContent>
+                          </Select>
                         </div>
                         <div>
                           <Label htmlFor="endDate">End Date (optional)</Label>

--- a/src/components/ui/password-input.tsx
+++ b/src/components/ui/password-input.tsx
@@ -32,7 +32,7 @@ export function PasswordInput({
     setShowPassword(!showPassword)
   }
 
-  const baseInputClasses = `w-full px-3 py-2 border border-border rounded-md shadow-sm placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent min-h-[44px] pr-10 ${className}`
+  const baseInputClasses = `w-full px-3 py-2 text-base md:text-sm border border-border rounded-md shadow-sm placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent min-h-[44px] pr-10 ${className}`
   const errorInputClasses = error ? 'border-red-500 focus:ring-red-500' : ''
 
   return (

--- a/src/components/workers/AnalyticsView.tsx
+++ b/src/components/workers/AnalyticsView.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -179,9 +180,7 @@ export function AnalyticsView({
                     {formatCurrency(fixedAnalytics.advanceRecovered, currencyPreference)}
                   </p>
                 </div>
-                <div className="rounded-full bg-accent/10 text-primary px-3 py-1 text-xs font-semibold">
-                  Fixed
-                </div>
+                <Badge className="bg-accent/10 text-primary font-semibold">Fixed</Badge>
               </CardContent>
             </Card>
             <Card className="rounded-2xl border-none bg-white shadow-sm">
@@ -198,9 +197,9 @@ export function AnalyticsView({
                     {tempAnalytics.byWorker.reduce((sum, entry) => sum + entry.hours, 0).toFixed(1)}
                   </p>
                 </div>
-                <div className="rounded-full bg-amber-100 text-amber-700 px-3 py-1 text-xs font-semibold">
+                <Badge variant="secondary" className="bg-amber-100 text-amber-700 font-semibold">
                   Temp
-                </div>
+                </Badge>
               </CardContent>
             </Card>
           </div>
@@ -214,9 +213,9 @@ export function AnalyticsView({
                   </p>
                   <h3 className="text-lg font-semibold">Salaries vs. recovered advances</h3>
                 </div>
-                <div className="inline-flex rounded-full border border-accent/20 bg-accent/10 px-3 py-1 text-xs font-semibold text-primary">
+                <Badge className="border border-accent/20 bg-accent/10 font-semibold text-primary">
                   {fixedAnalytics.byWorker.length} workers
-                </div>
+                </Badge>
               </div>
 
               {fixedAnalytics.byWorker.length === 0 ? (
@@ -224,7 +223,10 @@ export function AnalyticsView({
               ) : (
                 <div className="grid gap-3 sm:grid-cols-2">
                   {fixedAnalytics.byWorker.map((entry) => (
-                    <div key={entry.worker_id} className="rounded-2xl border border-muted p-3">
+                    <Card
+                      key={entry.worker_id}
+                      className="gap-0 rounded-2xl border-muted py-3 px-3"
+                    >
                       <div className="flex items-center justify-between">
                         <div>
                           <p className="font-semibold">{entry.worker_name}</p>
@@ -237,7 +239,7 @@ export function AnalyticsView({
                           {formatCurrency(entry.salary, currencyPreference)}
                         </p>
                       </div>
-                    </div>
+                    </Card>
                   ))}
                 </div>
               )}
@@ -363,9 +365,12 @@ export function AnalyticsView({
                   </p>
                   <h3 className="text-lg font-semibold">Payments to short-term labor</h3>
                 </div>
-                <div className="inline-flex rounded-full border border-amber-100 bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-600">
+                <Badge
+                  variant="secondary"
+                  className="border border-amber-100 bg-amber-50 font-semibold text-amber-600"
+                >
                   {tempAnalytics.byWorker.length} workers
-                </div>
+                </Badge>
               </div>
 
               {tempAnalytics.byWorker.length === 0 ? (
@@ -373,7 +378,7 @@ export function AnalyticsView({
               ) : (
                 <div className="grid gap-3 sm:grid-cols-2">
                   {tempAnalytics.byWorker.map((entry) => (
-                    <div key={entry.name} className="rounded-2xl border border-muted p-3">
+                    <Card key={entry.name} className="gap-0 rounded-2xl border-muted py-3 px-3">
                       <div className="flex items-center justify-between">
                         <div>
                           <p className="font-semibold">{entry.name}</p>
@@ -385,7 +390,7 @@ export function AnalyticsView({
                           {formatCurrency(entry.totalPaid, currencyPreference)}
                         </p>
                       </div>
-                    </div>
+                    </Card>
                   ))}
                 </div>
               )}

--- a/src/components/workers/MobileAttendanceView.tsx
+++ b/src/components/workers/MobileAttendanceView.tsx
@@ -492,9 +492,10 @@ export function MobileAttendanceView({
                 <Label className="text-xs text-muted-foreground shrink-0">Farms:</Label>
                 <Popover>
                   <PopoverTrigger asChild>
-                    <button
+                    <Button
                       type="button"
-                      className="flex-1 h-9 px-3 text-sm bg-white border rounded-lg text-left hover:bg-gray-50 transition-colors flex items-center justify-between"
+                      variant="outline"
+                      className="flex-1 h-9 px-3 font-normal bg-white text-left flex items-center justify-between"
                     >
                       <span
                         className={
@@ -508,7 +509,7 @@ export function MobileAttendanceView({
                             : `${selectedFarmIds.length} farm${selectedFarmIds.length > 1 ? 's' : ''} selected`}
                       </span>
                       <ChevronRight className="h-4 w-4 text-muted-foreground" />
-                    </button>
+                    </Button>
                   </PopoverTrigger>
                   <PopoverContent className="w-56 p-2" align="start">
                     <div className="space-y-1" role="menu">


### PR DESCRIPTION
## Summary

Codebase-wide sweep moving raw HTML and custom-styled markup onto the existing **shadcn/ui** primitives in `src/components/ui/`, for visual and behavioral consistency. **37 files** changed.

## What changed

**Form controls**
- Raw `<input>` → `<Input>` + `<Label>` (login, all signup flows, `SignupForm`)
- Native `<select>` → `<Select>` (`onChange` → `onValueChange`) in reminders, `TaskTemplateSelector`, `NotificationSettings`
- `<textarea>` → `<Textarea>`; native checkboxes → `<Checkbox>` (`onCheckedChange`)
- Raw `<button>` → `<Button>` with appropriate variants (tab switchers, view toggles, filter pills, text links, icon buttons)

**Containers & status**
- Custom `rounded/border/shadow` wrappers → `<Card>` (auth/signup, calculators, workers analytics, empty-state, help FAQ, consultant, JoinCodeCard, TestRecommendations)
- Custom pill spans → `<Badge>` — semantic green/amber/blue colors preserved via `className`

**Overlays & blocking calls**
- Hand-rolled `fixed inset-0` modals → `<Dialog>` (reminders)
- Destructive `window.confirm()` → controlled `<AlertDialog>` (delete farm, record/date-group, soil profile, warehouse item). Delete logic preserved byte-for-byte; a single shared dialog drives `.map`-ed rows
- `alert()` placeholders → `toast` from sonner (reports export error, empty-state "coming soon")

## Intentionally left as-is
- **Native radios** (`AddWarehouseItemModal`) and **`<input type="file">`** pickers — no shadcn equivalent installed
- **Rich clickable card-buttons** (farm field-signal tiles, calculator cards, consultant queue rows, attendance day-grid cells) — a `<Button>` swap would nest interactive elements (invalid HTML) or override bespoke layout
- A few tag-pill spans with responsive icon sizing where Badge's forced `[&>svg]:size-3!` would shrink icons

## Verification
- ✅ `tsc --noEmit` — 0 errors
- ✅ `eslint` — 0 errors (remaining warnings are all pre-existing `any`/unused-var noise in `lib/`, `types/`, API routes; verified no new warnings introduced)
- ✅ `next build` — succeeds, all routes compile

No functional behavior changed — handlers, validation, state, and accessibility pairings preserved throughout.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized UI across the app by replacing custom markup with `shadcn/ui` components. Behavior is unchanged; destructive actions now use `AlertDialog`, and notifications use `sonner` toasts.

- **Refactors**
  - Forms: native inputs/selects/textareas/checkboxes → `Input`/`Select`/`Textarea`/`Checkbox` (`onChange` → `onValueChange`; `onCheckedChange`).
  - Buttons: raw buttons → `Button` variants across toggles, menus, link-like actions, dismiss icons, and selectors.
  - Layout: custom wrappers → `Card`; pill labels → `Badge` (login, signup flows, help FAQ, users, fertilizer plans, analytics).
  - Overlays: custom modals → `Dialog`; `confirm()` → controlled `AlertDialog` (farms list/detail, soil profiles, warehouse items; pending-delete state prevents duplicates).
  - Notifications: `alert()` → `toast` (report export errors, “demo data coming soon”).
  - Left as-is: native radios, file inputs, and complex clickable card-buttons to avoid invalid nesting.

- **Bug Fixes**
  - Reminders: added missing “note” type; full-width `Select` triggers; `NotificationSettings` dialog gets sr-only title/description and drops redundant close.
  - Delete flows: farm delete errors surfaced via `toast`; Delete Farm dialog disables submit to prevent duplicates.
  - Visual polish: login method switcher uses white-pill; FAQ cards show borders; header badges no longer clip text; `PasswordInput` font size matches `Input`; lab test recommendation keys stabilized.

<sup>Written for commit da75604023f018df4c16175ae4bc6282d5ee584f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ashish921998/Vinesight/pull/172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **UI Improvements**
  * Standardized interactive controls using shared `Button`, `Card`, `Badge`, `Input`, `Select`, and `Checkbox` components across pages and common UI (including login/signup and dashboards).
  * Updated delete flows to use `AlertDialog` confirmations (two-step and item/farm/profile deletions) instead of browser `confirm()` prompts, with clearer in-progress handling.
  * Replaced browser `alert()` usage with toast-based error reporting for export and empty states.
  * Refreshed layouts for consistency (e.g., card-wrapped sections and improved badge styling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->