### PR TITLE
feat(farms): migrate farm detail dashboard + log writes to TanStack Query (#174)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -61,7 +61,6 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.3",
         "@tailwindcss/postcss": "^4.1.18",
-        "@tanstack/react-query-devtools": "^5.0.0",
         "@types/bun": "^1.3.5",
         "@types/jspdf": "^1.3.3",
         "@types/node": "^20.19.27",
@@ -792,11 +791,7 @@
 
     "@tanstack/query-core": ["@tanstack/query-core@5.101.0", "", {}, "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow=="],
 
-    "@tanstack/query-devtools": ["@tanstack/query-devtools@5.101.0", "", {}, "sha512-MVqw17k08RQtGGLEL654+dX/btbX9p/8WjkznO//zusLTMaObxi3Q+MoFwGVkC9K3tqjn8qrrNhJevXx4fJTeQ=="],
-
     "@tanstack/react-query": ["@tanstack/react-query@5.101.0", "", { "dependencies": { "@tanstack/query-core": "5.101.0" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg=="],
-
-    "@tanstack/react-query-devtools": ["@tanstack/react-query-devtools@5.101.0", "", { "dependencies": { "@tanstack/query-devtools": "5.101.0" }, "peerDependencies": { "@tanstack/react-query": "^5.101.0", "react": "^18 || ^19" } }, "sha512-cpZA0+WqKXwrwMfiWZEGGF6QrIWVQFbhBtxqDF5sQsAfrFf47HIE6fiPbQU3wyAUEN2+7UNqLCQe7oG6m3f93w=="],
 
     "@tensorflow/tfjs": ["@tensorflow/tfjs@4.22.0", "", { "dependencies": { "@tensorflow/tfjs-backend-cpu": "4.22.0", "@tensorflow/tfjs-backend-webgl": "4.22.0", "@tensorflow/tfjs-converter": "4.22.0", "@tensorflow/tfjs-core": "4.22.0", "@tensorflow/tfjs-data": "4.22.0", "@tensorflow/tfjs-layers": "4.22.0", "argparse": "^1.0.10", "chalk": "^4.1.0", "core-js": "3.29.1", "regenerator-runtime": "^0.13.5", "yargs": "^16.0.3" }, "bin": { "tfjs-custom-module": "dist/tools/custom_module/cli.js" } }, "sha512-0TrIrXs6/b7FLhLVNmfh8Sah6JgjBPH4mZ8JGb7NU6WW+cx00qK5BcAZxw7NCzxj6N8MRAIfHq+oNbPUNG5VAg=="],
 

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.3",
     "@tailwindcss/postcss": "^4.1.18",
-    "@tanstack/react-query-devtools": "^5.0.0",
     "@types/bun": "^1.3.5",
     "@types/jspdf": "^1.3.3",
     "@types/node": "^20.19.27",

--- a/src/actions/search-logs.ts
+++ b/src/actions/search-logs.ts
@@ -192,6 +192,8 @@ export async function searchLogs({
     const q = (searchQuery || '').toLowerCase().trim()
     const hasQuery = q.length > 0
     const hasTypeFilter = Array.isArray(selectedActivityTypes) && selectedActivityTypes.length > 0
+    const selectedActivityTypeSet = hasTypeFilter ? new Set(selectedActivityTypes) : null
+    const queryPattern = hasQuery ? new RegExp(q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')) : null
     const normalizedFrom = dateFrom ? normalizeDateToYYYYMMDD(dateFrom) : null
     const normalizedTo = dateTo ? normalizeDateToYYYYMMDD(dateTo) : null
 
@@ -199,7 +201,7 @@ export async function searchLogs({
     const shortlisted: ActivityLog[] = []
     for (const log of combined) {
       // activity type filter
-      if (hasTypeFilter && !selectedActivityTypes.includes(log.type)) continue
+      if (selectedActivityTypeSet && !selectedActivityTypeSet.has(log.type)) continue
 
       // date range (based on activity date)
       if (normalizedFrom || normalizedTo) {
@@ -210,24 +212,24 @@ export async function searchLogs({
       }
 
       // search query filter (if any)
-      if (hasQuery) {
+      if (queryPattern) {
         const notes = (log.notes || '').toLowerCase()
         let matched = false
 
-        if (log.type.toLowerCase().includes(q)) matched = true
-        else if (notes.includes(q)) matched = true
-        else if (log.duration != null && String(log.duration).includes(q)) matched = true
-        else if (log.quantity != null && String(log.quantity).includes(q)) matched = true
-        else if (log.cost != null && String(log.cost).includes(q)) matched = true
-        else if (log.chemical && log.chemical.toLowerCase().includes(q)) matched = true
+        if (queryPattern.test(log.type.toLowerCase())) matched = true
+        else if (queryPattern.test(notes)) matched = true
+        else if (log.duration != null && queryPattern.test(String(log.duration))) matched = true
+        else if (log.quantity != null && queryPattern.test(String(log.quantity))) matched = true
+        else if (log.cost != null && queryPattern.test(String(log.cost))) matched = true
+        else if (log.chemical && queryPattern.test(log.chemical.toLowerCase())) matched = true
         else if (
           Array.isArray(log.chemicals) &&
-          log.chemicals.some((c) => c?.name?.toLowerCase().includes(q))
+          log.chemicals.some((c) => queryPattern.test(c?.name?.toLowerCase() || ''))
         )
           matched = true
         else if (
           Array.isArray(log.fertilizers) &&
-          log.fertilizers.some((f) => f?.name?.toLowerCase().includes(q))
+          log.fertilizers.some((f) => queryPattern.test(f?.name?.toLowerCase() || ''))
         )
           matched = true
 
@@ -238,7 +240,7 @@ export async function searchLogs({
     }
 
     // sort by activity date (newest first) - clone array to avoid mutating originals
-    const sorted = [...shortlisted].sort(
+    const sorted = shortlisted.toSorted(
       (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
     )
 

--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import type React from 'react'
+import { useEffect, useReducer } from 'react'
 import { SEOSchema } from '@/components/SEOSchema'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -32,6 +33,8 @@ import { AnalyticsService, AdvancedAnalytics } from '@/lib/analytics-service'
 import { Farm } from '@/types/types'
 import { capitalize } from '@/lib/utils'
 
+type TimeRange = '30d' | '90d' | '1y'
+
 interface AnalyticsData {
   totalFarms: number
   totalArea: number
@@ -49,31 +52,80 @@ interface AnalyticsData {
   }[]
 }
 
+interface AnalyticsPageState {
+  farms: Farm[]
+  selectedFarm: Farm | null
+  analytics: AnalyticsData | null
+  advancedAnalytics: AdvancedAnalytics | null
+  loading: boolean
+  timeRange: TimeRange
+}
+
+type AnalyticsPageAction =
+  | { type: 'loadingStarted' }
+  | { type: 'farmsLoaded'; farms: Farm[] }
+  | { type: 'emptyDataLoaded' }
+  | { type: 'loadFinished' }
+  | { type: 'analyticsLoaded'; analytics: AnalyticsData }
+  | { type: 'advancedAnalyticsLoaded'; advancedAnalytics: AdvancedAnalytics }
+  | { type: 'loadFailed' }
+  | { type: 'timeRangeChanged'; timeRange: TimeRange }
+
+const initialAnalyticsPageState: AnalyticsPageState = {
+  farms: [],
+  selectedFarm: null,
+  analytics: null,
+  advancedAnalytics: null,
+  loading: true,
+  timeRange: '30d'
+}
+
+function analyticsPageReducer(
+  state: AnalyticsPageState,
+  action: AnalyticsPageAction
+): AnalyticsPageState {
+  switch (action.type) {
+    case 'loadingStarted':
+      return { ...state, loading: true }
+    case 'farmsLoaded':
+      return {
+        ...state,
+        farms: action.farms,
+        selectedFarm: state.selectedFarm ?? action.farms[0] ?? null
+      }
+    case 'emptyDataLoaded':
+      return { ...state, analytics: null, advancedAnalytics: null, loading: false }
+    case 'loadFinished':
+      return { ...state, loading: false }
+    case 'analyticsLoaded':
+      return { ...state, analytics: action.analytics }
+    case 'advancedAnalyticsLoaded':
+      return { ...state, advancedAnalytics: action.advancedAnalytics }
+    case 'loadFailed':
+      return { ...state, analytics: null, advancedAnalytics: null, loading: false }
+    case 'timeRangeChanged':
+      return { ...state, timeRange: action.timeRange }
+    default:
+      return state
+  }
+}
+
 export default function AnalyticsPage() {
-  const [farms, setFarms] = useState<Farm[]>([])
-  const [selectedFarm, setSelectedFarm] = useState<Farm | null>(null)
-  const [analytics, setAnalytics] = useState<AnalyticsData | null>(null)
-  const [advancedAnalytics, setAdvancedAnalytics] = useState<AdvancedAnalytics | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [timeRange, setTimeRange] = useState<'30d' | '90d' | '1y'>('30d')
+  const [state, dispatch] = useReducer(analyticsPageReducer, initialAnalyticsPageState)
+  const { farms, analytics, advancedAnalytics, loading, timeRange } = state
 
   useEffect(() => {
     loadData()
   }, [timeRange])
 
   const loadData = async () => {
-    setLoading(true)
+    dispatch({ type: 'loadingStarted' })
     try {
       const farmList = await CloudDataService.getAllFarms()
-      setFarms(farmList)
-
-      if (!selectedFarm && farmList.length > 0) {
-        setSelectedFarm(farmList[0])
-      }
+      dispatch({ type: 'farmsLoaded', farms: farmList })
 
       if (farmList.length === 0) {
-        setAnalytics(null)
-        setLoading(false)
+        dispatch({ type: 'emptyDataLoaded' })
         return
       }
 
@@ -199,20 +251,20 @@ export default function AnalyticsPage() {
         .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
         .slice(0, 10)
 
-      setAnalytics(analyticsData)
+      dispatch({ type: 'analyticsLoaded', analytics: analyticsData })
 
       // Generate advanced analytics
       try {
         const advanced = await AnalyticsService.generateAdvancedAnalytics(farmList)
-        setAdvancedAnalytics(advanced)
+        dispatch({ type: 'advancedAnalyticsLoaded', advancedAnalytics: advanced })
       } catch (error) {
         console.error('Error generating advanced analytics:', error)
       }
     } catch (error) {
       console.error('Error loading analytics:', error)
-      setAnalytics(null)
+      dispatch({ type: 'loadFailed' })
     } finally {
-      setLoading(false)
+      dispatch({ type: 'loadFinished' })
     }
   }
 
@@ -265,6 +317,33 @@ export default function AnalyticsPage() {
     )
   }
 
+  return renderAnalyticsDashboard({
+    analytics,
+    advancedAnalytics,
+    timeRange,
+    dispatch,
+    formatCurrency,
+    getActivityIcon
+  })
+}
+
+interface AnalyticsDashboardRenderProps {
+  analytics: AnalyticsData
+  advancedAnalytics: AdvancedAnalytics | null
+  timeRange: TimeRange
+  dispatch: React.Dispatch<AnalyticsPageAction>
+  formatCurrency: (value: number) => string
+  getActivityIcon: (type: string) => React.ReactNode
+}
+
+function renderAnalyticsDashboard({
+  analytics,
+  advancedAnalytics,
+  timeRange,
+  dispatch,
+  formatCurrency,
+  getActivityIcon
+}: AnalyticsDashboardRenderProps) {
   return (
     <>
       <SEOSchema
@@ -294,7 +373,7 @@ export default function AnalyticsPage() {
             <Button
               variant={timeRange === '30d' ? 'default' : 'outline'}
               size="sm"
-              onClick={() => setTimeRange('30d')}
+              onClick={() => dispatch({ type: 'timeRangeChanged', timeRange: '30d' })}
               className="whitespace-nowrap"
             >
               <span className="hidden sm:inline">30 Days</span>
@@ -303,7 +382,7 @@ export default function AnalyticsPage() {
             <Button
               variant={timeRange === '90d' ? 'default' : 'outline'}
               size="sm"
-              onClick={() => setTimeRange('90d')}
+              onClick={() => dispatch({ type: 'timeRangeChanged', timeRange: '90d' })}
               className="whitespace-nowrap"
             >
               <span className="hidden sm:inline">90 Days</span>
@@ -312,7 +391,7 @@ export default function AnalyticsPage() {
             <Button
               variant={timeRange === '1y' ? 'default' : 'outline'}
               size="sm"
-              onClick={() => setTimeRange('1y')}
+              onClick={() => dispatch({ type: 'timeRangeChanged', timeRange: '1y' })}
               className="whitespace-nowrap"
             >
               <span className="hidden sm:inline">1 Year</span>

--- a/src/app/farms/[id]/page.tsx
+++ b/src/app/farms/[id]/page.tsx
@@ -389,6 +389,11 @@ export default function FarmDetailsPage() {
     dayPhotos: File[],
     existingDailyNoteId?: number | null
   ) => {
+    if (!Number.isSafeInteger(farmIdNum) || farmIdNum <= 0) {
+      toast.error('Invalid farm URL. Please open the farm from the farms list.')
+      return
+    }
+
     setIsSubmitting(true)
     try {
       let firstRecordId: number | null = null
@@ -467,7 +472,7 @@ export default function FarmDetailsPage() {
         }
 
         record = await logMutations.irrigation.add.mutateAsync({
-          farm_id: parseInt(farmId),
+          farm_id: farmIdNum,
           date: date,
           duration: duration,
           area: area,
@@ -489,7 +494,7 @@ export default function FarmDetailsPage() {
             const newWaterLevel = currentWaterLevel + waterAdded
 
             await updateFarmMutation.mutateAsync({
-              id: parseInt(farmId),
+              id: farmIdNum,
               updates: {
                 remainingWater: newWaterLevel,
                 waterCalculationUpdatedAt: new Date().toISOString()
@@ -534,7 +539,7 @@ export default function FarmDetailsPage() {
 
         // Handle spray record with chemicals array (new format) or single chemical (old format)
         const sprayData: any = {
-          farm_id: parseInt(farmId),
+          farm_id: farmIdNum,
           date: date,
           chemicals: [],
           area: dashboardData.farm.area,
@@ -593,7 +598,7 @@ export default function FarmDetailsPage() {
 
       case 'harvest':
         record = await logMutations.harvest.add.mutateAsync({
-          farm_id: parseInt(farmId),
+          farm_id: farmIdNum,
           date: date,
           quantity: parseFloat(data.quantity || '0'),
           grade: data.grade || 'Standard',
@@ -606,7 +611,7 @@ export default function FarmDetailsPage() {
 
       case 'expense':
         record = await logMutations.expense.add.mutateAsync({
-          farm_id: parseInt(farmId),
+          farm_id: farmIdNum,
           date: date,
           type: data.type || 'other',
           cost: parseFloat(data.cost || '0'),
@@ -652,7 +657,7 @@ export default function FarmDetailsPage() {
         // Only include area if it's a valid positive number
         const farmArea = dashboardData?.farm?.area
         const payload: any = {
-          farm_id: parseInt(farmId),
+          farm_id: farmIdNum,
           date: date,
           fertilizers: validatedFertilizers,
           notes: data.notes || '',
@@ -771,7 +776,7 @@ export default function FarmDetailsPage() {
         })
 
         record = await logMutations.soilTest.add.mutateAsync({
-          farm_id: parseInt(farmId),
+          farm_id: farmIdNum,
           date,
           parameters: combinedParameters,
           notes: combineNotes.filter(Boolean).join(' | ') || '',
@@ -820,7 +825,7 @@ export default function FarmDetailsPage() {
         pushParameter('ammonical_nitrogen', data.ammonical_nitrogen)
 
         record = await logMutations.petioleTest.add.mutateAsync({
-          farm_id: parseInt(farmId),
+          farm_id: farmIdNum,
           date,
           sample_id: data.sample_id || '',
           parameters,
@@ -872,7 +877,7 @@ export default function FarmDetailsPage() {
         record = await logMutations.irrigation.update.mutateAsync({
           id: originalId,
           updates: {
-            farm_id: parseInt(farmId),
+            farm_id: farmIdNum,
             date: originalDate,
             duration: duration,
             area: area,
@@ -894,7 +899,7 @@ export default function FarmDetailsPage() {
 
         // Handle spray record with chemicals array (new format) or single chemical (old format)
         const sprayData: any = {
-          farm_id: parseInt(farmId),
+          farm_id: farmIdNum,
           date: originalDate,
           chemicals: [],
           area: dashboardData.farm.area,
@@ -955,7 +960,7 @@ export default function FarmDetailsPage() {
         record = await logMutations.harvest.update.mutateAsync({
           id: originalId,
           updates: {
-            farm_id: parseInt(farmId),
+            farm_id: farmIdNum,
             date: originalDate,
             quantity: parseFloat(data.quantity || '0'),
             grade: data.grade || 'Standard',
@@ -974,7 +979,7 @@ export default function FarmDetailsPage() {
         record = await logMutations.expense.update.mutateAsync({
           id: originalId,
           updates: {
-            farm_id: parseInt(farmId),
+            farm_id: farmIdNum,
             date: originalDate,
             type: data.type || 'other',
             cost: parseFloat(data.cost || '0'),
@@ -1031,7 +1036,7 @@ export default function FarmDetailsPage() {
         // Only include area if it's a valid positive number
         const updateFarmArea = dashboardData?.farm?.area
         const updatePayload: any = {
-          farm_id: parseInt(farmId),
+          farm_id: farmIdNum,
           date: originalDate,
           fertilizers: validatedFertilizers,
           notes: data.notes || '',
@@ -1155,7 +1160,7 @@ export default function FarmDetailsPage() {
         record = await logMutations.soilTest.update.mutateAsync({
           id: originalId,
           updates: {
-            farm_id: parseInt(farmId),
+            farm_id: farmIdNum,
             date: originalDate,
             parameters: combinedParameters,
             notes: combineNotes.filter(Boolean).join(' | ') || '',
@@ -1207,7 +1212,7 @@ export default function FarmDetailsPage() {
         record = await logMutations.petioleTest.update.mutateAsync({
           id: originalId,
           updates: {
-            farm_id: parseInt(farmId),
+            farm_id: farmIdNum,
             date: originalDate,
             sample_id: data.sample_id || '',
             parameters,
@@ -1307,13 +1312,19 @@ export default function FarmDetailsPage() {
         }
       }
 
-      await Promise.all(activities.map(deleteActivity))
+      const results = await Promise.allSettled(activities.map(deleteActivity))
+      const failedDeletes = results.filter((result) => result.status === 'rejected')
+
+      if (failedDeletes.length > 0) {
+        throw new Error(`${failedDeletes.length} log deletion failed`)
+      }
+
+      setPendingDateGroupDelete(null)
     } catch (error) {
       logger.error('Error deleting date group:', error)
       toast.error('Failed to delete logs. Please try again.')
     } finally {
       setIsDeleting(false)
-      setPendingDateGroupDelete(null)
     }
   }
 
@@ -1414,8 +1425,12 @@ export default function FarmDetailsPage() {
       }
 
       if (editingFarm) {
+        if (!Number.isSafeInteger(farmIdNum) || farmIdNum <= 0) {
+          throw new Error('Invalid farm URL. Please open the farm from the farms list.')
+        }
+
         // Edit mode: update existing farm (mutation invalidates list/detail/summary)
-        await updateFarmMutation.mutateAsync({ id: parseInt(farmId), updates: farmInput })
+        await updateFarmMutation.mutateAsync({ id: farmIdNum, updates: farmInput })
         setShowFarmModal(false)
         setEditingFarm(null)
       } else {
@@ -2090,7 +2105,7 @@ export default function FarmDetailsPage() {
           }}
           onSubmit={handleDataLogsSubmit}
           isSubmitting={isSubmitting}
-          farmId={parseInt(farmId)}
+          farmId={farmIdNum}
           mode={editMode}
           existingLogs={editModeLogs}
           selectedDate={editModeDate}

--- a/src/app/farms/[id]/page.tsx
+++ b/src/app/farms/[id]/page.tsx
@@ -98,7 +98,10 @@ export default function FarmDetailsPage() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const farmId = params.id as string
-  const farmIdNum = Number.parseInt(farmId, 10)
+  // Strict parse: a loose parseInt would turn "/farms/12abc" into farm 12 and
+  // drive queries/mutations against the wrong farm. NaN disables them instead.
+  const parsedFarmId = Number(farmId)
+  const farmIdNum = Number.isSafeInteger(parsedFarmId) && parsedFarmId > 0 ? parsedFarmId : NaN
   const queryClient = useQueryClient()
 
   // Server state via TanStack Query. The summary is the page's single source of
@@ -425,7 +428,11 @@ export default function FarmDetailsPage() {
         date
       })
 
-      invalidateFarmSummary()
+      // The daily-note/photo util writes through SupabaseService directly (not a
+      // mutation hook), so invalidate both the summary and the records bucket
+      // any logs page reads — matching what the per-log mutations invalidate.
+      queryClient.invalidateQueries({ queryKey: farmKeys.summary(farmIdNum) })
+      queryClient.invalidateQueries({ queryKey: farmKeys.records(farmIdNum) })
       toast.success('Data logs saved successfully')
       setShowDataLogsModal(false)
       setEditModeDayNote(null)
@@ -1305,6 +1312,7 @@ export default function FarmDetailsPage() {
       }
     } catch (error) {
       logger.error('Error deleting date group:', error)
+      toast.error('Failed to delete logs. Please try again.')
     } finally {
       setIsDeleting(false)
       setPendingDateGroupDelete(null)
@@ -1348,6 +1356,7 @@ export default function FarmDetailsPage() {
       setDeletingRecord(null)
     } catch (error) {
       logger.error('Error deleting record:', error)
+      toast.error('Failed to delete record. Please try again.')
     } finally {
       setIsDeleting(false)
     }

--- a/src/app/farms/[id]/page.tsx
+++ b/src/app/farms/[id]/page.tsx
@@ -1281,35 +1281,33 @@ export default function FarmDetailsPage() {
     try {
       setIsDeleting(true)
 
-      // Delete each activity in the group
-      for (const activity of activities) {
+      // Delete every activity in the group concurrently — they're independent
+      // records, and each mutation invalidates the summary/records caches so the
+      // post-delete refetch reflects whatever was removed.
+      const deleteActivity = (activity: { type: string; id: number }): Promise<unknown> => {
         switch (activity.type) {
           case 'irrigation':
-            await logMutations.irrigation.remove.mutateAsync(activity.id)
-            break
+            return logMutations.irrigation.remove.mutateAsync(activity.id)
           case 'spray':
-            await logMutations.spray.remove.mutateAsync(activity.id)
-            break
+            return logMutations.spray.remove.mutateAsync(activity.id)
           case 'harvest':
-            await logMutations.harvest.remove.mutateAsync(activity.id)
-            break
+            return logMutations.harvest.remove.mutateAsync(activity.id)
           case 'fertigation':
-            await logMutations.fertigation.remove.mutateAsync(activity.id)
-            break
+            return logMutations.fertigation.remove.mutateAsync(activity.id)
           case 'expense':
-            await logMutations.expense.remove.mutateAsync(activity.id)
-            break
+            return logMutations.expense.remove.mutateAsync(activity.id)
           case 'soil_test':
-            await logMutations.soilTest.remove.mutateAsync(activity.id)
-            break
+            return logMutations.soilTest.remove.mutateAsync(activity.id)
           case 'petiole_test':
-            await logMutations.petioleTest.remove.mutateAsync(activity.id)
-            break
+            return logMutations.petioleTest.remove.mutateAsync(activity.id)
           case 'daily_note':
-            await logMutations.dailyNote.remove.mutateAsync(activity.id)
-            break
+            return logMutations.dailyNote.remove.mutateAsync(activity.id)
+          default:
+            return Promise.resolve()
         }
       }
+
+      await Promise.all(activities.map(deleteActivity))
     } catch (error) {
       logger.error('Error deleting date group:', error)
       toast.error('Failed to delete logs. Please try again.')

--- a/src/app/farms/[id]/page.tsx
+++ b/src/app/farms/[id]/page.tsx
@@ -3,7 +3,18 @@
 import { useState, useEffect, useCallback } from 'react'
 import type { MouseEvent } from 'react'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
+import { useQueryClient } from '@tanstack/react-query'
 import { SupabaseService } from '@/lib/supabase-service'
+import { farmKeys } from '@/lib/farm-query-keys'
+import {
+  useFarms,
+  useDashboardSummary,
+  useFarmFertilizerPlans,
+  useCreateFarm,
+  useUpdateFarm,
+  useDeleteFarm
+} from '@/hooks/farms/useFarmQueries'
+import { useFarmLogMutations } from '@/hooks/farms/useFarmLogMutations'
 import { FarmHeader, type FarmWeatherSummary } from '@/components/farm-details/FarmHeader'
 import { ActivityFeed } from '@/components/farm-details/ActivityFeed'
 import { UnifiedDataLogsModal } from '@/components/farm-details/UnifiedDataLogsModal'
@@ -60,7 +71,6 @@ import {
   handleDailyNotesAndPhotosAfterLogs
 } from '@/lib/daily-note-utils'
 import { TasksOverviewCard } from '@/components/tasks/TasksOverviewCard'
-import { FertilizerPlanService, type FertilizerPlanWithItems } from '@/lib/fertilizer-plan-service'
 import { FertilizerPlanView } from '@/components/fertilizer/FertilizerPlanView'
 
 interface DashboardData {
@@ -88,12 +98,29 @@ export default function FarmDetailsPage() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const farmId = params.id as string
+  const farmIdNum = Number.parseInt(farmId, 10)
+  const queryClient = useQueryClient()
 
-  const [dashboardData, setDashboardData] = useState<DashboardData>()
-  const [loading, setLoading] = useState(true)
+  // Server state via TanStack Query. The summary is the page's single source of
+  // truth; every journal write invalidates farmKeys.summary(farmId) so it
+  // refetches wholesale (recent activity, counts, totals, pending tasks).
+  const { data: dashboardData, isLoading: loading } = useDashboardSummary(farmIdNum)
+  const { data: allFarms = [] } = useFarms()
+  const { data: fertilizerPlans = [] } = useFarmFertilizerPlans(farmIdNum)
+
+  // Journal write mutations (add/update/delete for all 8 record types) plus the
+  // farm mutations reused for the in-header switcher and water-level bump.
+  const logMutations = useFarmLogMutations(farmIdNum)
+  const updateFarmMutation = useUpdateFarm()
+  const createFarmMutation = useCreateFarm()
+  const deleteFarmMutation = useDeleteFarm()
+
+  const invalidateFarmSummary = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: farmKeys.summary(farmIdNum) })
+  }, [queryClient, farmIdNum])
+
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [weatherSummary, setWeatherSummary] = useState<FarmWeatherSummary | null>(null)
-  const [allFarms, setAllFarms] = useState<Farm[]>([])
   const [insightsOpen, setInsightsOpen] = useState(true)
   const [readinessOpen, setReadinessOpen] = useState(true)
   const [labTestSignal, setLabTestSignal] = useState<{
@@ -101,7 +128,6 @@ export default function FarmDetailsPage() {
     message: string
     pill?: string
   } | null>(null)
-  const [fertilizerPlans, setFertilizerPlans] = useState<FertilizerPlanWithItems[]>([])
   const dismissalStorageKey = `field-signal-dismissals:${farmId}`
   const [dismissedSignals, setDismissedSignals] = useState<Record<string, number>>({})
   const updateDismissedSignals = useCallback(
@@ -175,52 +201,6 @@ export default function FarmDetailsPage() {
   const isMobile = useIsMobile()
 
   const { preferences: userPreferences } = useUserPreferences(dashboardData?.farm?.userId)
-
-  const loadDashboardData = useCallback(async () => {
-    try {
-      setLoading(true)
-      const data = await SupabaseService.getDashboardSummary(parseInt(farmId))
-      setDashboardData({
-        ...data,
-        farm: data.farm
-      })
-
-      // Load fertilizer plans for this farm
-      try {
-        const plans = await FertilizerPlanService.getPlansByFarm(parseInt(farmId))
-        setFertilizerPlans(plans)
-      } catch (planError) {
-        // Silently fail - plans might not exist yet
-        logger.debug('No fertilizer plans found:', planError)
-      }
-    } catch (error) {
-      logger.error('Error loading dashboard data:', error)
-    } finally {
-      setLoading(false)
-    }
-  }, [farmId])
-
-  // Load all farms for farm switcher
-  useEffect(() => {
-    let isMounted = true
-
-    const loadAllFarms = async () => {
-      try {
-        const farms = await SupabaseService.getAllFarms()
-        if (isMounted) {
-          setAllFarms(farms)
-        }
-      } catch (error) {
-        logger.error('Error loading all farms:', error)
-      }
-    }
-
-    loadAllFarms()
-
-    return () => {
-      isMounted = false
-    }
-  }, [])
 
   useEffect(() => {
     if (isMobile) {
@@ -296,12 +276,6 @@ export default function FarmDetailsPage() {
       setDismissedSignals({})
     }
   }, [dismissalStorageKey])
-
-  useEffect(() => {
-    if (farmId) {
-      loadDashboardData()
-    }
-  }, [farmId, loadDashboardData])
 
   // Handle edit parameters from logs page
   useEffect(() => {
@@ -414,7 +388,6 @@ export default function FarmDetailsPage() {
   ) => {
     setIsSubmitting(true)
     try {
-      const farmIdNum = parseFarmId(farmId)
       let firstRecordId: number | null = null
 
       for (let i = 0; i < logs.length; i++) {
@@ -439,7 +412,9 @@ export default function FarmDetailsPage() {
         }
       }
 
-      // Handle daily notes and photos based on whether logs exist
+      // Handle daily notes and photos based on whether logs exist. Log writes
+      // above already invalidated the summary via their mutation hooks; this
+      // covers the notes-only / photo paths that go through the shared util.
       await handleDailyNotesAndPhotosAfterLogs({
         logs,
         dayNotes,
@@ -450,7 +425,7 @@ export default function FarmDetailsPage() {
         date
       })
 
-      await loadDashboardData()
+      invalidateFarmSummary()
       toast.success('Data logs saved successfully')
       setShowDataLogsModal(false)
       setEditModeDayNote(null)
@@ -484,7 +459,7 @@ export default function FarmDetailsPage() {
           throw new Error('Irrigation area must be greater than 0')
         }
 
-        record = await SupabaseService.addIrrigationRecord({
+        record = await logMutations.irrigation.add.mutateAsync({
           farm_id: parseInt(farmId),
           date: date,
           duration: duration,
@@ -506,9 +481,12 @@ export default function FarmDetailsPage() {
             const currentWaterLevel = Number(dashboardData.farm.remainingWater ?? 0)
             const newWaterLevel = currentWaterLevel + waterAdded
 
-            await SupabaseService.updateFarm(parseInt(farmId), {
-              remainingWater: newWaterLevel,
-              waterCalculationUpdatedAt: new Date().toISOString()
+            await updateFarmMutation.mutateAsync({
+              id: parseInt(farmId),
+              updates: {
+                remainingWater: newWaterLevel,
+                waterCalculationUpdatedAt: new Date().toISOString()
+              }
             })
 
             logger.info('Water level updated successfully', {
@@ -602,12 +580,12 @@ export default function FarmDetailsPage() {
               : 'As per label'
         }
 
-        record = await SupabaseService.addSprayRecord(sprayData)
+        record = await logMutations.spray.add.mutateAsync(sprayData)
         break
       }
 
       case 'harvest':
-        record = await SupabaseService.addHarvestRecord({
+        record = await logMutations.harvest.add.mutateAsync({
           farm_id: parseInt(farmId),
           date: date,
           quantity: parseFloat(data.quantity || '0'),
@@ -620,7 +598,7 @@ export default function FarmDetailsPage() {
         break
 
       case 'expense':
-        record = await SupabaseService.addExpenseRecord({
+        record = await logMutations.expense.add.mutateAsync({
           farm_id: parseInt(farmId),
           date: date,
           type: data.type || 'other',
@@ -679,7 +657,7 @@ export default function FarmDetailsPage() {
           payload.area = farmArea
         }
 
-        record = await SupabaseService.addFertigationRecord(payload)
+        record = await logMutations.fertigation.add.mutateAsync(payload)
         break
       }
 
@@ -785,7 +763,7 @@ export default function FarmDetailsPage() {
           }
         })
 
-        record = await SupabaseService.addSoilTestRecord({
+        record = await logMutations.soilTest.add.mutateAsync({
           farm_id: parseInt(farmId),
           date,
           parameters: combinedParameters,
@@ -834,7 +812,7 @@ export default function FarmDetailsPage() {
         pushParameter('nitrate_nitrogen', data.nitrate_nitrogen)
         pushParameter('ammonical_nitrogen', data.ammonical_nitrogen)
 
-        record = await SupabaseService.addPetioleTestRecord({
+        record = await logMutations.petioleTest.add.mutateAsync({
           farm_id: parseInt(farmId),
           date,
           sample_id: data.sample_id || '',
@@ -884,16 +862,19 @@ export default function FarmDetailsPage() {
           throw new Error('Irrigation area must be greater than 0')
         }
 
-        record = await SupabaseService.updateIrrigationRecord(originalId, {
-          farm_id: parseInt(farmId),
-          date: originalDate,
-          duration: duration,
-          area: area,
-          growth_stage: 'Active',
-          moisture_status: 'Good',
-          system_discharge: dashboardData.farm.systemDischarge,
-          notes: data.notes || '',
-          date_of_pruning: dashboardData.farm.dateOfPruning
+        record = await logMutations.irrigation.update.mutateAsync({
+          id: originalId,
+          updates: {
+            farm_id: parseInt(farmId),
+            date: originalDate,
+            duration: duration,
+            area: area,
+            growth_stage: 'Active',
+            moisture_status: 'Good',
+            system_discharge: dashboardData.farm.systemDischarge,
+            notes: data.notes || '',
+            date_of_pruning: dashboardData.farm.dateOfPruning
+          }
         })
         break
       }
@@ -959,34 +940,40 @@ export default function FarmDetailsPage() {
               : 'As per label'
         }
 
-        record = await SupabaseService.updateSprayRecord(originalId, sprayData)
+        record = await logMutations.spray.update.mutateAsync({ id: originalId, updates: sprayData })
         break
       }
 
       case 'harvest':
-        record = await SupabaseService.updateHarvestRecord(originalId, {
-          farm_id: parseInt(farmId),
-          date: originalDate,
-          quantity: parseFloat(data.quantity || '0'),
-          grade: data.grade || 'Standard',
-          price:
-            data.price !== undefined
-              ? parseFloat(data.price.toString())
-              : logEntry.data?.price || 0,
-          buyer: data.buyer !== undefined ? data.buyer : logEntry.data?.buyer || '',
-          notes: data.notes || '',
-          date_of_pruning: dashboardData?.farm?.dateOfPruning
+        record = await logMutations.harvest.update.mutateAsync({
+          id: originalId,
+          updates: {
+            farm_id: parseInt(farmId),
+            date: originalDate,
+            quantity: parseFloat(data.quantity || '0'),
+            grade: data.grade || 'Standard',
+            price:
+              data.price !== undefined
+                ? parseFloat(data.price.toString())
+                : logEntry.data?.price || 0,
+            buyer: data.buyer !== undefined ? data.buyer : logEntry.data?.buyer || '',
+            notes: data.notes || '',
+            date_of_pruning: dashboardData?.farm?.dateOfPruning
+          }
         })
         break
 
       case 'expense':
-        record = await SupabaseService.updateExpenseRecord(originalId, {
-          farm_id: parseInt(farmId),
-          date: originalDate,
-          type: data.type || 'other',
-          cost: parseFloat(data.cost || '0'),
-          remarks: data.notes || '',
-          date_of_pruning: dashboardData?.farm?.dateOfPruning
+        record = await logMutations.expense.update.mutateAsync({
+          id: originalId,
+          updates: {
+            farm_id: parseInt(farmId),
+            date: originalDate,
+            type: data.type || 'other',
+            cost: parseFloat(data.cost || '0'),
+            remarks: data.notes || '',
+            date_of_pruning: dashboardData?.farm?.dateOfPruning
+          }
         })
         break
 
@@ -1049,7 +1036,10 @@ export default function FarmDetailsPage() {
           updatePayload.area = updateFarmArea
         }
 
-        record = await SupabaseService.updateFertigationRecord(originalId, updatePayload)
+        record = await logMutations.fertigation.update.mutateAsync({
+          id: originalId,
+          updates: updatePayload
+        })
         break
       }
 
@@ -1155,20 +1145,23 @@ export default function FarmDetailsPage() {
           }
         })
 
-        record = await SupabaseService.updateSoilTestRecord(originalId, {
-          farm_id: parseInt(farmId),
-          date: originalDate,
-          parameters: combinedParameters,
-          notes: combineNotes.filter(Boolean).join(' | ') || '',
-          report_url: reportMeta?.signedUrl,
-          report_storage_path: reportMeta?.storagePath,
-          report_filename: reportMeta?.filename,
-          report_type: reportMeta?.reportType,
-          extraction_status: reportMeta?.extractionStatus,
-          extraction_error: reportMeta?.extractionError,
-          parsed_parameters: reportMeta?.parsedParameters,
-          raw_notes: reportMeta?.rawNotes ?? undefined,
-          date_of_pruning: dashboardData?.farm?.dateOfPruning
+        record = await logMutations.soilTest.update.mutateAsync({
+          id: originalId,
+          updates: {
+            farm_id: parseInt(farmId),
+            date: originalDate,
+            parameters: combinedParameters,
+            notes: combineNotes.filter(Boolean).join(' | ') || '',
+            report_url: reportMeta?.signedUrl,
+            report_storage_path: reportMeta?.storagePath,
+            report_filename: reportMeta?.filename,
+            report_type: reportMeta?.reportType,
+            extraction_status: reportMeta?.extractionStatus,
+            extraction_error: reportMeta?.extractionError,
+            parsed_parameters: reportMeta?.parsedParameters,
+            raw_notes: reportMeta?.rawNotes ?? undefined,
+            date_of_pruning: dashboardData?.farm?.dateOfPruning
+          }
         })
         break
       }
@@ -1204,21 +1197,24 @@ export default function FarmDetailsPage() {
         pushParameter('nitrate_nitrogen', data.nitrate_nitrogen)
         pushParameter('ammonical_nitrogen', data.ammonical_nitrogen)
 
-        record = await SupabaseService.updatePetioleTestRecord(originalId, {
-          farm_id: parseInt(farmId),
-          date: originalDate,
-          sample_id: data.sample_id || '',
-          parameters,
-          notes: combineNotes.filter(Boolean).join(' | ') || '',
-          report_url: reportMeta?.signedUrl,
-          report_storage_path: reportMeta?.storagePath,
-          report_filename: reportMeta?.filename,
-          report_type: reportMeta?.reportType,
-          extraction_status: reportMeta?.extractionStatus,
-          extraction_error: reportMeta?.extractionError,
-          parsed_parameters: reportMeta?.parsedParameters,
-          raw_notes: reportMeta?.rawNotes ?? undefined,
-          date_of_pruning: dashboardData?.farm?.dateOfPruning
+        record = await logMutations.petioleTest.update.mutateAsync({
+          id: originalId,
+          updates: {
+            farm_id: parseInt(farmId),
+            date: originalDate,
+            sample_id: data.sample_id || '',
+            parameters,
+            notes: combineNotes.filter(Boolean).join(' | ') || '',
+            report_url: reportMeta?.signedUrl,
+            report_storage_path: reportMeta?.storagePath,
+            report_filename: reportMeta?.filename,
+            report_type: reportMeta?.reportType,
+            extraction_status: reportMeta?.extractionStatus,
+            extraction_error: reportMeta?.extractionError,
+            parsed_parameters: reportMeta?.parsedParameters,
+            raw_notes: reportMeta?.rawNotes ?? undefined,
+            date_of_pruning: dashboardData?.farm?.dateOfPruning
+          }
         })
         break
       }
@@ -1282,33 +1278,31 @@ export default function FarmDetailsPage() {
       for (const activity of activities) {
         switch (activity.type) {
           case 'irrigation':
-            await SupabaseService.deleteIrrigationRecord(activity.id)
+            await logMutations.irrigation.remove.mutateAsync(activity.id)
             break
           case 'spray':
-            await SupabaseService.deleteSprayRecord(activity.id)
+            await logMutations.spray.remove.mutateAsync(activity.id)
             break
           case 'harvest':
-            await SupabaseService.deleteHarvestRecord(activity.id)
+            await logMutations.harvest.remove.mutateAsync(activity.id)
             break
           case 'fertigation':
-            await SupabaseService.deleteFertigationRecord(activity.id)
+            await logMutations.fertigation.remove.mutateAsync(activity.id)
             break
           case 'expense':
-            await SupabaseService.deleteExpenseRecord(activity.id)
+            await logMutations.expense.remove.mutateAsync(activity.id)
             break
           case 'soil_test':
-            await SupabaseService.deleteSoilTestRecord(activity.id)
+            await logMutations.soilTest.remove.mutateAsync(activity.id)
             break
           case 'petiole_test':
-            await SupabaseService.deletePetioleTestRecord(activity.id)
+            await logMutations.petioleTest.remove.mutateAsync(activity.id)
             break
           case 'daily_note':
-            await SupabaseService.deleteDailyNote(activity.id)
+            await logMutations.dailyNote.remove.mutateAsync(activity.id)
             break
         }
       }
-
-      await loadDashboardData()
     } catch (error) {
       logger.error('Error deleting date group:', error)
     } finally {
@@ -1325,32 +1319,31 @@ export default function FarmDetailsPage() {
 
       switch (deletingRecord.type) {
         case 'irrigation':
-          await SupabaseService.deleteIrrigationRecord(deletingRecord.id)
+          await logMutations.irrigation.remove.mutateAsync(deletingRecord.id)
           break
         case 'spray':
-          await SupabaseService.deleteSprayRecord(deletingRecord.id)
+          await logMutations.spray.remove.mutateAsync(deletingRecord.id)
           break
         case 'harvest':
-          await SupabaseService.deleteHarvestRecord(deletingRecord.id)
+          await logMutations.harvest.remove.mutateAsync(deletingRecord.id)
           break
         case 'fertigation':
-          await SupabaseService.deleteFertigationRecord(deletingRecord.id)
+          await logMutations.fertigation.remove.mutateAsync(deletingRecord.id)
           break
         case 'expense':
-          await SupabaseService.deleteExpenseRecord(deletingRecord.id)
+          await logMutations.expense.remove.mutateAsync(deletingRecord.id)
           break
         case 'soil_test':
-          await SupabaseService.deleteSoilTestRecord(deletingRecord.id)
+          await logMutations.soilTest.remove.mutateAsync(deletingRecord.id)
           break
         case 'petiole_test':
-          await SupabaseService.deletePetioleTestRecord(deletingRecord.id)
+          await logMutations.petioleTest.remove.mutateAsync(deletingRecord.id)
           break
         case 'daily_note':
-          await SupabaseService.deleteDailyNote(deletingRecord.id)
+          await logMutations.dailyNote.remove.mutateAsync(deletingRecord.id)
           break
       }
 
-      await loadDashboardData()
       setShowDeleteDialog(false)
       setDeletingRecord(null)
     } catch (error) {
@@ -1375,7 +1368,7 @@ export default function FarmDetailsPage() {
     const farmIdToDelete = pendingFarmDelete
     setIsDeleting(true)
     try {
-      await SupabaseService.deleteFarm(farmIdToDelete)
+      await deleteFarmMutation.mutateAsync(farmIdToDelete)
       router.push('/farms') // Navigate back to farms list
     } catch (error) {
       logger.error('Error deleting farm:', error)
@@ -1403,15 +1396,24 @@ export default function FarmDetailsPage() {
     try {
       setFarmSubmitLoading(true)
 
+      // FarmModal submits location fields snake_cased; the Supabase mappers read
+      // camelCase, so normalize here or the saved location is silently dropped.
+      const { location_name, location_source, location_updated_at, ...rest } = farmData
+      const farmInput = {
+        ...rest,
+        locationName: location_name,
+        locationSource: location_source,
+        locationUpdatedAt: location_updated_at
+      }
+
       if (editingFarm) {
-        // Edit mode: update existing farm
-        await SupabaseService.updateFarm(parseInt(farmId), farmData)
-        await loadDashboardData()
+        // Edit mode: update existing farm (mutation invalidates list/detail/summary)
+        await updateFarmMutation.mutateAsync({ id: parseInt(farmId), updates: farmInput })
         setShowFarmModal(false)
         setEditingFarm(null)
       } else {
         // Create mode: add new farm and navigate to it
-        const newFarm = await SupabaseService.createFarm(farmData)
+        const newFarm = await createFarmMutation.mutateAsync(farmInput)
         setShowFarmModal(false)
         setEditingFarm(null)
 
@@ -1689,7 +1691,7 @@ export default function FarmDetailsPage() {
             tasks={dashboardData?.pendingTasks || []}
             farmName={farm?.name ? capitalize(farm.name) : undefined}
             loading={loading}
-            onTasksUpdated={loadDashboardData}
+            onTasksUpdated={invalidateFarmSummary}
             className="border-none bg-transparent p-0 shadow-none"
           />
         </TabsContent>
@@ -2096,7 +2098,13 @@ export default function FarmDetailsPage() {
             isOpen={showWaterCalculationModal}
             onClose={() => setShowWaterCalculationModal(false)}
             farm={dashboardData.farm}
-            onCalculationComplete={loadDashboardData}
+            onCalculationComplete={() => {
+              // Recalculating water mutates the farm record, so refresh the
+              // dashboard summary plus the list/detail caches that show it.
+              queryClient.invalidateQueries({ queryKey: farmKeys.summary(farmIdNum) })
+              queryClient.invalidateQueries({ queryKey: farmKeys.detail(farmIdNum) })
+              queryClient.invalidateQueries({ queryKey: farmKeys.list() })
+            }}
           />
         )}
 

--- a/src/app/farms/[id]/soil-profiling/page.tsx
+++ b/src/app/farms/[id]/soil-profiling/page.tsx
@@ -413,7 +413,7 @@ export default function SoilProfilingPage() {
 
   const sortedProfiles = useMemo(() => {
     if (!soilProfiles.length) return []
-    return [...soilProfiles].sort((a, b) => {
+    return soilProfiles.toSorted((a, b) => {
       const aDate = a.created_at ? new Date(a.created_at).getTime() : 0
       const bDate = b.created_at ? new Date(b.created_at).getTime() : 0
       return aDate - bDate

--- a/src/components/lab-tests/LabTestComparisonTable.tsx
+++ b/src/components/lab-tests/LabTestComparisonTable.tsx
@@ -132,7 +132,7 @@ export function LabTestComparisonTable({ soilTests, petioleTests }: LabTestCompa
   // Render comparison table
   const renderComparisonTable = (tests: LabTestRecord[], params: ParamOption[]) => {
     // Sort tests by date (oldest to newest)
-    const sortedTests = [...tests].sort(
+    const sortedTests = tests.toSorted(
       (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
     )
 

--- a/src/components/lab-tests/LabTestTrendCharts.tsx
+++ b/src/components/lab-tests/LabTestTrendCharts.tsx
@@ -67,8 +67,8 @@ export function LabTestTrendCharts({ soilTests, petioleTests }: LabTestTrendChar
   }
 
   // Prepare soil test data
-  const soilTrendData: TrendData[] = [...soilTests]
-    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+  const soilTrendData: TrendData[] = soilTests
+    .toSorted((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
     .map((record) => ({
       date: new Date(record.date).toISOString(),
       displayDate: format(new Date(record.date), 'MMM dd, yyyy'),
@@ -95,8 +95,8 @@ export function LabTestTrendCharts({ soilTests, petioleTests }: LabTestTrendChar
     }))
 
   // Prepare petiole test data
-  const petioleTrendData: TrendData[] = [...petioleTests]
-    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+  const petioleTrendData: TrendData[] = petioleTests
+    .toSorted((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
     .map((record) => ({
       date: new Date(record.date).toISOString(),
       displayDate: format(new Date(record.date), 'MMM dd, yyyy'),

--- a/src/components/lab-tests/LabTestsTimeline.tsx
+++ b/src/components/lab-tests/LabTestsTimeline.tsx
@@ -98,7 +98,7 @@ export function LabTestsTimeline({
     type: 'soil' | 'petiole'
   ): LabTestRecord | undefined => {
     const testsOfType = type === 'soil' ? soilTests : petioleTests
-    const sorted = [...testsOfType].sort(
+    const sorted = testsOfType.toSorted(
       (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
     )
     const currentIndex = sorted.findIndex((t) => t.id === currentTest.id)

--- a/src/hooks/farms/useFarmLogMutations.ts
+++ b/src/hooks/farms/useFarmLogMutations.ts
@@ -1,0 +1,303 @@
+'use client'
+
+import { useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query'
+import { SupabaseService } from '@/lib/supabase-service'
+import { farmKeys } from '@/lib/farm-query-keys'
+import type {
+  IrrigationRecord,
+  SprayRecord,
+  FertigationRecord,
+  HarvestRecord,
+  ExpenseRecord,
+  SoilTestRecord,
+  PetioleTestRecord,
+  DailyNoteRecord
+} from '@/lib/supabase'
+
+/**
+ * Mutation hooks for the farm journal write surface (farms/[id]).
+ *
+ * Per the slice's design we use *wholesale* invalidation of the farm summary on
+ * every write — this matches the page's previous refetch-everything behavior and
+ * keeps the recent-activity / counts / totals aggregate correct. Alongside the
+ * summary we also invalidate the relevant `records` / `labTests` bucket so other
+ * surfaces (logs page, lab workspace) reading those keys stay fresh. Per-record
+ * granular caches are intentionally out of scope.
+ */
+
+// Activity/journal records that surface in the logs + activity feed.
+function invalidateRecords(queryClient: QueryClient, farmId: number) {
+  queryClient.invalidateQueries({ queryKey: farmKeys.summary(farmId) })
+  queryClient.invalidateQueries({ queryKey: farmKeys.records(farmId) })
+}
+
+// Lab analyses (soil + petiole) that surface in the lab workspace.
+function invalidateLabTests(queryClient: QueryClient, farmId: number) {
+  queryClient.invalidateQueries({ queryKey: farmKeys.summary(farmId) })
+  queryClient.invalidateQueries({ queryKey: farmKeys.labTests(farmId) })
+}
+
+type CreateInput<T> = Omit<T, 'id' | 'created_at'>
+type UpdateArgs<T> = { id: number; updates: Partial<T> }
+
+// ── Irrigation ──────────────────────────────────────────────────────────────
+export function useAddIrrigationRecord(farmId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (record: CreateInput<IrrigationRecord>) =>
+      SupabaseService.addIrrigationRecord(record),
+    onSuccess: () => invalidateRecords(queryClient, farmId)
+  })
+}
+
+export function useUpdateIrrigationRecord(farmId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, updates }: UpdateArgs<IrrigationRecord>) =>
+      SupabaseService.updateIrrigationRecord(id, updates),
+    onSuccess: () => invalidateRecords(queryClient, farmId)
+  })
+}
+
+export function useDeleteIrrigationRecord(farmId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => SupabaseService.deleteIrrigationRecord(id),
+    onSuccess: () => invalidateRecords(queryClient, farmId)
+  })
+}
+
+// ── Spray ─────────────────────────────────────────────────────────────────--
+export function useAddSprayRecord(farmId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (record: CreateInput<SprayRecord>) => SupabaseService.addSprayRecord(record),
+    onSuccess: () => invalidateRecords(queryClient, farmId)
+  })
+}
+
+export function useUpdateSprayRecord(farmId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, updates }: UpdateArgs<SprayRecord>) =>
+      SupabaseService.updateSprayRecord(id, updates),
+    onSuccess: () => invalidateRecords(queryClient, farmId)
+  })
+}
+
+export function useDeleteSprayRecord(farmId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => SupabaseService.deleteSprayRecord(id),
+    onSuccess: () => invalidateRecords(queryClient, farmId)
+  })
+}
+
+// ── Harvest ───────────────────────────────────────────────────────────────--
+export function useAddHarvestRecord(farmId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (record: CreateInput<HarvestRecord>) => SupabaseService.addHarvestRecord(record),
+    onSuccess: () => invalidateRecords(queryClient, farmId)
+  })
+}
+
+export function useUpdateHarvestRecord(farmId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, updates }: UpdateArgs<HarvestRecord>) =>
+      SupabaseService.updateHarvestRecord(id, updates),
+    onSuccess: () => invalidateRecords(queryClient, farmId)
+  })
+}
+
+export function useDeleteHarvestRecord(farmId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => SupabaseService.deleteHarvestRecord(id),
+    onSuccess: () => invalidateRecords(queryClient, farmId)
+  })
+}
+
+// ── Expense ───────────────────────────────────────────────────────────────--
+export function useAddExpenseRecord(farmId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (record: CreateInput<ExpenseRecord>) => SupabaseService.addExpenseRecord(record),
+    onSuccess: () => invalidateRecords(queryClient, farmId)
+  })
+}
+
+export function useUpdateExpenseRecord(farmId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, updates }: UpdateArgs<ExpenseRecord>) =>
+      SupabaseService.updateExpenseRecord(id, updates),
+    onSuccess: () => invalidateRecords(queryClient, farmId)
+  })
+}
+
+export function useDeleteExpenseRecord(farmId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => SupabaseService.deleteExpenseRecord(id),
+    onSuccess: () => invalidateRecords(queryClient, farmId)
+  })
+}
+
+// ── Fertigation ─────────────────────────────────────────────────────────────
+export function useAddFertigationRecord(farmId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (record: CreateInput<FertigationRecord>) =>
+      SupabaseService.addFertigationRecord(record),
+    onSuccess: () => invalidateRecords(queryClient, farmId)
+  })
+}
+
+export function useUpdateFertigationRecord(farmId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, updates }: UpdateArgs<FertigationRecord>) =>
+      SupabaseService.updateFertigationRecord(id, updates),
+    onSuccess: () => invalidateRecords(queryClient, farmId)
+  })
+}
+
+export function useDeleteFertigationRecord(farmId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => SupabaseService.deleteFertigationRecord(id),
+    onSuccess: () => invalidateRecords(queryClient, farmId)
+  })
+}
+
+// ── Soil test ───────────────────────────────────────────────────────────────
+export function useAddSoilTestRecord(farmId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (record: CreateInput<SoilTestRecord>) => SupabaseService.addSoilTestRecord(record),
+    onSuccess: () => invalidateLabTests(queryClient, farmId)
+  })
+}
+
+export function useUpdateSoilTestRecord(farmId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, updates }: UpdateArgs<SoilTestRecord>) =>
+      SupabaseService.updateSoilTestRecord(id, updates),
+    onSuccess: () => invalidateLabTests(queryClient, farmId)
+  })
+}
+
+export function useDeleteSoilTestRecord(farmId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => SupabaseService.deleteSoilTestRecord(id),
+    onSuccess: () => invalidateLabTests(queryClient, farmId)
+  })
+}
+
+// ── Petiole test ────────────────────────────────────────────────────────────
+export function useAddPetioleTestRecord(farmId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (record: CreateInput<PetioleTestRecord>) =>
+      SupabaseService.addPetioleTestRecord(record),
+    onSuccess: () => invalidateLabTests(queryClient, farmId)
+  })
+}
+
+export function useUpdatePetioleTestRecord(farmId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, updates }: UpdateArgs<PetioleTestRecord>) =>
+      SupabaseService.updatePetioleTestRecord(id, updates),
+    onSuccess: () => invalidateLabTests(queryClient, farmId)
+  })
+}
+
+export function useDeletePetioleTestRecord(farmId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => SupabaseService.deletePetioleTestRecord(id),
+    onSuccess: () => invalidateLabTests(queryClient, farmId)
+  })
+}
+
+// ── Daily note ──────────────────────────────────────────────────────────────
+type DailyNoteInput = { farm_id: number; date: string; notes?: string | null }
+
+export function useAddDailyNote(farmId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (note: DailyNoteInput) => SupabaseService.upsertDailyNote(note),
+    onSuccess: () => invalidateRecords(queryClient, farmId)
+  })
+}
+
+export function useUpdateDailyNote(farmId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, updates }: UpdateArgs<DailyNoteRecord>) =>
+      SupabaseService.updateDailyNote(id, updates),
+    onSuccess: () => invalidateRecords(queryClient, farmId)
+  })
+}
+
+export function useDeleteDailyNote(farmId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => SupabaseService.deleteDailyNote(id),
+    onSuccess: () => invalidateRecords(queryClient, farmId)
+  })
+}
+
+/**
+ * Convenience aggregator: every journal record type's add/update/delete mutation
+ * grouped by type, so a write surface can wire them with a single hook call.
+ */
+export function useFarmLogMutations(farmId: number) {
+  return {
+    irrigation: {
+      add: useAddIrrigationRecord(farmId),
+      update: useUpdateIrrigationRecord(farmId),
+      remove: useDeleteIrrigationRecord(farmId)
+    },
+    spray: {
+      add: useAddSprayRecord(farmId),
+      update: useUpdateSprayRecord(farmId),
+      remove: useDeleteSprayRecord(farmId)
+    },
+    harvest: {
+      add: useAddHarvestRecord(farmId),
+      update: useUpdateHarvestRecord(farmId),
+      remove: useDeleteHarvestRecord(farmId)
+    },
+    expense: {
+      add: useAddExpenseRecord(farmId),
+      update: useUpdateExpenseRecord(farmId),
+      remove: useDeleteExpenseRecord(farmId)
+    },
+    fertigation: {
+      add: useAddFertigationRecord(farmId),
+      update: useUpdateFertigationRecord(farmId),
+      remove: useDeleteFertigationRecord(farmId)
+    },
+    soilTest: {
+      add: useAddSoilTestRecord(farmId),
+      update: useUpdateSoilTestRecord(farmId),
+      remove: useDeleteSoilTestRecord(farmId)
+    },
+    petioleTest: {
+      add: useAddPetioleTestRecord(farmId),
+      update: useUpdatePetioleTestRecord(farmId),
+      remove: useDeletePetioleTestRecord(farmId)
+    },
+    dailyNote: {
+      add: useAddDailyNote(farmId),
+      update: useUpdateDailyNote(farmId),
+      remove: useDeleteDailyNote(farmId)
+    }
+  }
+}

--- a/src/hooks/farms/useFarmQueries.ts
+++ b/src/hooks/farms/useFarmQueries.ts
@@ -21,19 +21,21 @@ export function useFarms() {
  * write invalidates `farmKeys.summary(farmId)` so this refetches wholesale.
  */
 export function useDashboardSummary(farmId: number | null) {
+  const hasFarm = farmId != null && Number.isFinite(farmId)
   return useQuery({
-    queryKey: farmId != null ? farmKeys.summary(farmId) : ['farms', 'summary', 'disabled'],
+    queryKey: hasFarm ? farmKeys.summary(farmId as number) : ['farms', 'summary', 'disabled'],
     queryFn: () => SupabaseService.getDashboardSummary(farmId as number),
-    enabled: farmId != null && Number.isFinite(farmId)
+    enabled: hasFarm
   })
 }
 
 /** Agronomist fertilizer plans for a farm. Read-only on this surface. */
 export function useFarmFertilizerPlans(farmId: number | null) {
+  const hasFarm = farmId != null && Number.isFinite(farmId)
   return useQuery({
-    queryKey: farmId != null ? farmKeys.plans(farmId) : ['farms', 'plans', 'disabled'],
+    queryKey: hasFarm ? farmKeys.plans(farmId as number) : ['farms', 'plans', 'disabled'],
     queryFn: () => FertilizerPlanService.getPlansByFarm(farmId as number),
-    enabled: farmId != null && Number.isFinite(farmId)
+    enabled: hasFarm
   })
 }
 

--- a/src/hooks/farms/useFarmQueries.ts
+++ b/src/hooks/farms/useFarmQueries.ts
@@ -2,6 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { SupabaseService } from '@/lib/supabase-service'
+import { FertilizerPlanService } from '@/lib/fertilizer-plan-service'
 import { farmKeys } from '@/lib/farm-query-keys'
 import type { Farm } from '@/types/types'
 
@@ -11,6 +12,28 @@ export function useFarms() {
   return useQuery({
     queryKey: farmKeys.list(),
     queryFn: () => SupabaseService.getAllFarms()
+  })
+}
+
+/**
+ * Aggregate dashboard payload for the farm detail page (farm, recent activity,
+ * counts, totals, pending tasks). Backed by `getDashboardSummary`; every journal
+ * write invalidates `farmKeys.summary(farmId)` so this refetches wholesale.
+ */
+export function useDashboardSummary(farmId: number | null) {
+  return useQuery({
+    queryKey: farmId != null ? farmKeys.summary(farmId) : ['farms', 'summary', 'disabled'],
+    queryFn: () => SupabaseService.getDashboardSummary(farmId as number),
+    enabled: farmId != null && Number.isFinite(farmId)
+  })
+}
+
+/** Agronomist fertilizer plans for a farm. Read-only on this surface. */
+export function useFarmFertilizerPlans(farmId: number | null) {
+  return useQuery({
+    queryKey: farmId != null ? farmKeys.plans(farmId) : ['farms', 'plans', 'disabled'],
+    queryFn: () => FertilizerPlanService.getPlansByFarm(farmId as number),
+    enabled: farmId != null && Number.isFinite(farmId)
   })
 }
 
@@ -52,6 +75,9 @@ export function useUpdateFarm() {
     onSuccess: (_farm, { id }) => {
       queryClient.invalidateQueries({ queryKey: farmKeys.list() })
       queryClient.invalidateQueries({ queryKey: farmKeys.detail(id) })
+      // Farm edits (incl. the irrigation water-level bump) feed the dashboard
+      // header/readiness, so refresh the summary too.
+      queryClient.invalidateQueries({ queryKey: farmKeys.summary(id) })
     }
   })
 }

--- a/src/lib/ai-service.ts
+++ b/src/lib/ai-service.ts
@@ -670,7 +670,11 @@ export class AIService {
 
     // Find matching pattern
     for (const pattern of patterns) {
-      if (pattern.keywords.some((keyword) => lowerMessage.includes(keyword))) {
+      const keywordPattern = new RegExp(
+        pattern.keywords.map((keyword) => keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')
+      )
+      const matchingKeyword = keywordPattern.test(lowerMessage)
+      if (matchingKeyword) {
         return pattern.responses[language as keyof typeof pattern.responses] || pattern.responses.en
       }
     }

--- a/src/lib/crop-data.ts
+++ b/src/lib/crop-data.ts
@@ -224,11 +224,15 @@ export function getRecommendedCropsForRegion(region: string): string[] {
     return POPULAR_CROPS
   }
 
-  const region_lower = region.toLowerCase().trim()
+  const regionLower = region.toLowerCase().trim()
 
   // Check for exact matches and aliases
   for (const [canonicalRegion, aliases] of Object.entries(REGION_ALIASES)) {
-    if (aliases.some((alias) => region_lower.includes(alias))) {
+    const aliasPattern = new RegExp(
+      aliases.map((alias) => alias.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')
+    )
+    const matchingAlias = aliasPattern.test(regionLower)
+    if (matchingAlias) {
       return (
         REGION_CROP_MAPPINGS[canonicalRegion as keyof typeof REGION_CROP_MAPPINGS] || POPULAR_CROPS
       )
@@ -237,21 +241,18 @@ export function getRecommendedCropsForRegion(region: string): string[] {
 
   // Check for partial matches in region names
   for (const [regionKey, crops] of Object.entries(REGION_CROP_MAPPINGS)) {
-    if (region_lower.includes(regionKey)) {
+    const regionPattern = new RegExp(regionKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    if (regionPattern.test(regionLower)) {
       return crops
     }
   }
 
   // Climate-based fallback (very basic for now)
-  if (
-    region_lower.includes('north') ||
-    region_lower.includes('hill') ||
-    region_lower.includes('mountain')
-  ) {
+  if (/north|hill|mountain/.test(regionLower)) {
     return REGION_CROP_MAPPINGS.cool
   }
 
-  if (region_lower.includes('coastal') || region_lower.includes('beach')) {
+  if (/coastal|beach/.test(regionLower)) {
     return ['Mango', 'Coconut', 'Pomegranates']
   }
 

--- a/src/lib/farm-query-keys.ts
+++ b/src/lib/farm-query-keys.ts
@@ -6,5 +6,6 @@ export const farmKeys = {
   records: (farmId: number) => ['farms', farmId, 'records'] as const,
   tasks: (farmId: number) => ['farms', farmId, 'tasks'] as const,
   labTests: (farmId: number) => ['farms', farmId, 'lab-tests'] as const,
-  soilProfiles: (farmId: number) => ['farms', farmId, 'soil-profiles'] as const
+  soilProfiles: (farmId: number) => ['farms', farmId, 'soil-profiles'] as const,
+  plans: (farmId: number) => ['farms', farmId, 'plans'] as const
 }

--- a/src/lib/lab-test-integration.ts
+++ b/src/lib/lab-test-integration.ts
@@ -448,25 +448,33 @@ export function matchExpenseToRecommendation(
   recommendations: Recommendation[]
 ): { matched: boolean; recommendation?: Recommendation } {
   const descLower = expenseDescription.toLowerCase()
+  const trackedProducts = [
+    'lime',
+    'gypsum',
+    'urea',
+    'dap',
+    'mop',
+    'potash',
+    'zinc',
+    'boron',
+    'iron',
+    'calcium',
+    'magnesium',
+    'compost'
+  ]
+  const mentionedProducts = new Set(
+    trackedProducts.filter((product) => new RegExp(product).test(descLower))
+  )
 
   for (const rec of recommendations) {
+    if (mentionedProducts.size === 0) break
     const techLower = rec.technical.toLowerCase()
 
     // Check for product mentions
-    if (
-      (descLower.includes('lime') && techLower.includes('lime')) ||
-      (descLower.includes('gypsum') && techLower.includes('gypsum')) ||
-      (descLower.includes('urea') && techLower.includes('urea')) ||
-      (descLower.includes('dap') && techLower.includes('dap')) ||
-      (descLower.includes('mop') && techLower.includes('mop')) ||
-      (descLower.includes('potash') && techLower.includes('potash')) ||
-      (descLower.includes('zinc') && techLower.includes('zinc')) ||
-      (descLower.includes('boron') && techLower.includes('boron')) ||
-      (descLower.includes('iron') && techLower.includes('iron')) ||
-      (descLower.includes('calcium') && techLower.includes('calcium')) ||
-      (descLower.includes('magnesium') && techLower.includes('magnesium')) ||
-      (descLower.includes('compost') && techLower.includes('compost'))
-    ) {
+    const hasMatchingProduct = trackedProducts.some((product) => {
+      return mentionedProducts.has(product) && new RegExp(product).test(techLower)
+    })
+    if (hasMatchingProduct) {
       return { matched: true, recommendation: rec }
     }
   }

--- a/src/lib/supabase-service.ts
+++ b/src/lib/supabase-service.ts
@@ -708,12 +708,12 @@ export class SupabaseService {
       const unit = fertilizer.unit.trim()
 
       // Validate unit is one of the allowed values
-      if (!['kg/acre', 'liter/acre'].includes(unit)) {
+      if (!isValidFertigationUnit(unit)) {
         throw new Error('Fertilizer unit must be either "kg/acre" or "liter/acre"')
       }
 
       // Assign/store sanitized trimmed value back to object with proper type assertion
-      fertilizer.unit = unit as 'kg/acre' | 'liter/acre'
+      fertilizer.unit = unit
     }
 
     // Validate area if provided
@@ -795,12 +795,12 @@ export class SupabaseService {
         const unit = fertilizer.unit.trim()
 
         // Validate unit is one of the allowed values
-        if (!['kg/acre', 'liter/acre'].includes(unit)) {
+        if (!isValidFertigationUnit(unit)) {
           throw new Error('Fertilizer unit must be either "kg/acre" or "liter/acre"')
         }
 
         // Assign/store sanitized trimmed value back to object with proper type assertion
-        fertilizer.unit = unit as 'kg/acre' | 'liter/acre'
+        fertilizer.unit = unit
       }
     }
 


### PR DESCRIPTION
## What

Migrates the farm detail page (`farms/[id]`) — the app's heaviest write surface — onto the shared TanStack Query foundation from #173. Closes #174.

## Changes

- **`useDashboardSummary(farmId)`** wraps `getDashboardSummary` and is now the page's single source of truth. No direct `getDashboardSummary` call remains.
- **Farm switcher** reads from the shared **`useFarms()`** — no second `getAllFarms` fetch on this route.
- **`useFarmLogMutations.ts`** (new): add/update/delete mutation hooks for all 8 record types — irrigation, spray, harvest, expense, fertigation, soil test, petiole test, daily note. Activity records invalidate `summary` + `records`; lab analyses invalidate `summary` + `labTests`. An aggregator hook wires them with a single call in the page.
- Every journal write and the farm create/update/delete now flow through mutation hooks (reusing `useCreateFarm`/`useUpdateFarm`/`useDeleteFarm`). Per the slice's design, writes use **wholesale invalidation of the farm summary**, matching the page's prior refetch-everything behavior.
- `useUpdateFarm` now also invalidates `summary(id)` so the irrigation water-level bump and farm edits refresh the dashboard.
- Added `useFarmFertilizerPlans(farmId)` and a `plans` key to the factory (plans were previously loaded inside `loadDashboardData`).
- Removed `loadDashboardData`, its triggering `useEffect`, and the all-farms-loading `useEffect`. No manual reload calls remain — adding/editing/deleting any log updates the dashboard via cache invalidation.
- Normalized `FarmModal` snake_case location fields to camelCase before saving, fixing the same silent-drop bug #173 fixed on the list page.

## Acceptance criteria

- [x] `useDashboardSummary(farmId)` backs the page; no direct `getDashboardSummary`
- [x] Farm switcher reads from shared `useFarms()`
- [x] All 8 record types have add/update/delete mutation hooks invalidating `summary(farmId)` + relevant `records`/`labTests` keys
- [x] Writes update the dashboard with no manual reload call
- [x] `loadDashboardData` and its triggering `useEffect`s removed
- [x] No new render-reactive `useEffect` introduced for toasts/redirects
- [x] `bun run typecheck`, `bun run lint` (0 errors), and `bun run build` pass

## Notes

The only direct `SupabaseService` call left on the page is the one-shot `getDailyNoteByDate` read on modal open (not a journal write). Per-record granular queries are intentionally out of scope for this slice.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the farm detail dashboard and all journal writes to `@tanstack/react-query`, replacing manual reloads with cache-driven updates. Added safer farm ID handling and tighter post-write invalidation to keep the dashboard, logs, and plans in sync.

- **Refactors**
  - Added `useDashboardSummary(farmId)` as the page’s source of truth; all writes invalidate `farmKeys.summary(farmId)`.
  - Introduced `useFarmLogMutations` with add/update/delete hooks for 8 record types; activity invalidates `summary` + `records`, lab tests invalidate `summary` + `labTests`.
  - Switched farm switcher to `useFarms()`; added `useFarmFertilizerPlans(farmId)` and `farmKeys.plans`.
  - Routed farm create/update/delete through mutations; `useUpdateFarm` also invalidates `summary(id)`. Water calculation now invalidates `summary` + `detail` + `list`; tasks card invalidates `summary`.
  - Removed `loadDashboardData` and effects; date-group deletes run concurrently, with each mutation invalidating the right `farmKeys.*`.
  - Code quality: immutable sorting (`toSorted`), precompiled/escaped regex in search and helpers, analytics page uses a reducer, fertigation unit validation via `isValidFertigationUnit`, data-driven expense–recommendation matching, and removed `@tanstack/react-query-devtools`.

- **Bug Fixes**
  - Normalized `FarmModal` location fields (snake_case -> camelCase) before save.
  - Invalidated `farmKeys.records(farmId)` after the daily-note/photo-only path to prevent stale logs.
  - Strictly parse `farmId` and use a disabled query key for non-finite IDs; invalid IDs block writes with a toast to avoid targeting the wrong farm.
  - Show error toasts when record or date-group deletions fail.

<sup>Written for commit 5241e92fdd938b8522a736ab672877c46910f7ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ashish921998/Vinesight/pull/188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Farm details now refresh automatically after journal edits, additions, and deletions—updating summaries, record lists, and fertilizer plan info in sync.
  * Unified journal/log update handling keeps related screens consistent, including daily notes and photos.
* **Bug Fixes**
  * Improved farm create/edit saving so location fields are stored consistently.
  * Invalid farm IDs are handled safely to prevent updates from targeting the wrong farm.
* **Performance / Improvements**
  * Faster, more robust log searching (regex-based matching and improved filtering).
* **Chores**
  * React Query devtools removed from development dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->