### PR TITLE
fix(auth): treat empty-string confirmPassword as a mismatch (#158)

### DIFF
--- a/src/lib/__tests__/auth-operations.test.ts
+++ b/src/lib/__tests__/auth-operations.test.ts
@@ -148,6 +148,19 @@ describe('signUpWithEmail', () => {
     expect(kit.toast.error).not.toHaveBeenCalled()
   })
 
+  it('treats an explicit empty-string confirmPassword as a mismatch', async () => {
+    const kit = buildDeps({ signUp: vi.fn() })
+
+    const result = await signUpWithEmail(
+      { email: 'a@b.com', password: 'pw', confirmPassword: '' },
+      kit.deps
+    )
+
+    expect(result).toEqual({ success: false, error: 'Passwords do not match' })
+    expect(kit.supabaseAuth.signUp).not.toHaveBeenCalled()
+    expect(kit.toast.error).not.toHaveBeenCalled()
+  })
+
   it('gates on an invalid name, toasts the error, and does not call signUp', async () => {
     const kit = buildDeps({ signUp: vi.fn() })
 

--- a/src/lib/auth/auth-operations.ts
+++ b/src/lib/auth/auth-operations.ts
@@ -71,8 +71,10 @@ export async function signUpWithEmail(
   const { supabase, toast } = deps
   const { email, password, confirmPassword, firstName, lastName } = params
 
-  // Validate password confirmation if provided
-  if (confirmPassword && password !== confirmPassword) {
+  // Validate password confirmation if provided. Guard against `undefined` (the
+  // "not provided" case) rather than falsiness, so an explicit empty-string
+  // confirmation is still treated as a mismatch instead of silently bypassing.
+  if (confirmPassword !== undefined && password !== confirmPassword) {
     return { success: false, error: 'Passwords do not match' }
   }
 


### PR DESCRIPTION
Closes #158.

## Summary

Of the three pre-existing latent auth bugs tracked in #158, two were already resolved in prior work on `main`; this PR fixes the remaining one.

### #1 — `signUp` empty-string `confirmPassword` bypass (fixed here)
An explicit empty-string `confirmPassword` (`''`) is falsy, so the old `if (confirmPassword && ...)` guard skipped the mismatch check when a caller passed an empty confirmation. Now guards against `undefined` (the genuine "not provided" case) instead, so an empty confirmation is correctly treated as a mismatch.

```ts
if (confirmPassword !== undefined && password !== confirmPassword) {
```

### #2 — `signOut` ignores Supabase's returned error (already fixed)
`signOut` already destructures `{ error }`, toasts on failure, and returns `{ success: false }` (`auth-operations.ts`).

### #3 — consolidate per-flow `posthog.identify()` (already fixed)
Identify now happens once at the `onAuthStateChange` chokepoint (`session.ts`); `verifyOtp` / `verifyPhoneOtp` only fire the acquisition-funnel `capture`.

## Testing
- Added a regression test: *treats an explicit empty-string confirmPassword as a mismatch*.
- `npx vitest run src/lib/__tests__/auth-operations.test.ts` → 41 passed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix sign-up validation: an explicit empty-string `confirmPassword` no longer bypasses the mismatch check by guarding against `undefined`. Includes a regression test.

<sup>Written for commit 79b2322d5615f43570acacf3cfe30f542d49b50b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ashish921998/Vinesight/pull/186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password confirmation handling during email sign-up so explicitly provided empty confirmation values are treated as mismatches.
  * Sign-up now correctly returns a password mismatch error when the confirmation does not match, instead of proceeding.
  * Added coverage to verify the sign-up flow does not continue or show an error toast in this mismatch case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->