### PR TITLE
fix(team): claim-invite gate on password presence, not last_sign_in_at

### DIFF
--- a/src/app/api/organizations/claim-invite/route.ts
+++ b/src/app/api/organizations/claim-invite/route.ts
@@ -80,16 +80,22 @@ export async function POST(request: NextRequest) {
 
     if (userId) {
       // Account-takeover guard. This endpoint sets a password from a logged-out, link-only
-      // request, so it must only ever touch an UNCLAIMED invited account: created by
-      // inviteUserByEmail (confirmed, passwordless) and never signed in. If the email already
-      // belongs to a real account that has signed in, overwriting its password would be
-      // account takeover — refuse and route them to sign in instead.
-      const { data: existing, error: getUserError } = await admin.auth.admin.getUserById(userId)
-      if (getUserError || !existing?.user) {
-        console.error('Error loading invitee during claim:', getUserError)
+      // request, so it must only ever touch a PASSWORDLESS account — an unclaimed invite stub
+      // created by inviteUserByEmail. If the email already has a real password, overwriting it
+      // would be account takeover, so refuse and route them to sign in.
+      //
+      // We gate on the actual credential (encrypted_password), NOT last_sign_in_at: opening the
+      // Supabase invite email signs the user in without setting a password, so last_sign_in_at
+      // would falsely block legitimately-passwordless invitees who clicked the email.
+      const { data: hasPassword, error: pwError } = await admin.rpc(
+        'claim_invite_account_has_password',
+        { p_user_id: userId }
+      )
+      if (pwError) {
+        console.error('Error checking credential during claim:', pwError)
         return NextResponse.json({ error: 'Failed to verify invitee' }, { status: 500 })
       }
-      if (existing.user.last_sign_in_at) {
+      if (hasPassword) {
         return NextResponse.json(
           { error: 'This email already has an account. Please sign in to accept the invite.' },
           { status: 409 }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -2585,6 +2585,10 @@ export type Database = {
         }
         Returns: undefined
       }
+      claim_invite_account_has_password: {
+        Args: { p_user_id: string }
+        Returns: boolean
+      }
       decay_context_relevance: {
         Args: Record<PropertyKey, never>
         Returns: undefined

--- a/supabase/migrations/202606300001_claim_invite_password_gate.sql
+++ b/supabase/migrations/202606300001_claim_invite_password_gate.sql
@@ -1,0 +1,28 @@
+-- The claim-invite endpoint (logged-out, link-only) sets a password on an invited account.
+-- It must only ever touch an UNCLAIMED, passwordless invitee — never overwrite a real
+-- credential (that would be account takeover via mere link possession).
+--
+-- `last_sign_in_at` was the wrong signal for "has a usable credential": opening the Supabase
+-- invite *email* magic link signs the user in (sets last_sign_in_at) WITHOUT setting a
+-- password, so the old gate stranded legitimately-passwordless invitees who had clicked the
+-- email — they could neither claim (blocked) nor sign in (no password). The correct signal is
+-- whether the account actually has an encrypted_password.
+--
+-- auth.users is not exposed via PostgREST, so expose a minimal SECURITY DEFINER reader that
+-- returns only a boolean and is callable only by the service role (used by the server-side
+-- claim-invite route).
+create or replace function public.claim_invite_account_has_password(p_user_id uuid)
+returns boolean
+language sql
+security definer
+set search_path = ''
+as $$
+  select coalesce(u.encrypted_password, '') <> ''
+  from auth.users u
+  where u.id = p_user_id;
+$$;
+
+revoke all on function public.claim_invite_account_has_password(uuid) from public;
+revoke all on function public.claim_invite_account_has_password(uuid) from anon;
+revoke all on function public.claim_invite_account_has_password(uuid) from authenticated;
+grant execute on function public.claim_invite_account_has_password(uuid) to service_role;

--- a/supabase/supabase-schema.sql
+++ b/supabase/supabase-schema.sql
@@ -1783,3 +1783,22 @@ INSERT INTO farms (name, region, area, crop, crop_variety, planting_date, vine_s
 ('Pune Valley Farm', 'Pune, Maharashtra', 1.8, 'Grapes', 'Flame Seedless', '2019-11-20', 2.5, 8.0, auth.uid()),
 ('Sangli Export Vineyard', 'Sangli, Maharashtra', 4.2, 'Grapes', 'Red Globe', '2018-12-10', 3.5, 10.0, auth.uid());
 */
+
+-- Credential-presence reader for the claim-invite gate (see migration
+-- 202606300001_claim_invite_password_gate.sql). SECURITY DEFINER so the service role can read
+-- auth.users.encrypted_password without exposing the auth schema; returns only a boolean.
+create or replace function public.claim_invite_account_has_password(p_user_id uuid)
+returns boolean
+language sql
+security definer
+set search_path = ''
+as $$
+  select coalesce(u.encrypted_password, '') <> ''
+  from auth.users u
+  where u.id = p_user_id;
+$$;
+
+revoke all on function public.claim_invite_account_has_password(uuid) from public;
+revoke all on function public.claim_invite_account_has_password(uuid) from anon;
+revoke all on function public.claim_invite_account_has_password(uuid) from authenticated;
+grant execute on function public.claim_invite_account_has_password(uuid) to service_role;


### PR DESCRIPTION
## Bug

Invited agronomists (Pratik + 2 others on Fratelli Fruits FPC) hit **"This email already has an account. Please sign in to accept the invite."** on the shared-link claim form and are stranded — they have **no password** but can't claim either.

## Root cause

The takeover guard in `claim-invite` keyed off `last_sign_in_at`. But opening the original Supabase **invite email** magic link signs the user in (sets `last_sign_in_at`) **without** setting a password. So a legitimately-passwordless invite stub looked "already has an account" → blocked from claiming, and with no password they can't sign in, and the reset email rides the throttled mailer.

Verified on prod: of the 3 currently-blocked invitees, **0 have a password** — the gate is a 100% false positive for them.

## Fix

Gate on the **actual credential** (`auth.users.encrypted_password`), not `last_sign_in_at`:

- New `SECURITY DEFINER` reader `claim_invite_account_has_password(uuid)` (migration `202606300001`), granted to `service_role` only — `auth.users` isn't exposed via PostgREST, so this returns just a boolean.
- Route blocks only when a real password exists (takeover protection intact); passwordless invite stubs claim normally. Drops the now-unused `getUserById` call.

## Deploy order (important)

1. **Apply migration `202606300001` to prod first** (additive; old code doesn't call the function, so it's a no-op until this deploys).
2. Merge → Vercel prod deploy → blocked invitees can claim immediately.

`tsc` ✅ · `eslint` ✅. Schema snapshot + generated types updated to match.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the claim-invite gate to check for a real password instead of `last_sign_in_at`, so passwordless invitees can claim while takeover protection stays intact.

- **Bug Fixes**
  - Gate on `auth.users.encrypted_password` via new RPC `public.claim_invite_account_has_password(uuid)` (SECURITY DEFINER, `service_role` only).
  - Stops false positives where the Supabase invite email sets `last_sign_in_at` without a password; returns 409 only if a real password exists. Also removes the `getUserById` call.

- **Migration**
  - Apply migration `202606300001` first (adds the RPC), then deploy the app.

<sup>Written for commit 29b98f84f48f740e0d3abff066d25c4cd98f4002. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ashish921998/Vinesight/pull/193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened invite claiming checks so existing accounts with a password can no longer be claimed inappropriately.
  * Improved error handling during invite verification, returning a clearer failure when the account check cannot be completed.

* **New Features**
  * Added a secure backend check to verify whether an invited email already belongs to a password-protected account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->