### PR TITLE
feat(ui): replace content loaders with shadcn Skeleton placeholders

### DIFF
--- a/src/app/consultant/farmers/[farmerId]/farms/[farmId]/components/FarmPageStates.tsx
+++ b/src/app/consultant/farmers/[farmerId]/farms/[farmId]/components/FarmPageStates.tsx
@@ -1,7 +1,9 @@
 'use client'
 
 import Link from 'next/link'
-import { Loader2, MapPin } from 'lucide-react'
+import { MapPin } from 'lucide-react'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/Skeleton'
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -13,11 +15,50 @@ import {
 
 export function FarmPageLoading() {
   return (
-    <div className="flex items-center justify-center min-h-[60vh]">
-      <div className="text-center space-y-3">
-        <Loader2 className="h-8 w-8 animate-spin text-primary mx-auto" />
-        <p className="text-sm text-muted-foreground">Loading farm workspace...</p>
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <Skeleton className="h-8 w-32" />
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-8 w-8 rounded-full" />
+          <div className="space-y-2">
+            <Skeleton className="h-8 w-48" />
+            <Skeleton className="h-4 w-32" />
+          </div>
+        </div>
       </div>
+
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-32" />
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="space-y-2">
+                <Skeleton className="h-4 w-16" />
+                <Skeleton className="h-5 w-20" />
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="space-y-2">
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-4 w-64" />
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="space-y-2">
+                <Skeleton className="h-4 w-20" />
+                <Skeleton className="h-5 w-16" />
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/src/app/consultant/farmers/[farmerId]/page.tsx
+++ b/src/app/consultant/farmers/[farmerId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useParams } from 'next/navigation'
 import Link from 'next/link'
-import { Card, CardContent } from '@/components/ui/card'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -11,7 +11,8 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator
 } from '@/components/ui/breadcrumb'
-import { Loader2, User, Mail, Phone, IndianRupee, CircleAlert } from 'lucide-react'
+import { User, Mail, Phone, IndianRupee, CircleAlert } from 'lucide-react'
+import { Skeleton } from '@/components/ui/Skeleton'
 import { PaidToggleButton } from '@/components/consultant/PaidToggleButton'
 import { RecordVisitDialog } from '@/components/consultant/RecordVisitDialog'
 import { useFarmerProfileData } from './components/useFarmerProfileData'
@@ -26,10 +27,43 @@ export default function FarmerProfilePage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center min-h-[60vh]">
-        <div className="text-center space-y-3">
-          <Loader2 className="h-8 w-8 animate-spin text-primary mx-auto" />
-          <p className="text-sm text-muted-foreground">Loading farmer profile...</p>
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-32" />
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-2">
+            <Skeleton className="h-8 w-56" />
+            <Skeleton className="h-4 w-72" />
+          </div>
+          <Skeleton className="h-9 w-32" />
+        </div>
+
+        <div className="space-y-3">
+          <Skeleton className="h-6 w-32" />
+          <Card>
+            <CardContent className="p-8">
+              <Skeleton className="mx-auto h-10 w-10 rounded-full" />
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="space-y-3">
+          <Skeleton className="h-6 w-28" />
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Card key={i}>
+                <CardHeader className="pb-2">
+                  <Skeleton className="h-5 w-2/3" />
+                </CardHeader>
+                <CardContent className="space-y-3 pt-0">
+                  <Skeleton className="h-3 w-1/2" />
+                  <div className="flex justify-end">
+                    <Skeleton className="h-4 w-4" />
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
         </div>
       </div>
     )

--- a/src/app/consultant/farmers/page.tsx
+++ b/src/app/consultant/farmers/page.tsx
@@ -6,6 +6,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Input } from '@/components/ui/input'
+import { Skeleton } from '@/components/ui/Skeleton'
 import {
   Select,
   SelectContent,
@@ -14,18 +15,7 @@ import {
   SelectValue
 } from '@/components/ui/select'
 import { toast } from 'sonner'
-import {
-  Users,
-  Search,
-  Sprout,
-  User,
-  UserX,
-  Phone,
-  Mail,
-  Loader2,
-  ChevronRight,
-  MapPin
-} from 'lucide-react'
+import { Users, Search, Sprout, User, UserX, Phone, Mail, ChevronRight, MapPin } from 'lucide-react'
 import { InviteFarmerDialog } from '@/components/consultant/InviteFarmerDialog'
 import { JoinCodeCard } from '@/components/consultant/JoinCodeCard'
 import { PaidToggleButton } from '@/components/consultant/PaidToggleButton'
@@ -155,10 +145,39 @@ export default function FarmerDirectoryPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center min-h-[60vh]">
-        <div className="text-center space-y-3">
-          <Loader2 className="h-8 w-8 animate-spin text-primary mx-auto" />
-          <p className="text-sm text-muted-foreground">Loading farmer directory...</p>
+      <div className="space-y-6">
+        {/* Header */}
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-2">
+            <Skeleton className="h-8 w-48" />
+            <Skeleton className="h-4 w-64" />
+          </div>
+          <Skeleton className="h-9 w-36" />
+        </div>
+
+        {/* Join code card */}
+        <Skeleton className="h-24 w-full rounded-lg" />
+
+        {/* Filters */}
+        <div className="flex flex-col sm:flex-row gap-3">
+          <Skeleton className="h-9 flex-1" />
+          <Skeleton className="h-9 sm:w-56" />
+        </div>
+
+        {/* Farmer list */}
+        <div className="space-y-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Card key={i} className="border-0 shadow-sm">
+              <CardContent className="flex items-center gap-3 p-4">
+                <Skeleton className="h-12 w-12 rounded-full" />
+                <div className="flex-1 space-y-2">
+                  <Skeleton className="h-4 w-1/3" />
+                  <Skeleton className="h-3 w-1/2" />
+                </div>
+                <Skeleton className="h-8 w-20" />
+              </CardContent>
+            </Card>
+          ))}
         </div>
       </div>
     )

--- a/src/app/consultant/page.tsx
+++ b/src/app/consultant/page.tsx
@@ -2,10 +2,11 @@
 
 import { useEffect, useMemo } from 'react'
 import Link from 'next/link'
-import { ArrowRight, ChevronRight, FlaskConical, Loader2, UserPlus, Users } from 'lucide-react'
+import { ArrowRight, ChevronRight, FlaskConical, UserPlus, Users } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/Skeleton'
 import { roleLabels } from '@/lib/consultant-access'
 import { InviteFarmerDialog } from '@/components/consultant/InviteFarmerDialog'
 import { JoinCodeCard } from '@/components/consultant/JoinCodeCard'
@@ -68,8 +69,31 @@ export default function ConsultantOverviewPage() {
 
   if (accessQuery.isPending) {
     return (
-      <div className="flex min-h-[50vh] items-center justify-center">
-        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      <div className="space-y-6">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-2">
+            <Skeleton className="h-8 w-64" />
+            <Skeleton className="h-4 w-96 max-w-full" />
+          </div>
+          <Skeleton className="h-9 w-32" />
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <Card key={i} className="border-border/80">
+              <CardHeader className="space-y-3">
+                <Skeleton className="h-10 w-10 rounded-md" />
+                <div className="space-y-2">
+                  <Skeleton className="h-5 w-40" />
+                  <Skeleton className="h-4 w-full" />
+                </div>
+              </CardHeader>
+              <CardContent>
+                <Skeleton className="h-9 w-32" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
       </div>
     )
   }

--- a/src/app/consultant/team/assignments/page.tsx
+++ b/src/app/consultant/team/assignments/page.tsx
@@ -10,6 +10,7 @@ import { Label } from '@/components/ui/label'
 import { Checkbox } from '@/components/ui/checkbox'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Separator } from '@/components/ui/separator'
+import { Skeleton } from '@/components/ui/Skeleton'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import {
   Select,
@@ -185,11 +186,48 @@ export default function FarmerAssignmentsPage() {
 
   if (busy || (Boolean(access?.canViewAllFarmers) && farmersQuery.isPending)) {
     return (
-      <div className="flex items-center justify-center min-h-[60vh]">
-        <div className="text-center space-y-3">
-          <Loader2 className="h-8 w-8 animate-spin text-primary mx-auto" />
-          <p className="text-sm text-muted-foreground">Loading assignments...</p>
+      <div className="space-y-6">
+        {/* Header */}
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-56" />
+          <Skeleton className="h-4 w-64" />
         </div>
+
+        {/* Target agronomist picker */}
+        <Card>
+          <CardHeader className="pb-3">
+            <Skeleton className="h-5 w-40" />
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <Skeleton className="h-4 w-64" />
+            <Skeleton className="h-9 w-full sm:w-[320px]" />
+          </CardContent>
+        </Card>
+
+        {/* Farmer list */}
+        <Card>
+          <CardHeader className="pb-3 space-y-3">
+            <div className="flex items-center justify-between gap-3">
+              <Skeleton className="h-5 w-24" />
+              <Skeleton className="h-6 w-24" />
+            </div>
+            <Skeleton className="h-9 w-full" />
+          </CardHeader>
+          <CardContent className="pt-0">
+            <div className="space-y-1">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <div key={i} className="flex items-center gap-3 p-3 rounded-lg border bg-muted/30">
+                  <Skeleton className="h-4 w-4" />
+                  <div className="flex-1 space-y-2">
+                    <Skeleton className="h-4 w-1/3" />
+                    <Skeleton className="h-3 w-16" />
+                  </div>
+                  <Skeleton className="h-6 w-20" />
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
       </div>
     )
   }

--- a/src/app/consultant/team/page.tsx
+++ b/src/app/consultant/team/page.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Skeleton } from '@/components/ui/Skeleton'
 import {
   Dialog,
   DialogContent,
@@ -255,11 +256,35 @@ export default function TeamSettingsPage() {
 
   if (busy) {
     return (
-      <div className="flex items-center justify-center min-h-[60vh]">
-        <div className="text-center space-y-3">
-          <Loader2 className="h-8 w-8 animate-spin text-primary mx-auto" />
-          <p className="text-sm text-muted-foreground">Loading team...</p>
+      <div className="space-y-6">
+        {/* Header */}
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-2">
+            <Skeleton className="h-8 w-32" />
+            <Skeleton className="h-4 w-56" />
+          </div>
+          <Skeleton className="h-9 w-32" />
         </div>
+
+        {/* Members */}
+        <Card>
+          <CardHeader className="pb-3">
+            <Skeleton className="h-6 w-28" />
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <div key={i} className="flex items-center gap-3 p-3 rounded-lg border bg-muted/50">
+                  <div className="flex-1 space-y-2">
+                    <Skeleton className="h-4 w-1/3" />
+                    <Skeleton className="h-3 w-1/2" />
+                  </div>
+                  <Skeleton className="h-8 w-20" />
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
       </div>
     )
   }

--- a/src/app/consultant/triage/page.tsx
+++ b/src/app/consultant/triage/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Input } from '@/components/ui/input'
+import { Skeleton } from '@/components/ui/Skeleton'
 import {
   Select,
   SelectContent,
@@ -13,7 +14,7 @@ import {
   SelectValue
 } from '@/components/ui/select'
 import { toast } from 'sonner'
-import { Search, Loader2, ClipboardList, ChevronRight } from 'lucide-react'
+import { Search, ClipboardList, ChevronRight } from 'lucide-react'
 import { useConsultantAccess, useTriageItems } from '@/hooks/consultant/useConsultantQueries'
 import posthog from 'posthog-js'
 import {
@@ -129,11 +130,44 @@ export default function ReportsToReviewPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center min-h-[60vh]">
-        <div className="text-center space-y-3">
-          <Loader2 className="h-8 w-8 animate-spin text-primary mx-auto" />
-          <p className="text-sm text-muted-foreground">Loading reports...</p>
+      <div className="space-y-6">
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-28" />
+          <Skeleton className="h-4 w-72" />
         </div>
+
+        <div className="grid grid-cols-3 gap-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Card key={i}>
+              <CardContent className="space-y-2 p-4">
+                <Skeleton className="h-3 w-20" />
+                <Skeleton className="h-8 w-10" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+
+        <div className="flex flex-col gap-3 sm:flex-row">
+          <Skeleton className="h-9 flex-1" />
+          <Skeleton className="h-9 w-full sm:w-[170px]" />
+        </div>
+
+        <Card>
+          <CardContent className="p-0">
+            <ul className="divide-y">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <li key={i} className="flex items-center gap-3 px-4 py-3">
+                  <div className="flex-1 space-y-2">
+                    <Skeleton className="h-4 w-1/3" />
+                    <Skeleton className="h-3 w-1/4" />
+                  </div>
+                  <Skeleton className="h-6 w-16" />
+                  <Skeleton className="h-6 w-20" />
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
       </div>
     )
   }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/Skeleton'
 import { FarmerDashboard } from '@/components/dashboard/FarmerDashboard'
 import { useSupabaseAuth } from '@/hooks/useSupabaseAuth'
 import posthog from 'posthog-js'
@@ -25,10 +26,36 @@ export default function DashboardPage() {
   // Show loading state
   if (loading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50 flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-green-600 mx-auto"></div>
-          <p className="text-muted-foreground mt-4">Loading Dashboard...</p>
+      <div className="min-h-screen bg-background px-4 py-6 space-y-6 sm:px-6 lg:px-10">
+        {/* Header: farm selector + actions */}
+        <div className="space-y-3">
+          <Skeleton className="h-6 w-28 rounded-full" />
+          <div className="flex flex-col gap-2.5 sm:flex-row sm:items-center">
+            <Skeleton className="h-11 w-full rounded-full sm:h-12 sm:w-64" />
+            <div className="flex gap-1.5">
+              <Skeleton className="h-9 flex-1 rounded-full sm:h-11 sm:w-28" />
+              <Skeleton className="h-9 flex-1 rounded-full sm:h-11 sm:w-28" />
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            <Skeleton className="h-6 w-24 rounded-full" />
+            <Skeleton className="h-6 w-28 rounded-full" />
+            <Skeleton className="h-6 w-20 rounded-full" />
+          </div>
+        </div>
+
+        {/* Today at a glance: stat tiles */}
+        <div className="grid grid-cols-2 gap-3 xl:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-28 rounded-2xl" />
+          ))}
+        </div>
+
+        {/* Sections */}
+        <Skeleton className="h-40 w-full rounded-3xl" />
+        <div className="grid gap-4 md:grid-cols-2">
+          <Skeleton className="h-48 w-full rounded-3xl" />
+          <Skeleton className="h-48 w-full rounded-3xl" />
         </div>
       </div>
     )

--- a/src/app/export/page.tsx
+++ b/src/app/export/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
+import { Loader2 } from 'lucide-react'
 
 export default function ExportPage() {
   const router = useRouter()
@@ -13,8 +14,8 @@ export default function ExportPage() {
 
   return (
     <div className="min-h-screen flex items-center justify-center">
-      <div className="text-center">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-accent mx-auto mb-4"></div>
+      <div className="flex flex-col items-center gap-3">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" aria-hidden="true" />
         <p className="text-muted-foreground">Redirecting to Reports...</p>
       </div>
     </div>

--- a/src/app/farms/[id]/ai-insights/page.tsx
+++ b/src/app/farms/[id]/ai-insights/page.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import { Progress } from '@/components/ui/progress'
+import { Skeleton } from '@/components/ui/Skeleton'
 import {
   ArrowLeft,
   AlertTriangle,
@@ -368,8 +369,8 @@ export default function AIInsightsPage() {
         <div className="bg-white shadow-sm border-b">
           <div className="px-4 py-3">
             <div className="flex items-center gap-3">
-              <div className="w-6 h-6 bg-gray-200 rounded animate-pulse"></div>
-              <div className="w-48 h-5 bg-gray-200 rounded animate-pulse"></div>
+              <Skeleton className="w-6 h-6" />
+              <Skeleton className="w-48 h-5" />
             </div>
           </div>
         </div>
@@ -377,12 +378,12 @@ export default function AIInsightsPage() {
           {/* Stats Cards Skeleton */}
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
             {[1, 2, 3].map((i) => (
-              <div key={i} className="bg-white rounded-lg p-4 animate-pulse">
+              <div key={i} className="bg-white rounded-lg p-4">
                 <div className="flex items-center gap-3">
-                  <div className="w-10 h-10 bg-gray-200 rounded-lg"></div>
+                  <Skeleton className="w-10 h-10 rounded-lg" />
                   <div>
-                    <div className="w-12 h-6 bg-gray-200 rounded mb-1"></div>
-                    <div className="w-24 h-4 bg-gray-200 rounded"></div>
+                    <Skeleton className="w-12 h-6 mb-1" />
+                    <Skeleton className="w-24 h-4" />
                   </div>
                 </div>
               </div>
@@ -390,16 +391,16 @@ export default function AIInsightsPage() {
           </div>
 
           {/* Overview Card Skeleton */}
-          <div className="bg-white rounded-lg p-6 mb-6 animate-pulse">
+          <div className="bg-white rounded-lg p-6 mb-6">
             <div className="flex items-center gap-2 mb-4">
-              <div className="w-5 h-5 bg-gray-200 rounded"></div>
-              <div className="w-32 h-4 bg-gray-200 rounded"></div>
+              <Skeleton className="w-5 h-5" />
+              <Skeleton className="w-32 h-4" />
             </div>
             <div className="grid grid-cols-3 gap-4 text-center">
               {[1, 2, 3].map((i) => (
                 <div key={i}>
-                  <div className="w-8 h-8 bg-gray-200 rounded mx-auto mb-2"></div>
-                  <div className="w-16 h-3 bg-gray-200 rounded mx-auto"></div>
+                  <Skeleton className="w-8 h-8 mx-auto mb-2" />
+                  <Skeleton className="w-16 h-3 mx-auto" />
                 </div>
               ))}
             </div>
@@ -408,33 +409,30 @@ export default function AIInsightsPage() {
           {/* Tab Skeleton */}
           <div className="flex gap-2 mb-4">
             {[1, 2, 3, 4, 5].map((i) => (
-              <div key={i} className="w-20 h-9 bg-gray-200 rounded animate-pulse"></div>
+              <Skeleton key={i} className="w-20 h-9" />
             ))}
           </div>
 
           {/* Insight Cards Skeleton */}
           <div className="space-y-3">
             {[1, 2, 3].map((i) => (
-              <div
-                key={i}
-                className="bg-white rounded-lg border border-l-4 border-l-gray-300 animate-pulse"
-              >
+              <div key={i} className="bg-white rounded-lg border border-l-4 border-l-gray-300">
                 <div className="p-4">
                   <div className="flex items-start gap-3 mb-3">
-                    <div className="w-9 h-9 bg-gray-200 rounded-lg"></div>
+                    <Skeleton className="w-9 h-9 rounded-lg" />
                     <div className="flex-1">
                       <div className="flex items-center gap-2 mb-2">
-                        <div className="w-32 h-4 bg-gray-200 rounded"></div>
-                        <div className="w-16 h-5 bg-gray-200 rounded"></div>
+                        <Skeleton className="w-32 h-4" />
+                        <Skeleton className="w-16 h-5" />
                       </div>
-                      <div className="w-48 h-3 bg-gray-200 rounded mb-1"></div>
-                      <div className="w-64 h-3 bg-gray-200 rounded"></div>
+                      <Skeleton className="w-48 h-3 mb-1" />
+                      <Skeleton className="w-64 h-3" />
                     </div>
                   </div>
-                  <div className="w-full h-2 bg-gray-200 rounded mb-3"></div>
+                  <Skeleton className="w-full h-2 mb-3" />
                   <div className="flex gap-2">
-                    <div className="w-24 h-8 bg-gray-200 rounded"></div>
-                    <div className="w-8 h-8 bg-gray-200 rounded"></div>
+                    <Skeleton className="w-24 h-8" />
+                    <Skeleton className="w-8 h-8" />
                   </div>
                 </div>
               </div>

--- a/src/app/farms/[id]/lab-tests/page.tsx
+++ b/src/app/farms/[id]/lab-tests/page.tsx
@@ -179,12 +179,10 @@ function LabTestsPage() {
 
   if (loading) {
     return (
-      <div
-        className="container max-w-7xl mx-auto p-3 sm:p-6 space-y-2 sm:space-y-6"
-        role="status"
-        aria-live="polite"
-      >
-        <span className="sr-only">Loading lab tests...</span>
+      <div className="container max-w-7xl mx-auto p-3 sm:p-6 space-y-2 sm:space-y-6">
+        <output className="sr-only" aria-live="polite">
+          Loading lab tests...
+        </output>
         {/* Header */}
         <div className="space-y-1.5 sm:space-y-3">
           <Skeleton className="h-8 w-32" />

--- a/src/app/farms/[id]/lab-tests/page.tsx
+++ b/src/app/farms/[id]/lab-tests/page.tsx
@@ -8,6 +8,7 @@ import { LabTestTrendCharts } from '@/components/lab-tests/LabTestTrendCharts'
 import { LabTestComparisonTable } from '@/components/lab-tests/LabTestComparisonTable'
 import { LabTestModal } from '@/components/lab-tests/LabTestModal'
 import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/Skeleton'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import {
   Dialog,
@@ -178,10 +179,29 @@ function LabTestsPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center min-h-[60vh]">
-        <div className="text-center space-y-3">
-          <Loader2 className="h-8 w-8 animate-spin text-primary mx-auto" />
-          <p className="text-sm text-muted-foreground">Loading lab tests...</p>
+      <div
+        className="container max-w-7xl mx-auto p-3 sm:p-6 space-y-2 sm:space-y-6"
+        role="status"
+        aria-live="polite"
+      >
+        <span className="sr-only">Loading lab tests...</span>
+        {/* Header */}
+        <div className="space-y-1.5 sm:space-y-3">
+          <Skeleton className="h-8 w-32" />
+          <div className="space-y-2">
+            <Skeleton className="h-8 w-40" />
+            <Skeleton className="h-4 w-72 hidden sm:block" />
+          </div>
+        </div>
+
+        {/* Tabs */}
+        <Skeleton className="h-14 w-full max-w-md rounded-2xl" />
+
+        {/* Content */}
+        <div className="space-y-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-24 w-full rounded-xl" />
+          ))}
         </div>
       </div>
     )

--- a/src/app/farms/[id]/logs/page.tsx
+++ b/src/app/farms/[id]/logs/page.tsx
@@ -22,6 +22,7 @@ import {
   SelectValue
 } from '@/components/ui/select'
 import { Input } from '@/components/ui/input'
+import { Skeleton } from '@/components/ui/Skeleton'
 import { Label } from '@/components/ui/label'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import {
@@ -684,14 +685,11 @@ export default function FarmLogsPage() {
             <CardContent className="px-3 py-3">
               <div className="space-y-2">
                 {[...Array(5)].map((_, i) => (
-                  <div
-                    key={i}
-                    className="flex items-center gap-2 p-2 bg-gray-50 rounded-lg h-14 animate-pulse"
-                  >
-                    <div className="w-6 h-6 bg-gray-200 rounded flex-shrink-0" />
+                  <div key={i} className="flex items-center gap-2 p-2 bg-gray-50 rounded-lg h-14">
+                    <Skeleton className="w-6 h-6 flex-shrink-0" />
                     <div className="flex-1">
-                      <div className="w-32 h-3 bg-gray-200 rounded mb-1" />
-                      <div className="w-24 h-3 bg-gray-200 rounded" />
+                      <Skeleton className="w-32 h-3 mb-1" />
+                      <Skeleton className="w-24 h-3" />
                     </div>
                   </div>
                 ))}
@@ -951,8 +949,17 @@ export default function FarmLogsPage() {
           </CardHeader>
           <CardContent className="px-2 sm:px-3 pb-3 relative" aria-busy={searchLoading}>
             {searchLoading ? (
-              <div className="flex flex-col items-center justify-center py-12" role="status">
-                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-accent mb-3"></div>
+              <div className="space-y-2" aria-live="polite">
+                <span className="sr-only">Loading activity logs...</span>
+                {[...Array(5)].map((_, i) => (
+                  <div key={i} className="flex items-center gap-2 p-2 bg-gray-50 rounded-lg h-14">
+                    <Skeleton className="w-6 h-6 flex-shrink-0" />
+                    <div className="flex-1">
+                      <Skeleton className="w-32 h-3 mb-1" />
+                      <Skeleton className="w-24 h-3" />
+                    </div>
+                  </div>
+                ))}
               </div>
             ) : logs.length > 0 ? (
               <LogsList

--- a/src/app/farms/[id]/page.tsx
+++ b/src/app/farms/[id]/page.tsx
@@ -19,6 +19,7 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/Skeleton'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute'
@@ -1742,11 +1743,11 @@ export default function FarmDetailsPage() {
                   key={`readiness-skeleton-${index}`}
                   className="flex items-start gap-3 rounded-2xl border border-border/60 bg-muted/30 p-4"
                 >
-                  <div className="h-11 w-11 rounded-2xl bg-muted animate-pulse" />
+                  <Skeleton className="h-11 w-11 rounded-2xl" />
                   <div className="flex-1 space-y-2">
-                    <div className="h-3 w-20 rounded-full bg-muted animate-pulse" />
-                    <div className="h-4 w-36 rounded-full bg-muted animate-pulse" />
-                    <div className="h-3 w-48 rounded-full bg-muted animate-pulse" />
+                    <Skeleton className="h-3 w-20 rounded-full" />
+                    <Skeleton className="h-4 w-36 rounded-full" />
+                    <Skeleton className="h-3 w-48 rounded-full" />
                   </div>
                 </div>
               ))}
@@ -1901,13 +1902,13 @@ export default function FarmDetailsPage() {
                           className="min-w-[190px] rounded-2xl border border-border/60 bg-muted/30 p-3"
                         >
                           <div className="flex items-center justify-between gap-1">
-                            <span className="flex h-8 w-8 items-center justify-center rounded-xl bg-muted animate-pulse" />
-                            <span className="h-3 w-10 rounded-full bg-muted animate-pulse" />
+                            <Skeleton className="h-8 w-8 rounded-xl" />
+                            <Skeleton className="h-3 w-10 rounded-full" />
                           </div>
                           <div className="mt-2 space-y-2">
-                            <div className="h-3 w-20 rounded-full bg-muted animate-pulse" />
-                            <div className="h-4 w-28 rounded-full bg-muted animate-pulse" />
-                            <div className="h-3 w-36 rounded-full bg-muted animate-pulse" />
+                            <Skeleton className="h-3 w-20 rounded-full" />
+                            <Skeleton className="h-4 w-28 rounded-full" />
+                            <Skeleton className="h-3 w-36 rounded-full" />
                           </div>
                         </div>
                       ))}

--- a/src/app/farms/[id]/pest-alerts/page.tsx
+++ b/src/app/farms/[id]/pest-alerts/page.tsx
@@ -3,6 +3,7 @@
 import { useParams, useRouter } from 'next/navigation'
 import { useState, useEffect, useCallback } from 'react'
 import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/Skeleton'
 import { ArrowLeft } from 'lucide-react'
 import { PestAlertDashboard } from '@/components/ai/PestAlertDashboard'
 import { SupabaseService } from '@/lib/supabase-service'
@@ -39,19 +40,20 @@ export default function PestAlertsPage() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gray-50">
+      <div className="min-h-screen bg-gray-50" role="status" aria-live="polite">
+        <span className="sr-only">Loading pest alerts...</span>
         <div className="bg-white shadow-sm border-b">
           <div className="px-4 py-3">
             <div className="flex items-center gap-3">
-              <div className="w-6 h-6 bg-gray-200 rounded animate-pulse"></div>
-              <div className="w-48 h-5 bg-gray-200 rounded animate-pulse"></div>
+              <Skeleton className="w-6 h-6" />
+              <Skeleton className="w-48 h-5" />
             </div>
           </div>
         </div>
         <div className="px-4 py-6">
-          <div className="animate-pulse space-y-4">
-            <div className="h-20 bg-gray-200 rounded"></div>
-            <div className="h-32 bg-gray-200 rounded"></div>
+          <div className="space-y-4">
+            <Skeleton className="h-20 w-full" />
+            <Skeleton className="h-32 w-full" />
           </div>
         </div>
       </div>

--- a/src/app/farms/[id]/pest-alerts/page.tsx
+++ b/src/app/farms/[id]/pest-alerts/page.tsx
@@ -40,8 +40,10 @@ export default function PestAlertsPage() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gray-50" role="status" aria-live="polite">
-        <span className="sr-only">Loading pest alerts...</span>
+      <div className="min-h-screen bg-gray-50">
+        <output className="sr-only" aria-live="polite">
+          Loading pest alerts...
+        </output>
         <div className="bg-white shadow-sm border-b">
           <div className="px-4 py-3">
             <div className="flex items-center gap-3">

--- a/src/app/farms/[id]/tasks/page.tsx
+++ b/src/app/farms/[id]/tasks/page.tsx
@@ -403,30 +403,32 @@ export default function FarmTasksPage() {
             </CardHeader>
             <CardContent className="space-y-3 p-3 sm:p-6">
               {loading ? (
-                <div role="status" aria-live="polite" className="space-y-3">
-                  <span className="sr-only">Loading tasks...</span>
+                <div className="space-y-3">
+                  <output className="sr-only" aria-live="polite">
+                    Loading tasks...
+                  </output>
                   {Array.from({ length: 4 }).map((_, i) => (
-                  <div
-                    key={i}
-                    className="flex flex-col gap-2 rounded-lg border border-border/70 bg-white p-3 shadow-sm sm:gap-3 sm:rounded-xl sm:p-4 md:flex-row md:items-center md:justify-between"
-                  >
-                    <div className="flex flex-1 flex-col gap-1.5 sm:gap-2">
-                      <div className="flex flex-wrap items-center gap-1.5">
-                        <Skeleton className="h-5 w-40" />
-                        <Skeleton className="h-5 w-16 rounded-full" />
+                    <div
+                      key={i}
+                      className="flex flex-col gap-2 rounded-lg border border-border/70 bg-white p-3 shadow-sm sm:gap-3 sm:rounded-xl sm:p-4 md:flex-row md:items-center md:justify-between"
+                    >
+                      <div className="flex flex-1 flex-col gap-1.5 sm:gap-2">
+                        <div className="flex flex-wrap items-center gap-1.5">
+                          <Skeleton className="h-5 w-40" />
+                          <Skeleton className="h-5 w-16 rounded-full" />
+                        </div>
+                        <Skeleton className="h-4 w-3/4" />
+                        <div className="flex flex-wrap items-center gap-2.5 sm:gap-3">
+                          <Skeleton className="h-3 w-24" />
+                          <Skeleton className="h-3 w-20" />
+                        </div>
                       </div>
-                      <Skeleton className="h-4 w-3/4" />
-                      <div className="flex flex-wrap items-center gap-2.5 sm:gap-3">
-                        <Skeleton className="h-3 w-24" />
-                        <Skeleton className="h-3 w-20" />
+                      <div className="flex w-full items-center gap-1.5 sm:gap-2 md:w-auto">
+                        <Skeleton className="h-8 flex-1 sm:h-9 sm:w-20 sm:flex-none" />
+                        <Skeleton className="h-8 w-8 sm:h-9 sm:w-9" />
+                        <Skeleton className="h-8 w-8 sm:h-9 sm:w-9" />
                       </div>
                     </div>
-                    <div className="flex w-full items-center gap-1.5 sm:gap-2 md:w-auto">
-                      <Skeleton className="h-8 flex-1 sm:h-9 sm:w-20 sm:flex-none" />
-                      <Skeleton className="h-8 w-8 sm:h-9 sm:w-9" />
-                      <Skeleton className="h-8 w-8 sm:h-9 sm:w-9" />
-                    </div>
-                  </div>
                   ))}
                 </div>
               ) : filteredTasks.length === 0 ? (

--- a/src/app/farms/[id]/tasks/page.tsx
+++ b/src/app/farms/[id]/tasks/page.tsx
@@ -7,6 +7,7 @@ import { toast } from 'sonner'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/Skeleton'
 import { Input } from '@/components/ui/input'
 import {
   Select,
@@ -402,8 +403,31 @@ export default function FarmTasksPage() {
             </CardHeader>
             <CardContent className="space-y-3 p-3 sm:p-6">
               {loading ? (
-                <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Loading tasks…
+                <div role="status" aria-live="polite" className="space-y-3">
+                  <span className="sr-only">Loading tasks...</span>
+                  {Array.from({ length: 4 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="flex flex-col gap-2 rounded-lg border border-border/70 bg-white p-3 shadow-sm sm:gap-3 sm:rounded-xl sm:p-4 md:flex-row md:items-center md:justify-between"
+                  >
+                    <div className="flex flex-1 flex-col gap-1.5 sm:gap-2">
+                      <div className="flex flex-wrap items-center gap-1.5">
+                        <Skeleton className="h-5 w-40" />
+                        <Skeleton className="h-5 w-16 rounded-full" />
+                      </div>
+                      <Skeleton className="h-4 w-3/4" />
+                      <div className="flex flex-wrap items-center gap-2.5 sm:gap-3">
+                        <Skeleton className="h-3 w-24" />
+                        <Skeleton className="h-3 w-20" />
+                      </div>
+                    </div>
+                    <div className="flex w-full items-center gap-1.5 sm:gap-2 md:w-auto">
+                      <Skeleton className="h-8 flex-1 sm:h-9 sm:w-20 sm:flex-none" />
+                      <Skeleton className="h-8 w-8 sm:h-9 sm:w-9" />
+                      <Skeleton className="h-8 w-8 sm:h-9 sm:w-9" />
+                    </div>
+                  </div>
+                  ))}
                 </div>
               ) : filteredTasks.length === 0 ? (
                 <div className="rounded-xl border border-dashed border-border px-4 py-8 text-center sm:px-6 sm:py-10">

--- a/src/app/farms/page.tsx
+++ b/src/app/farms/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/Skeleton'
 import { Plus, Trash2, Edit, Sprout, MapPin, MoreVertical, ChevronRight } from 'lucide-react'
 import { toast } from 'sonner'
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute'
@@ -151,36 +152,26 @@ export default function FarmsPage() {
         <div className="px-4 py-4 max-w-md mx-auto">
           <div className="space-y-3 max-w-md mx-auto">
             {loading
-              ? // Modern skeleton loading
+              ? // Skeleton loading
                 Array.from({ length: 3 }).map((_, index) => (
-                  <Card key={index} className="border-0 shadow-sm animate-pulse">
+                  <Card key={index} className="border-0 shadow-sm">
                     <CardContent className="p-4">
                       <div className="flex items-center space-x-3">
-                        <div className="w-12 h-12 bg-gray-200 rounded-xl"></div>
+                        <Skeleton className="w-12 h-12 rounded-xl" />
                         <div className="flex-1 space-y-2">
-                          <div className="h-4 bg-gray-200 rounded w-3/4"></div>
-                          <div className="h-3 bg-gray-200 rounded w-1/2"></div>
+                          <Skeleton className="h-4 w-3/4" />
+                          <Skeleton className="h-3 w-1/2" />
                         </div>
-                        <div className="w-6 h-6 bg-gray-200 rounded"></div>
+                        <Skeleton className="w-6 h-6" />
                       </div>
                       <div className="mt-3 pt-3 border-t border-gray-100">
                         <div className="grid grid-cols-2 gap-3">
-                          <div className="text-center">
-                            <div className="h-4 bg-gray-200 rounded w-8 mx-auto mb-1"></div>
-                            <div className="h-2 bg-gray-200 rounded w-12 mx-auto"></div>
-                          </div>
-                          <div className="text-center">
-                            <div className="h-4 bg-gray-200 rounded w-12 mx-auto mb-1"></div>
-                            <div className="h-2 bg-gray-200 rounded w-8 mx-auto"></div>
-                          </div>
-                          <div className="text-center">
-                            <div className="h-4 bg-gray-200 rounded w-10 mx-auto mb-1"></div>
-                            <div className="h-2 bg-gray-200 rounded w-12 mx-auto"></div>
-                          </div>
-                          <div className="text-center">
-                            <div className="h-4 bg-gray-200 rounded w-8 mx-auto mb-1"></div>
-                            <div className="h-2 bg-gray-200 rounded w-12 mx-auto"></div>
-                          </div>
+                          {Array.from({ length: 4 }).map((_, i) => (
+                            <div key={i} className="text-center space-y-1">
+                              <Skeleton className="h-4 w-10 mx-auto" />
+                              <Skeleton className="h-2 w-12 mx-auto" />
+                            </div>
+                          ))}
                         </div>
                       </div>
                     </CardContent>

--- a/src/app/performance/page.tsx
+++ b/src/app/performance/page.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Progress } from '@/components/ui/progress'
+import { Skeleton } from '@/components/ui/Skeleton'
 import {
   Select,
   SelectContent,
@@ -351,14 +352,54 @@ export default function FarmEfficiencyPage() {
           </p>
         </div>
 
-        <Card>
-          <CardContent className="flex items-center justify-center p-8">
-            <div className="flex items-center gap-3">
-              <RefreshCw className="h-6 w-6 animate-spin text-primary" />
-              <span className="text-muted-foreground">Loading performance data...</span>
+        {/* Overall Farm Efficiency Score */}
+        <Card className="mb-6">
+          <CardContent className="p-6">
+            <div className="flex items-center gap-6">
+              <div className="flex-1 space-y-3">
+                <Skeleton className="h-10 w-24" />
+                <Skeleton className="h-3 w-full" />
+              </div>
+              <Skeleton className="h-12 w-12 rounded-full" />
             </div>
           </CardContent>
         </Card>
+
+        {/* Key Efficiency Metrics */}
+        <Card className="mb-6">
+          <CardContent className="p-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Card key={i} className="border-2">
+                  <CardContent className="p-4 space-y-3">
+                    <Skeleton className="h-4 w-2/3" />
+                    <Skeleton className="h-8 w-1/2" />
+                    <Skeleton className="h-2 w-full" />
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Detailed Farm Metrics */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <Card key={i}>
+              <CardContent className="p-6 space-y-4">
+                {Array.from({ length: 3 }).map((_, j) => (
+                  <div key={j} className="flex items-center justify-between p-3 rounded-lg border">
+                    <div className="space-y-2">
+                      <Skeleton className="h-4 w-32" />
+                      <Skeleton className="h-3 w-20" />
+                    </div>
+                    <Skeleton className="h-5 w-16" />
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
       </div>
     )
   }

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -5,6 +5,7 @@ import { PortfolioDashboard } from '@/components/dashboard/PortfolioDashboard'
 import { FarmerDashboard } from '@/components/dashboard/FarmerDashboard'
 import { FarmSelector, FarmTabs } from '@/components/dashboard/FarmSelector'
 import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/Skeleton'
 import { ArrowLeft, Settings } from 'lucide-react'
 import Link from 'next/link'
 import { capitalize } from '@/lib/utils'
@@ -76,14 +77,14 @@ export default function PortfolioPage() {
   if (loading) {
     return (
       <div className="min-h-screen bg-background">
-        <div className="animate-pulse p-4">
-          <div className="h-6 bg-gray-200 rounded w-32 mb-4" />
-          <div className="h-12 bg-gray-200 rounded mb-4" />
+        <div className="p-4">
+          <Skeleton className="h-6 w-32 mb-4" />
+          <Skeleton className="h-12 w-full mb-4" />
           <div className="grid grid-cols-2 gap-4 mb-6">
-            <div className="h-20 bg-gray-200 rounded" />
-            <div className="h-20 bg-gray-200 rounded" />
+            <Skeleton className="h-20 w-full" />
+            <Skeleton className="h-20 w-full" />
           </div>
-          <div className="h-64 bg-gray-200 rounded" />
+          <Skeleton className="h-64 w-full" />
         </div>
       </div>
     )

--- a/src/app/reminders/page.tsx
+++ b/src/app/reminders/page.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/Skeleton'
 import {
   Bell,
   Plus,
@@ -656,14 +657,42 @@ export default function RemindersPage() {
         )}
 
         {farmsLoading ? (
-          <Card className="text-center py-12">
-            <CardContent>
-              <div className="flex items-center justify-center gap-2">
-                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-accent"></div>
-                <span>Loading farms...</span>
-              </div>
-            </CardContent>
-          </Card>
+          <div className="space-y-6">
+            {/* Stats cards */}
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Card key={i}>
+                  <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                    <Skeleton className="h-4 w-24" />
+                    <Skeleton className="h-4 w-4 rounded-full" />
+                  </CardHeader>
+                  <CardContent className="space-y-2">
+                    <Skeleton className="h-8 w-12" />
+                    <Skeleton className="h-3 w-20" />
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+
+            {/* Task list */}
+            <Card>
+              <CardContent className="space-y-3 p-4">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="flex items-center gap-3 rounded-lg border border-border/40 p-3"
+                  >
+                    <Skeleton className="h-5 w-5 rounded-full" />
+                    <div className="flex-1 space-y-2">
+                      <Skeleton className="h-4 w-1/3" />
+                      <Skeleton className="h-3 w-1/2" />
+                    </div>
+                    <Skeleton className="h-6 w-16 rounded-full" />
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          </div>
         ) : farms.length === 0 ? (
           <Card className="text-center py-12">
             <CardContent>

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -18,7 +18,8 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Loader2, Users, UserPlus, Copy, Check, Building2, Shield, Leaf } from 'lucide-react'
+import { Skeleton } from '@/components/ui/Skeleton'
+import { Users, UserPlus, Copy, Check, Building2, Shield, Leaf } from 'lucide-react'
 import { toast } from 'sonner'
 
 interface OrgMember {
@@ -106,10 +107,34 @@ function UsersPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center min-h-[60vh]">
-        <div className="text-center space-y-3">
-          <Loader2 className="h-8 w-8 animate-spin text-primary mx-auto" />
-          <p className="text-sm text-muted-foreground">Loading...</p>
+      <div className="container max-w-4xl mx-auto p-4 sm:p-6 space-y-6">
+        {/* Header */}
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div className="space-y-2">
+            <Skeleton className="h-8 w-48" />
+            <Skeleton className="h-4 w-56" />
+          </div>
+          <Skeleton className="h-9 w-44" />
+        </div>
+
+        {/* Members list */}
+        <div className="grid gap-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Card key={i}>
+              <CardHeader className="pb-3">
+                <div className="flex items-center gap-3">
+                  <Skeleton className="h-5 w-5 rounded-full" />
+                  <div className="space-y-2">
+                    <Skeleton className="h-5 w-24" />
+                    <Skeleton className="h-3 w-40" />
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <Skeleton className="h-4 w-32" />
+              </CardContent>
+            </Card>
+          ))}
         </div>
       </div>
     )

--- a/src/app/warehouse/page.tsx
+++ b/src/app/warehouse/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/Skeleton'
 import { Package, Plus, AlertCircle, Edit, Trash2, PackagePlus, MoreVertical } from 'lucide-react'
 import { warehouseService } from '@/lib/warehouse-service'
 import { WarehouseItem } from '@/types/types'
@@ -211,19 +212,19 @@ function WarehousePageContent() {
         {loading ? (
           <div className="space-y-3">
             {Array.from({ length: 3 }).map((_, index) => (
-              <Card key={index} className="border-0 shadow-sm rounded-2xl animate-pulse">
+              <Card key={index} className="border-0 shadow-sm rounded-2xl">
                 <CardContent className="p-4">
                   <div className="flex items-center space-x-3">
-                    <div className="w-12 h-12 bg-gray-200 rounded-xl"></div>
+                    <Skeleton className="w-12 h-12 rounded-xl" />
                     <div className="flex-1 space-y-2">
-                      <div className="h-4 bg-gray-200 rounded w-3/4"></div>
-                      <div className="h-3 bg-gray-200 rounded w-1/2"></div>
+                      <Skeleton className="h-4 w-3/4" />
+                      <Skeleton className="h-3 w-1/2" />
                     </div>
                   </div>
                   <div className="mt-3 pt-3 border-t border-gray-100">
                     <div className="grid grid-cols-2 gap-3">
-                      <div className="h-4 bg-gray-200 rounded"></div>
-                      <div className="h-4 bg-gray-200 rounded"></div>
+                      <Skeleton className="h-4 w-full" />
+                      <Skeleton className="h-4 w-full" />
                     </div>
                   </div>
                 </CardContent>

--- a/src/app/workers/page.tsx
+++ b/src/app/workers/page.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Input } from '@/components/ui/input'
+import { Skeleton } from '@/components/ui/Skeleton'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -756,8 +757,60 @@ export default function WorkersPage() {
 
   if (authLoading) {
     return (
-      <div className="flex items-center justify-center min-h-screen">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      <div className="min-h-screen bg-gray-50 pb-20">
+        {/* Header */}
+        <div className="bg-white border-b sticky top-0 z-30">
+          <div className="max-w-4xl mx-auto px-4 py-3">
+            <div className="flex items-center gap-3">
+              <Skeleton className="h-9 w-9 rounded-md" />
+              <div className="flex-1 space-y-2">
+                <Skeleton className="h-5 w-32" />
+                <Skeleton className="h-4 w-48" />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="max-w-4xl mx-auto px-4 py-4">
+          {/* Summary Stats */}
+          <Card className="rounded-2xl mb-4">
+            <CardContent className="p-4">
+              <div className="grid grid-cols-2 gap-4">
+                {Array.from({ length: 2 }).map((_, i) => (
+                  <div key={i} className="flex items-start gap-3">
+                    <Skeleton className="h-9 w-9 rounded-xl" />
+                    <div className="flex-1 space-y-2">
+                      <Skeleton className="h-7 w-20" />
+                      <Skeleton className="h-3 w-24" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Controls */}
+          <div className="bg-white border rounded-2xl p-4 mb-5">
+            <Skeleton className="h-10 w-full max-w-sm sm:max-w-md mx-auto rounded-full" />
+          </div>
+
+          {/* List */}
+          <div className="space-y-3">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Card key={i} className="border-none shadow-sm rounded-3xl">
+                <CardContent className="p-4 sm:p-5">
+                  <div className="flex items-center gap-4">
+                    <Skeleton className="h-12 w-12 rounded-2xl" />
+                    <div className="flex-1 space-y-2">
+                      <Skeleton className="h-5 w-32" />
+                      <Skeleton className="h-4 w-40" />
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
       </div>
     )
   }
@@ -1205,8 +1258,23 @@ export default function WorkersPage() {
 
                 {/* Tabs */}
                 {loadingWorkerData ? (
-                  <div className="flex items-center justify-center py-8">
-                    <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                  <div className="space-y-4">
+                    <Skeleton className="h-9 w-full rounded-md" />
+                    <div className="space-y-2">
+                      {Array.from({ length: 4 }).map((_, i) => (
+                        <Card key={i}>
+                          <CardContent className="p-3">
+                            <div className="flex items-center justify-between">
+                              <div className="space-y-2">
+                                <Skeleton className="h-4 w-28" />
+                                <Skeleton className="h-5 w-20 rounded-full" />
+                              </div>
+                              <Skeleton className="h-4 w-16" />
+                            </div>
+                          </CardContent>
+                        </Card>
+                      ))}
+                    </div>
                   </div>
                 ) : (
                   <Tabs defaultValue="attendance" className="w-full">

--- a/src/components/ai/PestAlertDashboard.tsx
+++ b/src/components/ai/PestAlertDashboard.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Progress } from '@/components/ui/progress'
+import { Skeleton } from '@/components/ui/Skeleton'
 import {
   AlertTriangle,
   Bug,
@@ -119,11 +120,11 @@ export function PestAlertDashboard({
   if (loading) {
     return (
       <div className={`space-y-4 ${className}`}>
-        <div className="animate-pulse">
-          <div className="h-6 bg-gray-200 rounded w-1/3 mb-4"></div>
+        <div>
+          <Skeleton className="h-6 w-1/3 mb-4" />
           <div className="space-y-3">
-            <div className="h-20 bg-gray-200 rounded"></div>
-            <div className="h-20 bg-gray-200 rounded"></div>
+            <Skeleton className="h-20" />
+            <Skeleton className="h-20" />
           </div>
         </div>
       </div>

--- a/src/components/dashboard/AlertsSection.tsx
+++ b/src/components/dashboard/AlertsSection.tsx
@@ -2,6 +2,7 @@
 
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/Skeleton'
 import { cn } from '@/lib/utils'
 import {
   AlertTriangle,
@@ -77,16 +78,13 @@ export function AlertsSection({ alerts, onAlertAction, loading, className }: Ale
             <AlertTriangle className="h-5 w-5 text-muted-foreground" />
           </div>
           <div className="space-y-2">
-            <div className="h-4 w-32 rounded-full bg-muted/40 animate-pulse" />
-            <div className="h-3 w-24 rounded-full bg-muted/20 animate-pulse" />
+            <Skeleton className="h-4 w-32 rounded-full" />
+            <Skeleton className="h-3 w-24 rounded-full" />
           </div>
         </div>
         <div className="mt-4 space-y-3">
           {Array.from({ length: 3 }).map((_, index) => (
-            <div
-              key={index}
-              className="h-[88px] rounded-2xl border border-border/40 bg-muted/10 animate-pulse"
-            />
+            <Skeleton key={index} className="h-[88px] rounded-2xl" />
           ))}
         </div>
       </div>

--- a/src/components/dashboard/FarmerDashboard.tsx
+++ b/src/components/dashboard/FarmerDashboard.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { AlertsSection } from './AlertsSection'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/Skeleton'
 import type { LucideIcon } from 'lucide-react'
 import {
   Select,
@@ -229,10 +230,45 @@ export function FarmerDashboard({ className }: FarmerDashboardProps) {
   // Show loading state
   if (loading || authLoading) {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto"></div>
-          <p className="text-muted-foreground mt-4">Loading your dashboard...</p>
+      <div className={cn('relative min-h-screen bg-background pb-10 sm:pb-12', className)}>
+        <div className="px-3 pt-5 pb-6 space-y-5 sm:px-4 sm:pt-6 sm:pb-8 md:px-6 lg:px-10">
+          {/* Header: status badge, farm selector + actions, meta chips */}
+          <div className="space-y-3">
+            <Skeleton className="h-6 w-28 rounded-full" />
+            <div className="flex flex-col gap-2.5 sm:flex-row sm:items-center">
+              <Skeleton className="h-11 w-full rounded-full sm:h-12 sm:w-64" />
+              <div className="flex gap-1.5">
+                <Skeleton className="h-9 flex-1 rounded-full sm:h-11 sm:w-28" />
+                <Skeleton className="h-9 flex-1 rounded-full sm:h-11 sm:w-28" />
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              <Skeleton className="h-6 w-24 rounded-full" />
+              <Skeleton className="h-6 w-28 rounded-full" />
+              <Skeleton className="h-6 w-20 rounded-full" />
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-6 px-4 pb-12 md:px-6 lg:px-10">
+          {/* Today at a glance: stat tiles */}
+          <section className="space-y-3">
+            <Skeleton className="h-5 w-40" />
+            <div className="grid grid-cols-2 gap-3 xl:grid-cols-4">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-28 rounded-2xl" />
+              ))}
+            </div>
+          </section>
+
+          {/* Activity section */}
+          <Skeleton className="h-40 w-full rounded-3xl" />
+
+          {/* Tasks + Alerts */}
+          <div className="grid gap-4 md:grid-cols-2">
+            <Skeleton className="h-48 w-full rounded-3xl" />
+            <Skeleton className="h-48 w-full rounded-3xl" />
+          </div>
         </div>
       </div>
     )

--- a/src/components/dashboard/PortfolioDashboard.tsx
+++ b/src/components/dashboard/PortfolioDashboard.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Progress } from '@/components/ui/progress'
+import { Skeleton } from '@/components/ui/Skeleton'
 import {
   TrendingUp,
   AlertTriangle,
@@ -208,14 +209,14 @@ export function PortfolioDashboard({ onFarmSelect }: PortfolioDashboardProps) {
   if (loading) {
     return (
       <div className="min-h-screen bg-background p-4">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 bg-muted/60 rounded w-48" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-48" />
           <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
             {[...Array(4)].map((_, i) => (
-              <div key={i} className="h-24 bg-muted/60 rounded" />
+              <Skeleton key={i} className="h-24" />
             ))}
           </div>
-          <div className="h-64 bg-muted/60 rounded" />
+          <Skeleton className="h-64" />
         </div>
       </div>
     )

--- a/src/components/dashboard/TodaysTasksSection.tsx
+++ b/src/components/dashboard/TodaysTasksSection.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
+import { Skeleton } from '@/components/ui/Skeleton'
 import { cn } from '@/lib/utils'
 import {
   Calendar,
@@ -102,18 +103,15 @@ export function TodaysTasksSection({
               <Calendar className="h-4 w-4 text-muted-foreground" />
             </div>
             <div className="space-y-2">
-              <div className="h-4 w-36 rounded-full bg-muted/40 animate-pulse" />
-              <div className="h-3 w-24 rounded-full bg-muted/20 animate-pulse" />
+              <Skeleton className="h-4 w-36 rounded-full" />
+              <Skeleton className="h-3 w-24 rounded-full" />
             </div>
           </div>
-          <div className="h-9 w-20 rounded-full bg-muted/30 animate-pulse" />
+          <Skeleton className="h-9 w-20 rounded-full" />
         </div>
         <div className="mt-4 space-y-3">
           {Array.from({ length: 3 }).map((_, index) => (
-            <div
-              key={index}
-              className="h-[88px] rounded-2xl border border-border/40 bg-muted/10 animate-pulse"
-            />
+            <Skeleton key={index} className="h-[88px] rounded-2xl" />
           ))}
         </div>
       </div>

--- a/src/components/farm-details/ActivityFeed.tsx
+++ b/src/components/farm-details/ActivityFeed.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/Skeleton'
 import { ArrowRight, Calendar, Edit, Trash2 } from 'lucide-react'
 import {
   formatGroupedDate,
@@ -192,10 +193,7 @@ export function ActivityFeed({
       return (
         <div className={cn('space-y-3', className)}>
           {[...Array(2)].map((_, index) => (
-            <div
-              key={index}
-              className="h-20 rounded-2xl border border-border/60 bg-muted/20 animate-pulse"
-            />
+            <Skeleton key={index} className="h-20 rounded-2xl" />
           ))}
         </div>
       )
@@ -205,7 +203,7 @@ export function ActivityFeed({
       <div className="space-y-6">
         <Card className="rounded-3xl border border-gray-100 bg-white shadow-sm">
           <CardHeader>
-            <div className="h-4 w-32 rounded bg-slate-200 animate-pulse" />
+            <Skeleton className="h-4 w-32" />
           </CardHeader>
           <CardContent className="space-y-3">
             {[...Array(3)].map((_, index) => (
@@ -213,12 +211,12 @@ export function ActivityFeed({
                 key={index}
                 className="flex items-center gap-3 rounded-2xl border border-slate-100 bg-slate-50/60 p-3"
               >
-                <div className="h-10 w-10 rounded-xl bg-slate-200 animate-pulse" />
+                <Skeleton className="h-10 w-10 rounded-xl" />
                 <div className="flex-1 space-y-2">
-                  <div className="h-3 w-32 rounded bg-slate-200 animate-pulse" />
-                  <div className="h-3 w-24 rounded bg-slate-100 animate-pulse" />
+                  <Skeleton className="h-3 w-32" />
+                  <Skeleton className="h-3 w-24" />
                 </div>
-                <div className="h-9 w-16 rounded-lg bg-slate-200 animate-pulse" />
+                <Skeleton className="h-9 w-16 rounded-lg" />
               </div>
             ))}
           </CardContent>

--- a/src/components/farm-details/FarmHeader.tsx
+++ b/src/components/farm-details/FarmHeader.tsx
@@ -13,6 +13,7 @@ import {
   Thermometer
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/Skeleton'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -142,10 +143,10 @@ export function FarmHeader({
                     <div className="flex min-w-0 w-full flex-col gap-3">
                       <div className="flex flex-wrap items-center justify-between gap-3 sm:flex-nowrap sm:items-start sm:gap-2">
                         {/* Loading skeleton for farm name */}
-                        <div className="h-[48px] w-[200px] animate-pulse rounded-xl bg-muted sm:h-10 sm:w-[300px]" />
+                        <Skeleton className="h-[48px] w-[200px] rounded-xl sm:h-10 sm:w-[300px]" />
                         <div className="flex shrink-0 items-center gap-1 sm:ml-auto sm:hidden">
-                          <div className="h-8 w-14 animate-pulse rounded-full bg-muted" />
-                          <div className="h-8 w-8 animate-pulse rounded-full bg-muted" />
+                          <Skeleton className="h-8 w-14 rounded-full" />
+                          <Skeleton className="h-8 w-8 rounded-full" />
                         </div>
                       </div>
                     </div>
@@ -164,11 +165,11 @@ export function FarmHeader({
                 className="flex h-full min-h-[120px] w-full flex-col justify-between rounded-2xl border border-border/60 bg-muted/20 p-3 sm:min-h-[136px] sm:p-3.5"
               >
                 <div className="flex items-center justify-between gap-3">
-                  <div className="h-3 w-20 animate-pulse rounded bg-muted" />
-                  <div className="h-9 w-9 animate-pulse rounded-xl bg-muted sm:h-10 sm:w-10" />
+                  <Skeleton className="h-3 w-20" />
+                  <Skeleton className="h-9 w-9 rounded-xl sm:h-10 sm:w-10" />
                 </div>
-                <div className="mt-2 h-7 w-16 animate-pulse rounded bg-muted sm:h-8" />
-                <div className="h-3 w-full animate-pulse rounded bg-muted" />
+                <Skeleton className="mt-2 h-7 w-16 sm:h-8" />
+                <Skeleton className="h-3 w-full" />
               </div>
             ))}
           </div>

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+interface SkeletonProps extends React.ComponentProps<'div'> {}
+
+function Skeleton({ className, ...props }: SkeletonProps) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn('bg-muted animate-pulse rounded-md', className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/src/components/weather/WeatherDashboard.tsx
+++ b/src/components/weather/WeatherDashboard.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/Skeleton'
 import {
   Cloud,
   Sun,
@@ -136,10 +137,10 @@ export function WeatherDashboard({
       <div className="space-y-6">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
           {[...Array(4)].map((_, i) => (
-            <Card key={i} className="animate-pulse">
+            <Card key={i}>
               <CardContent className="p-6">
-                <div className="h-4 bg-gray-200 rounded mb-2"></div>
-                <div className="h-6 bg-gray-300 rounded"></div>
+                <Skeleton className="h-4 mb-2" />
+                <Skeleton className="h-6" />
               </CardContent>
             </Card>
           ))}

--- a/src/components/workers/AnalyticsView.tsx
+++ b/src/components/workers/AnalyticsView.tsx
@@ -11,7 +11,7 @@ import {
   SelectTrigger,
   SelectValue
 } from '@/components/ui/select'
-import { Loader2 } from 'lucide-react'
+import { Skeleton } from '@/components/ui/Skeleton'
 import { format } from 'date-fns'
 import { formatCurrency } from '@/lib/currency-utils'
 import type {
@@ -161,9 +161,47 @@ export function AnalyticsView({
       </Card>
 
       {analyticsLoading ? (
-        <div className="flex items-center justify-center py-12">
-          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-        </div>
+        <>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {Array.from({ length: 2 }).map((_, i) => (
+              <Card key={i} className="rounded-2xl border-none bg-white shadow-sm">
+                <CardContent className="p-4 flex items-center justify-between">
+                  <div className="space-y-2">
+                    <Skeleton className="h-3 w-24" />
+                    <Skeleton className="h-8 w-32" />
+                    <Skeleton className="h-3 w-36" />
+                  </div>
+                  <Skeleton className="h-6 w-14 rounded-full" />
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+
+          <Card className="border-none rounded-3xl shadow-sm">
+            <CardContent className="space-y-4 p-5">
+              <div className="flex items-center justify-between">
+                <div className="space-y-2">
+                  <Skeleton className="h-3 w-40" />
+                  <Skeleton className="h-6 w-56" />
+                </div>
+                <Skeleton className="h-6 w-20 rounded-full" />
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <div key={i} className="rounded-2xl border border-muted p-3">
+                    <div className="flex items-center justify-between">
+                      <div className="space-y-2">
+                        <Skeleton className="h-4 w-28" />
+                        <Skeleton className="h-3 w-36" />
+                      </div>
+                      <Skeleton className="h-5 w-16" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </>
       ) : (
         <>
           <div className="grid gap-3 sm:grid-cols-2">

--- a/src/components/workers/MobileAttendanceView.tsx
+++ b/src/components/workers/MobileAttendanceView.tsx
@@ -37,6 +37,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent } from '@/components/ui/card'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Skeleton } from '@/components/ui/Skeleton'
 
 interface Farm {
   id: number
@@ -563,8 +564,14 @@ export function MobileAttendanceView({
 
               {/* Day Grid */}
               {loading ? (
-                <div className="flex items-center justify-center py-8">
-                  <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                <div className="grid grid-cols-6 gap-1.5">
+                  {Array.from({ length: 6 }).map((_, i) => (
+                    <div key={i} className="flex flex-col items-center p-2 gap-1">
+                      <Skeleton className="h-2.5 w-6" />
+                      <Skeleton className="h-3 w-3" />
+                      <Skeleton className="h-10 w-10 rounded-lg" />
+                    </div>
+                  ))}
                 </div>
               ) : (
                 <div className="grid grid-cols-6 gap-1.5">
@@ -720,9 +727,22 @@ export function MobileAttendanceView({
           <Card>
             <CardContent className="p-3">
               {calendarLoading ? (
-                <div className="flex items-center justify-center py-12">
-                  <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-                </div>
+                <>
+                  {/* Weekday Headers */}
+                  <div className="grid grid-cols-7 gap-1 mb-2">
+                    {Array.from({ length: 7 }).map((_, i) => (
+                      <div key={i} className="flex justify-center py-1">
+                        <Skeleton className="h-3 w-6" />
+                      </div>
+                    ))}
+                  </div>
+                  {/* Calendar Days */}
+                  <div className="grid grid-cols-7 gap-1">
+                    {Array.from({ length: 42 }).map((_, i) => (
+                      <Skeleton key={i} className="aspect-square rounded-lg" />
+                    ))}
+                  </div>
+                </>
               ) : (
                 <>
                   {/* Weekday Headers */}

--- a/src/components/workers/WorkersListView.tsx
+++ b/src/components/workers/WorkersListView.tsx
@@ -3,7 +3,8 @@
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
-import { Loader2, Users, User, Wallet, Plus, Pencil, Trash2 } from 'lucide-react'
+import { Skeleton } from '@/components/ui/Skeleton'
+import { Users, User, Wallet, Plus, Pencil, Trash2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { Worker } from '@/lib/supabase'
 import { formatCurrency, type CurrencyCode } from '@/lib/currency-utils'
@@ -29,8 +30,33 @@ export function WorkersListView({
 }: WorkersListViewProps) {
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-12">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      <div className="space-y-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Card
+            key={i}
+            className="border-none bg-gradient-to-r from-white to-primary/10 shadow-sm rounded-3xl"
+          >
+            <CardContent className="p-4 sm:p-5">
+              <div className="flex items-center gap-4">
+                <Skeleton className="h-12 w-12 rounded-2xl" />
+                <div className="flex-1 space-y-2">
+                  <div className="flex items-center gap-2">
+                    <Skeleton className="h-5 w-32" />
+                    <Skeleton className="h-5 w-16 rounded-full" />
+                  </div>
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    <Skeleton className="h-4 w-24" />
+                    <Skeleton className="h-4 w-28" />
+                  </div>
+                </div>
+                <div className="flex flex-col gap-2">
+                  <Skeleton className="h-9 w-9 rounded-md" />
+                  <Skeleton className="h-9 w-9 rounded-md" />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
       </div>
     )
   }


### PR DESCRIPTION
## Description

Adds the shadcn `Skeleton` component (`src/components/ui/skeleton.tsx`) and uses it for content-loading states across the app, replacing ad-hoc spinners with layout-aware placeholders.

- **Content loaders → skeletons** that mirror each real layout (page, list, card, section, detail panel) across consultant, farms, workers, dashboard, and lab-test screens — previously centered `Loader2` or `animate-spin` border-spinners.
- **Hand-rolled `animate-pulse` blocks → migrated** to the shared `<Skeleton>` component. The component uses `bg-muted` (the `accent` token is the green brand color `#6f8f5e`, which would render solid-green blocks).
- **Button / action spinners intentionally kept** — save, login, OTP, upload, generate-plan, and run-prediction spinners stay inside their buttons, where replacing them with a skeleton would hide the action and shift layout.
- **Intentionally left as spinners:** the app-boot splash and auth/route-transition gates, where the destination layout is unknown.

34 files changed (33 screens/components + the new `Skeleton` component).

## Related Issue

N/A — this repo doesn't use an external tracker; the work is tracked via the PostHog Code `Task-Id` in the commit trailer.

## Potential Risk & Impact

- **Low risk** — presentational-only changes confined to loading branches. No data fetching, routing, or success-state UI was modified.
- A few skeletons may not perfectly match their loaded layout's dimensions on first pass — purely cosmetic and easy to tune.
- No new runtime logic or client/server-boundary changes.

## How Has This Been Tested?

- **`npm run typecheck`** — clean; the changeset introduces **zero** new type errors. (One pre-existing, unrelated error remains in `consultant/.../[farmId]/page.tsx` and is tolerated by `next.config.mjs`'s `ignoreBuildErrors` in prod.)
- **`npm run lint` (ESLint)** — **zero issues** across all 34 changed files; verified no orphaned `Loader2`/`RefreshCw` imports remain.
- Not yet manually QA'd in-browser — recommend a quick visual pass on a couple of screens.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced ad‑hoc loading spinners and pulses with shadcn `Skeleton` placeholders across the app to reduce layout shifts and improve perceived speed. Added a shared `Skeleton` component and improved a11y with aria-live and sr-only messages; action/button and redirect spinners remain.

- **Refactors**
  - Added `src/components/ui/Skeleton.tsx` (`bg-muted` + `animate-pulse`) for consistent placeholders.
  - Replaced centered spinners/custom pulses with layout‑matched skeletons across consultant (overview, directory, profile, triage, team settings/assignments, farm workspace), farms (list, details, logs, tasks, pest alerts, lab tests, AI insights), dashboards (main, farmer, portfolio, weather), workers (list, analytics, attendance), performance, reminders, users, and warehouse.
  - Standardized accessible loading states with `aria-live`, `role="status"`, and `sr-only` messages on key screens (e.g., logs, tasks, lab tests, pest alerts, dashboards, workers).
  - Kept spinners in action buttons and for splash/redirect transitions (e.g., Export redirect); no data fetching or routing changes.

- **Migration**
  - No breaking changes.
  - Use `Skeleton` for new loading UIs.

<sup>Written for commit add28e58f998df525352246ce88172186eadc96e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ashish921998/Vinesight/pull/181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared **Skeleton** component for consistent loading placeholders.

* **Improvements**
  * Replaced loading spinners/gray placeholder blocks with structured skeleton layouts across many pages and widgets (headers, cards, grids, and list rows).
  * Kept loading announcements accessible for screen readers via existing live-region patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->