### PR TITLE
Migrate farm detail data to React Query

### DIFF
--- a/src/app/farms/[id]/lab-tests/page.tsx
+++ b/src/app/farms/[id]/lab-tests/page.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useEffect, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
-import { SupabaseService } from '@/lib/supabase-service'
+import { useQueryClient } from '@tanstack/react-query'
 import { LabTestsTimeline } from '@/components/lab-tests/LabTestsTimeline'
 import { LabTestTrendCharts } from '@/components/lab-tests/LabTestTrendCharts'
 import { LabTestComparisonTable } from '@/components/lab-tests/LabTestComparisonTable'
@@ -21,17 +21,24 @@ import {
 import { ArrowLeft, Loader2, LineChart, Table2, Droplets } from 'lucide-react'
 import { toast } from 'sonner'
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute'
+import { farmKeys } from '@/lib/farm-query-keys'
+import { useDeleteFarmLabTest, useFarm, useFarmLabTests } from '@/hooks/farms/useFarmQueries'
 import { LabTestRecord } from '@/types/lab-tests'
 
 function LabTestsPage() {
   const params = useParams()
   const router = useRouter()
+  const queryClient = useQueryClient()
   const farmId = parseInt(params.id as string)
-
-  const [loading, setLoading] = useState(true)
-  const [soilTests, setSoilTests] = useState<LabTestRecord[]>([])
-  const [petioleTests, setPetioleTests] = useState<LabTestRecord[]>([])
-  const [farmName, setFarmName] = useState<string>('')
+  const farmIdValid = Number.isFinite(farmId)
+  const queryFarmId = farmIdValid ? farmId : null
+  const labTestsQuery = useFarmLabTests(queryFarmId)
+  const farmQuery = useFarm(queryFarmId)
+  const deleteLabTestMutation = useDeleteFarmLabTest(farmId)
+  const soilTests = labTestsQuery.data?.soilTests ?? []
+  const petioleTests = labTestsQuery.data?.petioleTests ?? []
+  const farmName = farmQuery.data?.name || 'Farm'
+  const loading = labTestsQuery.isPending
 
   // View mode state - initialize with server-safe default
   const [viewMode, setViewMode] = useState<'chart' | 'table'>('chart')
@@ -60,7 +67,6 @@ function LabTestsPage() {
   const [showAddSoilModal, setShowAddSoilModal] = useState(false)
   const [showAddPetioleModal, setShowAddPetioleModal] = useState(false)
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
-  const [isDeleting, setIsDeleting] = useState(false)
   const [deletingTest, setDeletingTest] = useState<{
     test: LabTestRecord
     type: 'soil' | 'petiole'
@@ -72,31 +78,18 @@ function LabTestsPage() {
     type: 'soil' | 'petiole'
   } | null>(null)
 
-  // Load data
-  const loadLabTests = useCallback(async () => {
-    try {
-      setLoading(true)
-
-      const [soilTestsData, petioleTestsData, farmData] = await Promise.all([
-        SupabaseService.getSoilTestRecords(farmId),
-        SupabaseService.getPetioleTestRecords(farmId),
-        SupabaseService.getFarmById(farmId)
-      ])
-
-      setSoilTests((soilTestsData || []) as LabTestRecord[])
-      setPetioleTests((petioleTestsData || []) as LabTestRecord[])
-      setFarmName(farmData?.name || 'Farm')
-    } catch (error) {
-      console.error('Error loading lab tests:', error)
-      toast.error('Failed to load lab tests')
-    } finally {
-      setLoading(false)
-    }
-  }, [farmId])
-
   useEffect(() => {
-    loadLabTests()
-  }, [loadLabTests])
+    if (labTestsQuery.isError) {
+      toast.error('Failed to load lab tests')
+    }
+  }, [labTestsQuery.isError])
+
+  const invalidateLabTestState = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: farmKeys.labTests(farmId) }),
+      queryClient.invalidateQueries({ queryKey: farmKeys.summary(farmId) })
+    ])
+  }
 
   // Handle adding new tests
   const handleAddSoilTest = () => {
@@ -130,25 +123,20 @@ function LabTestsPage() {
     if (!deletingTest || !deletingTest.test.id) return
 
     try {
-      setIsDeleting(true)
-
-      if (deletingTest.type === 'soil') {
-        await SupabaseService.deleteSoilTestRecord(deletingTest.test.id)
-        setSoilTests((prev) => prev.filter((t) => t.id !== deletingTest.test.id))
-        toast.success('Soil test deleted successfully')
-      } else {
-        await SupabaseService.deletePetioleTestRecord(deletingTest.test.id)
-        setPetioleTests((prev) => prev.filter((t) => t.id !== deletingTest.test.id))
-        toast.success('Petiole test deleted successfully')
-      }
-
+      await deleteLabTestMutation.mutateAsync({
+        id: deletingTest.test.id,
+        type: deletingTest.type
+      })
+      toast.success(
+        deletingTest.type === 'soil'
+          ? 'Soil test deleted successfully'
+          : 'Petiole test deleted successfully'
+      )
       setShowDeleteDialog(false)
       setDeletingTest(null)
     } catch (error) {
       console.error('Error deleting test:', error)
       toast.error('Failed to delete test')
-    } finally {
-      setIsDeleting(false)
     }
   }
 
@@ -159,7 +147,7 @@ function LabTestsPage() {
     setEditingTest(null)
 
     // Reload tests to get the latest data
-    await loadLabTests()
+    await invalidateLabTestState()
   }
 
   // Helper to transform LabTestRecord to modal format
@@ -355,12 +343,16 @@ function LabTestsPage() {
             <Button
               variant="outline"
               onClick={() => setShowDeleteDialog(false)}
-              disabled={isDeleting}
+              disabled={deleteLabTestMutation.isPending}
             >
               Cancel
             </Button>
-            <Button variant="destructive" onClick={handleConfirmDelete} disabled={isDeleting}>
-              {isDeleting ? (
+            <Button
+              variant="destructive"
+              onClick={handleConfirmDelete}
+              disabled={deleteLabTestMutation.isPending}
+            >
+              {deleteLabTestMutation.isPending ? (
                 <>
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                   Deleting...

--- a/src/app/farms/[id]/soil-profiling/page.tsx
+++ b/src/app/farms/[id]/soil-profiling/page.tsx
@@ -46,6 +46,11 @@ import {
 import { Badge } from '@/components/ui/badge'
 import { toast } from 'sonner'
 import { SoilProfileService } from '@/lib/soil-profile-service'
+import {
+  useDeleteFarmSoilProfile,
+  useFarmSoilProfiles,
+  useSaveFarmSoilProfile
+} from '@/hooks/farms/useFarmQueries'
 import type { SoilProfile, SoilSectionName } from '@/lib/supabase'
 import { cn } from '@/lib/utils'
 
@@ -187,11 +192,9 @@ export default function SoilProfilingPage() {
     left: initialSectionState('left'),
     right: initialSectionState('right')
   })
-  const [soilProfiles, setSoilProfiles] = useState<SoilProfile[]>([])
   const [savingProfile, setSavingProfile] = useState(false)
   const [fusarium, setFusarium] = useState('')
   const [profileDate, setProfileDate] = useState<string>(() => getTodayInputDate())
-  const [lastUpdated, setLastUpdated] = useState<string | null>(null)
   const [showProfileDialog, setShowProfileDialog] = useState(false)
   const [activeTab, setActiveTab] = useState<'history' | 'trends'>('history')
   const [editingProfileId, setEditingProfileId] = useState<number | null>(null)
@@ -205,23 +208,20 @@ export default function SoilProfilingPage() {
   })
 
   const farmIdValid = Number.isFinite(farmId)
-
-  const loadSoilProfiles = useCallback(async () => {
-    if (!farmIdValid) return
-    try {
-      const profiles = await SoilProfileService.listProfiles(farmId)
-      setSoilProfiles(profiles)
-      if (profiles[0]?.created_at) {
-        setLastUpdated(new Date(profiles[0].created_at).toLocaleDateString())
-      }
-    } catch (error) {
-      console.error('Failed to load soil profiles', error)
-    }
-  }, [farmId, farmIdValid])
+  const queryFarmId = farmIdValid ? farmId : null
+  const soilProfilesQuery = useFarmSoilProfiles(queryFarmId)
+  const saveProfileMutation = useSaveFarmSoilProfile(farmId)
+  const deleteProfileMutation = useDeleteFarmSoilProfile(farmId)
+  const soilProfiles = soilProfilesQuery.data ?? []
+  const lastUpdated = soilProfiles[0]?.created_at
+    ? new Date(soilProfiles[0].created_at).toLocaleDateString()
+    : null
 
   useEffect(() => {
-    void loadSoilProfiles()
-  }, [loadSoilProfiles])
+    if (soilProfilesQuery.isError) {
+      toast.error('Failed to load soil profiles')
+    }
+  }, [soilProfilesQuery.isError])
 
   const revokeObjectUrl = useCallback((url?: string | null) => {
     if (url && url.startsWith('blob:')) {
@@ -361,24 +361,14 @@ export default function SoilProfilingPage() {
         return
       }
 
-      if (editingProfileId) {
-        await SoilProfileService.updateProfile({
-          id: editingProfileId,
-          farm_id: farmId,
-          fusarium_pct: fusarium ? Number.parseFloat(fusarium) : null,
-          sections: payloadSections,
-          profileDate: profileDateISO
-        })
-        toast.success('Soil profile updated')
-      } else {
-        await SoilProfileService.createProfileWithSections({
-          farm_id: farmId,
-          fusarium_pct: fusarium ? Number.parseFloat(fusarium) : null,
-          sections: payloadSections,
-          profileDate: profileDateISO
-        })
-        toast.success('Soil profile saved')
-      }
+      await saveProfileMutation.mutateAsync({
+        id: editingProfileId,
+        farm_id: farmId,
+        fusarium_pct: fusarium ? Number.parseFloat(fusarium) : null,
+        sections: payloadSections,
+        profileDate: profileDateISO
+      })
+      toast.success(editingProfileId ? 'Soil profile updated' : 'Soil profile saved')
       setShowProfileDialog(false)
       setEditingProfileId(null)
       resetPreviewUrls()
@@ -389,7 +379,6 @@ export default function SoilProfilingPage() {
         right: initialSectionState('right')
       })
       setProfileDate(getTodayInputDate())
-      await loadSoilProfiles()
     } catch (error: unknown) {
       console.error('Save profile error', error)
       toast.error(error instanceof Error ? error.message : 'Failed to save soil profile')
@@ -401,8 +390,7 @@ export default function SoilProfilingPage() {
   const confirmDeleteProfile = async () => {
     if (pendingDeleteProfileId === null) return
     try {
-      await SoilProfileService.deleteProfile(pendingDeleteProfileId)
-      await loadSoilProfiles()
+      await deleteProfileMutation.mutateAsync(pendingDeleteProfileId)
       toast.success('Profile deleted')
     } catch (error: unknown) {
       toast.error(error instanceof Error ? error.message : 'Failed to delete profile')

--- a/src/app/farms/[id]/tasks/page.tsx
+++ b/src/app/farms/[id]/tasks/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
+import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -42,6 +43,14 @@ import {
 } from 'lucide-react'
 
 import { SupabaseService } from '@/lib/supabase-service'
+import { farmKeys } from '@/lib/farm-query-keys'
+import {
+  useCompleteFarmTask,
+  useDeleteFarmTask,
+  useFarm,
+  useFarmTasks,
+  useReopenFarmTask
+} from '@/hooks/farms/useFarmQueries'
 import type { TaskReminder } from '@/types/types'
 import { capitalize, cn } from '@/lib/utils'
 import { TaskModal } from '@/components/tasks/TaskModal'
@@ -82,10 +91,19 @@ export default function FarmTasksPage() {
   const farmIdParam = params.id
   const farmId = Number.parseInt(Array.isArray(farmIdParam) ? farmIdParam[0] : farmIdParam, 10)
   const { user } = useSupabaseAuth()
+  const queryClient = useQueryClient()
+  const farmIdValid = Number.isFinite(farmId)
+  const queryFarmId = farmIdValid ? farmId : null
+  const tasksQuery = useFarmTasks(queryFarmId)
+  const farmQuery = useFarm(queryFarmId)
+  const completeTaskMutation = useCompleteFarmTask(farmId)
+  const reopenTaskMutation = useReopenFarmTask(farmId)
+  const deleteTaskMutation = useDeleteFarmTask(farmId)
+  const tasks = tasksQuery.data ?? []
+  const farmName = farmQuery.data?.name ? capitalize(farmQuery.data.name) : ''
+  const loading = tasksQuery.isPending
+  const refreshing = tasksQuery.isFetching && !tasksQuery.isPending
 
-  const [loading, setLoading] = useState(true)
-  const [tasks, setTasks] = useState<TaskReminder[]>([])
-  const [farmName, setFarmName] = useState<string>('')
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
   const [priorityFilter, setPriorityFilter] = useState<PriorityFilter>('all')
   const [typeFilter, setTypeFilter] = useState<TaskTypeFilter>('all')
@@ -93,50 +111,31 @@ export default function FarmTasksPage() {
   const [taskModalOpen, setTaskModalOpen] = useState(false)
   const [selectedTask, setSelectedTask] = useState<TaskReminder | null>(null)
   const [taskToDelete, setTaskToDelete] = useState<TaskReminder | null>(null)
-  const [refreshing, setRefreshing] = useState(false)
-
-  const loadTasks = useCallback(async () => {
-    if (!Number.isFinite(farmId)) return
-
-    setLoading(true)
-    try {
-      const [taskList, farm] = await Promise.all([
-        SupabaseService.getTaskReminders(farmId),
-        SupabaseService.getFarmById(farmId)
-      ])
-      setTasks(taskList || [])
-      if (farm?.name) {
-        setFarmName(capitalize(farm.name))
-      }
-    } catch (error) {
-      // Log detailed error for debugging without exposing to user
-      if (process.env.NODE_ENV === 'development') {
-        console.error('Failed to load tasks:', error)
-      }
-      // Show generic error message to user (don't expose internal error details)
-      toast.error('Unable to load tasks for this farm.')
-    } finally {
-      setLoading(false)
-    }
-  }, [farmId])
 
   useEffect(() => {
-    loadTasks()
-  }, [loadTasks])
+    if (tasksQuery.isError) {
+      toast.error('Unable to load tasks for this farm.')
+    }
+  }, [tasksQuery.isError])
 
   const refreshTasks = useCallback(async () => {
-    setRefreshing(true)
-    try {
-      await loadTasks()
-      // Silent refresh - no toast notification
-    } catch (error) {
+    const [tasksResult] = await Promise.all([tasksQuery.refetch(), farmQuery.refetch()])
+
+    if (tasksResult.error) {
       const errorMessage =
-        error instanceof Error ? `Failed to refresh: ${error.message}` : 'Failed to refresh tasks'
+        tasksResult.error instanceof Error
+          ? `Failed to refresh: ${tasksResult.error.message}`
+          : 'Failed to refresh tasks'
       toast.error(errorMessage)
-    } finally {
-      setRefreshing(false)
     }
-  }, [loadTasks])
+  }, [farmQuery, tasksQuery])
+
+  const invalidateTaskState = useCallback(async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: farmKeys.tasks(farmId) }),
+      queryClient.invalidateQueries({ queryKey: farmKeys.summary(farmId) })
+    ])
+  }, [farmId, queryClient])
 
   const filteredTasks = useMemo(() => {
     return tasks.filter((task) => {
@@ -204,9 +203,8 @@ export default function FarmTasksPage() {
 
   const handleCompleteTask = async (taskId: number) => {
     try {
-      await SupabaseService.completeTask(taskId)
+      await completeTaskMutation.mutateAsync(taskId)
       toast.success('Task marked as completed.')
-      await loadTasks()
     } catch (error) {
       const errorMessage =
         error instanceof Error
@@ -218,9 +216,8 @@ export default function FarmTasksPage() {
 
   const handleReopenTask = async (taskId: number) => {
     try {
-      await SupabaseService.reopenTask(taskId)
+      await reopenTaskMutation.mutateAsync(taskId)
       toast.success('Task moved back to pending.')
-      await loadTasks()
     } catch (error) {
       const errorMessage =
         error instanceof Error
@@ -233,9 +230,8 @@ export default function FarmTasksPage() {
   const handleDeleteTask = async () => {
     if (!taskToDelete) return
     try {
-      await SupabaseService.deleteTask(taskToDelete.id)
+      await deleteTaskMutation.mutateAsync(taskToDelete.id)
       toast.success('Task deleted.')
-      await loadTasks()
     } catch (error) {
       const errorMessage =
         error instanceof Error
@@ -570,7 +566,7 @@ export default function FarmTasksPage() {
         task={selectedTask}
         onSaved={async () => {
           // Toast is already shown by TaskModal, just refresh the list
-          await loadTasks()
+          await invalidateTaskState()
         }}
       />
 

--- a/src/components/tasks/TasksOverviewCard.tsx
+++ b/src/components/tasks/TasksOverviewCard.tsx
@@ -1,12 +1,14 @@
 'use client'
 
 import { useMemo, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import type { TaskReminder } from '@/types/types'
 import { TodaysTasksSection } from '@/components/dashboard/TodaysTasksSection'
 import { TaskModal } from './TaskModal'
 import { SupabaseService } from '@/lib/supabase-service'
+import { farmKeys } from '@/lib/farm-query-keys'
 import { useSupabaseAuth } from '@/hooks/useSupabaseAuth'
 
 type TodaysTaskType =
@@ -57,6 +59,7 @@ export function TasksOverviewCard({
   onTasksUpdated
 }: TasksOverviewCardProps) {
   const { user } = useSupabaseAuth()
+  const queryClient = useQueryClient()
   const [modalOpen, setModalOpen] = useState(false)
   const [selectedTask, setSelectedTask] = useState<TaskReminder | null>(null)
   const [fetchingTask, setFetchingTask] = useState(false)
@@ -73,6 +76,14 @@ export function TasksOverviewCard({
     }
   }
 
+  const invalidateTaskState = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: farmKeys.tasks(farmId) }),
+      queryClient.invalidateQueries({ queryKey: farmKeys.summary(farmId) })
+    ])
+    await notifyRefresh()
+  }
+
   const handleTaskComplete = async (taskId: string) => {
     const numericId = Number.parseInt(taskId, 10)
     if (!Number.isFinite(numericId)) return
@@ -80,7 +91,7 @@ export function TasksOverviewCard({
     try {
       await SupabaseService.completeTask(numericId)
       toast.success('Task marked as completed.')
-      await notifyRefresh()
+      await invalidateTaskState()
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : 'Unable to complete the task right now.'
@@ -187,11 +198,11 @@ export function TasksOverviewCard({
         task={selectedTask}
         onSaved={async () => {
           // Toast is already shown by TaskModal, just refresh the list
-          await notifyRefresh()
+          await invalidateTaskState()
         }}
         onDeleted={async () => {
           // Toast is already shown by TaskModal, just refresh the list
-          await notifyRefresh()
+          await invalidateTaskState()
         }}
       />
     </>

--- a/src/hooks/farms/useFarmQueries.ts
+++ b/src/hooks/farms/useFarmQueries.ts
@@ -3,7 +3,10 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { SupabaseService } from '@/lib/supabase-service'
 import { farmKeys } from '@/lib/farm-query-keys'
+import { SoilProfileService } from '@/lib/soil-profile-service'
 import type { Farm } from '@/types/types'
+import type { LabTestRecord } from '@/types/lab-tests'
+import type { SoilSection } from '@/lib/supabase'
 
 type FarmCreateInput = Omit<Farm, 'id' | 'createdAt' | 'updatedAt' | 'userId'>
 
@@ -63,6 +66,136 @@ export function useDeleteFarm() {
     mutationFn: (id: number) => SupabaseService.deleteFarm(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: farmKeys.list() })
+    }
+  })
+}
+
+export function useFarmTasks(farmId: number | null) {
+  return useQuery({
+    queryKey: farmId != null ? farmKeys.tasks(farmId) : ['farms', 'tasks', 'disabled'],
+    queryFn: () => SupabaseService.getTaskReminders(farmId as number),
+    enabled: farmId != null
+  })
+}
+
+export function useCompleteFarmTask(farmId: number) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (taskId: number) => SupabaseService.completeTask(taskId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: farmKeys.tasks(farmId) })
+      queryClient.invalidateQueries({ queryKey: farmKeys.summary(farmId) })
+    }
+  })
+}
+
+export function useReopenFarmTask(farmId: number) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (taskId: number) => SupabaseService.reopenTask(taskId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: farmKeys.tasks(farmId) })
+      queryClient.invalidateQueries({ queryKey: farmKeys.summary(farmId) })
+    }
+  })
+}
+
+export function useDeleteFarmTask(farmId: number) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (taskId: number) => SupabaseService.deleteTask(taskId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: farmKeys.tasks(farmId) })
+      queryClient.invalidateQueries({ queryKey: farmKeys.summary(farmId) })
+    }
+  })
+}
+
+export function useFarmLabTests(farmId: number | null) {
+  return useQuery({
+    queryKey: farmId != null ? farmKeys.labTests(farmId) : ['farms', 'lab-tests', 'disabled'],
+    queryFn: async () => {
+      const [soilTests, petioleTests] = await Promise.all([
+        SupabaseService.getSoilTestRecords(farmId as number),
+        SupabaseService.getPetioleTestRecords(farmId as number)
+      ])
+
+      return {
+        soilTests: (soilTests || []) as LabTestRecord[],
+        petioleTests: (petioleTests || []) as LabTestRecord[]
+      }
+    },
+    enabled: farmId != null
+  })
+}
+
+export function useDeleteFarmLabTest(farmId: number) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ id, type }: { id: number; type: 'soil' | 'petiole' }) =>
+      type === 'soil'
+        ? SupabaseService.deleteSoilTestRecord(id)
+        : SupabaseService.deletePetioleTestRecord(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: farmKeys.labTests(farmId) })
+      queryClient.invalidateQueries({ queryKey: farmKeys.summary(farmId) })
+    }
+  })
+}
+
+export function useFarmSoilProfiles(farmId: number | null) {
+  return useQuery({
+    queryKey:
+      farmId != null ? farmKeys.soilProfiles(farmId) : ['farms', 'soil-profiles', 'disabled'],
+    queryFn: () => SoilProfileService.listProfiles(farmId as number),
+    enabled: farmId != null
+  })
+}
+
+export function useSaveFarmSoilProfile(farmId: number) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (input: {
+      id?: number | null
+      farm_id: number
+      fusarium_pct?: number | null
+      sections: Array<Omit<SoilSection, 'id' | 'profile_id' | 'created_at'>>
+      profileDate: string
+    }) =>
+      input.id
+        ? SoilProfileService.updateProfile({
+            id: input.id,
+            farm_id: input.farm_id,
+            fusarium_pct: input.fusarium_pct,
+            sections: input.sections as SoilSection[],
+            profileDate: input.profileDate
+          })
+        : SoilProfileService.createProfileWithSections({
+            farm_id: input.farm_id,
+            fusarium_pct: input.fusarium_pct,
+            sections: input.sections,
+            profileDate: input.profileDate
+          }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: farmKeys.soilProfiles(farmId) })
+      queryClient.invalidateQueries({ queryKey: farmKeys.summary(farmId) })
+    }
+  })
+}
+
+export function useDeleteFarmSoilProfile(farmId: number) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (profileId: number) => SoilProfileService.deleteProfile(profileId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: farmKeys.soilProfiles(farmId) })
+      queryClient.invalidateQueries({ queryKey: farmKeys.summary(farmId) })
     }
   })
 }


### PR DESCRIPTION
## Summary
- Add shared React Query hooks for farm tasks, lab tests, and soil profiles
- Move farm detail pages from local async loading state to query/mutation hooks
- Invalidate task, lab test, soil profile, and farm summary cache after writes

## Verification
- Reviewed diff locally
- npm run typecheck: blocked because dependencies are not installed in this environment (missing @types/node)
- npm run lint: blocked because dependencies are not installed in this environment (eslint not found)
- bun run typecheck / bun run lint: blocked because bun is not installed in this environment

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrate farm tasks, lab tests, and soil profiles to `@tanstack/react-query` with shared query/mutation hooks. Removes manual fetch logic, improves loading/error states, and keeps farm views up to date by auto‑invalidating caches after writes.

- **Refactors**
  - Added hooks in `src/hooks/farms/useFarmQueries.ts` for tasks (list, complete/reopen/delete), lab tests (list/delete), soil profiles (list/save/delete), and farm reads; each invalidates `farmKeys.*` and summary on success.
  - Migrated `tasks`, `lab-tests`, and `soil-profiling` pages to use hooks; derive `loading`/`refreshing` from query state and show error toasts when queries fail.
  - Replaced manual refresh with `refetch`/`invalidateQueries`; compute derived data (e.g., last updated) from query results.
  - Updated `TasksOverviewCard` to invalidate `tasks` and `summary` queries after create/edit/delete/complete.

<sup>Written for commit ae7d7b82d631be3b97a8676ae133bf139041158e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ashish921998/Vinesight/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved farm tasks, lab tests, and soil profiling screens with faster updates after save, edit, complete, reopen, or delete actions.
  * Added clearer error toasts when loading farm lab tests or soil profiles fails.

* **Bug Fixes**
  * Reduced stale or out-of-sync data by refreshing related farm views automatically after changes.
  * Simplified delete and save flows so the UI updates more reliably without manual reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->