### PR TITLE
fix(team): claim-invite fails closed when credential can't be verified

### DIFF
--- a/src/app/api/organizations/claim-invite/route.ts
+++ b/src/app/api/organizations/claim-invite/route.ts
@@ -91,8 +91,12 @@ export async function POST(request: NextRequest) {
         'claim_invite_account_has_password',
         { p_user_id: userId }
       )
-      if (pwError) {
-        console.error('Error checking credential during claim:', pwError)
+      // Fail closed: the function returns NULL when no auth.users row matches (e.g. an orphaned
+      // profile id). NULL means "could not confirm this account is passwordless", which must NOT
+      // be treated as "no password → safe to set one". Refuse instead of proceeding on an
+      // unverified id.
+      if (pwError || hasPassword === null) {
+        console.error('Error checking credential during claim:', pwError, 'invite', invite.id)
         return NextResponse.json({ error: 'Failed to verify invitee' }, { status: 500 })
       }
       if (hasPassword) {


### PR DESCRIPTION
Follow-up hardening after #193 (review comment on the password-gate function).

`claim_invite_account_has_password(uuid)` returns **NULL** when no `auth.users` row matches the resolved id (e.g. an orphaned `profiles` row). The route treated NULL as falsy, so the takeover gate fell through *as if the account were passwordless* and let the claim proceed on an unverified id.

An auth gate must **fail closed**: treat NULL like the error path and return 500 instead of proceeding.

**Severity: low / not currently reachable.** `userId` comes from `findAuthUserIdByEmail` — the `listUsers` path only returns real users, and the `profiles` path needs an orphaned profile, of which there are currently 0. There's no enforced FK guaranteeing that stays true (and the create-path `deleteUser` rollback is a latent way to orphan a profile), so this removes the fail-open seam rather than relying on data hygiene.

One-line change; `tsc` ✅ `eslint` ✅.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes claim-invite to fail closed when the password check can’t be confirmed, preventing claims on unverified users. Treats NULL from `claim_invite_account_has_password` as an error, returns 500, and adds `invite.id` to the error log.

<sup>Written for commit 33db68c061143f2bdcda8089f6b60f94e2aefa32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ashish921998/Vinesight/pull/194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved invite-claim handling so requests are rejected when account-password status cannot be determined.
  * Prevented ambiguous cases from being treated as passwordless, reducing the chance of incorrect account access behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->