### PR TITLE
feat(plans): Phase W — plan-item product_id FK + first-class quantity_basis

### DIFF
--- a/src/lib/fertilizer-plan-service.ts
+++ b/src/lib/fertilizer-plan-service.ts
@@ -26,6 +26,10 @@ export interface FertilizerPlanItem {
   notes: string | null
   sort_order: number
   created_at: string
+  /** Master-catalog product id (Phase W). Null for custom/legacy items — fertilizer_name is the fallback identity. */
+  product_id: number | null
+  /** total | per_acre | per_liter_water (Phase W). Null = infer from the unit string, as before. */
+  quantity_basis: string | null
 }
 
 export interface FertilizerPlanWithItems extends FertilizerPlan {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -2494,6 +2494,8 @@ export type Database = {
           notes: string | null
           sort_order: number
           created_at: string
+          product_id: number | null
+          quantity_basis: string | null
         }
         Insert: {
           id?: string
@@ -2507,6 +2509,8 @@ export type Database = {
           notes?: string | null
           sort_order?: number
           created_at?: string
+          product_id?: number | null
+          quantity_basis?: string | null
         }
         Update: {
           id?: string
@@ -2520,6 +2524,8 @@ export type Database = {
           notes?: string | null
           sort_order?: number
           created_at?: string
+          product_id?: number | null
+          quantity_basis?: string | null
         }
         Relationships: [
           {
@@ -2527,6 +2533,13 @@ export type Database = {
             columns: ['plan_id']
             isOneToOne: false
             referencedRelation: 'fertilizer_plans'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'fertilizer_plan_items_product_id_fkey'
+            columns: ['product_id']
+            isOneToOne: false
+            referencedRelation: 'chemical_products'
             referencedColumns: ['id']
           }
         ]

--- a/supabase/migrations/202607060001_plan_item_identity_and_basis.sql
+++ b/supabase/migrations/202607060001_plan_item_identity_and_basis.sql
@@ -1,0 +1,205 @@
+-- Phase W (RN issue #199, units plan §6): plan-item identity + first-class basis.
+--
+-- Until now plan items carried product identity only as the canonical catalog
+-- name stored verbatim (P2 "string-level convergence") and quantity basis only
+-- inside the unit string. This migration upgrades both to first-class columns:
+--
+--   product_id     nullable FK -> chemical_products. Plan authoring stamps the
+--                  picked catalog product; reports key plan-compliance on
+--                  identity instead of name matching. ON DELETE SET NULL: a
+--                  prescription outlives catalog edits — the name column
+--                  remains as the fallback the P2 contract already relies on.
+--
+--   quantity_basis 'total' | 'per_acre' | 'per_liter_water'. Null on legacy
+--                  and web-authored rows — readers fall back to inferring the
+--                  basis from the unit string exactly as they do today (the
+--                  quantity kernel gives unit-carried basis priority anyway).
+--                  Deliberately NOT derived in SQL: the app-side quantity
+--                  kernel is the only sanctioned unit interpreter, and a
+--                  second parser in the database would reintroduce the
+--                  drifting-parsers problem this plan exists to kill.
+--
+--   unit CHECK    both apps' pickers emit a closed set (web PLAN_ITEM_UNIT_OPTIONS
+--                  and RN MEASURE_TO_UNIT are the identical five: kg/acre,
+--                  g/acre, L/acre, ml/acre, ppm). The constraint admits that
+--                  set plus bare-mass/volume spellings, gm aliases, the
+--                  legacy column default 'kg', and per-liter concentration
+--                  spellings — everything kernel-parseable that either app
+--                  can write. Case-insensitive so 'L/acre' and 'l/acre' both
+--                  pass. All 7 existing rows (kg/acre, L/acre, ppm) satisfy it.
+--
+-- The send/update RPCs need no signature change — they pass p_items through
+-- to the shared validator + inserter, which are extended below. CREATE OR
+-- REPLACE preserves the existing revokes/grants on both.
+
+-- ── 1. product_id ───────────────────────────────────────────────────────────
+
+alter table public.fertilizer_plan_items
+  add column if not exists product_id bigint references public.chemical_products(id) on delete set null;
+
+comment on column public.fertilizer_plan_items.product_id is
+  'Master-catalog product this prescription refers to (chemical_products.id). Null for custom/legacy items — fertilizer_name remains the fallback identity.';
+
+create index if not exists idx_fertilizer_plan_items_product_id
+  on public.fertilizer_plan_items(product_id)
+  where product_id is not null;
+
+-- ── 2. quantity_basis ───────────────────────────────────────────────────────
+
+alter table public.fertilizer_plan_items
+  add column if not exists quantity_basis text;
+
+comment on column public.fertilizer_plan_items.quantity_basis is
+  'How the quantity relates to the plot: total | per_acre | per_liter_water. Null = legacy/web row; readers infer the basis from the unit string as before.';
+
+do $do$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'fertilizer_plan_items_quantity_basis_check'
+  ) then
+    alter table public.fertilizer_plan_items
+      add constraint fertilizer_plan_items_quantity_basis_check
+      check (quantity_basis is null or quantity_basis in ('total', 'per_acre', 'per_liter_water'));
+  end if;
+end
+$do$;
+
+-- ── 3. unit CHECK constraint ────────────────────────────────────────────────
+
+do $do$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'fertilizer_plan_items_unit_check'
+  ) then
+    alter table public.fertilizer_plan_items
+      add constraint fertilizer_plan_items_unit_check
+      check (
+        unit is null
+        or lower(unit) = any (array[
+          -- bare mass / volume (column default 'kg' + kernel display scales)
+          'kg', 'g', 'gm', 'l', 'ml',
+          -- per-acre rates (both apps' pickers)
+          'kg/acre', 'g/acre', 'gm/acre', 'l/acre', 'ml/acre',
+          -- per-liter-water concentrations
+          'g/l', 'gm/l', 'ml/l', 'ppm'
+        ])
+      );
+  end if;
+end
+$do$;
+
+-- ── 4. Extend the shared validator ──────────────────────────────────────────
+-- Same signature (jsonb), so existing grants/revokes are preserved and the
+-- send/update RPCs pick this up without changes.
+
+create or replace function public.validate_fertilizer_plan_items(p_items jsonb)
+returns void
+language plpgsql
+immutable
+as $$
+declare
+  v_item jsonb;
+  v_qty numeric;
+  v_freq numeric;
+  v_basis text;
+begin
+  if p_items is null or jsonb_typeof(p_items) <> 'array' or jsonb_array_length(p_items) = 0 then
+    raise exception 'A plan must have at least one fertilizer item';
+  end if;
+
+  for v_item in select * from jsonb_array_elements(p_items)
+  loop
+    if coalesce(btrim(v_item->>'fertilizer_name'), '') = '' then
+      raise exception 'Every fertilizer item needs a name';
+    end if;
+
+    begin
+      v_qty := (v_item->>'quantity')::numeric;
+    exception when others then
+      raise exception 'Invalid quantity for "%"', v_item->>'fertilizer_name';
+    end;
+    if v_qty is null or v_qty <= 0 then
+      raise exception 'Quantity for "%" must be greater than zero', v_item->>'fertilizer_name';
+    end if;
+
+    if (v_item ? 'application_frequency')
+       and coalesce(btrim(v_item->>'application_frequency'), '') <> '' then
+      begin
+        v_freq := (v_item->>'application_frequency')::numeric;
+      exception when others then
+        raise exception 'Invalid frequency for "%"', v_item->>'fertilizer_name';
+      end;
+      if v_freq is null or v_freq < 1 or v_freq <> floor(v_freq) then
+        raise exception 'Frequency for "%" must be a whole number >= 1', v_item->>'fertilizer_name';
+      end if;
+    end if;
+
+    -- product_id: when present it must be a JSON number (the catalog id).
+    -- Existence against chemical_products is checked at insert, not here —
+    -- this validator is IMMUTABLE and must not read tables.
+    if (v_item ? 'product_id')
+       and jsonb_typeof(v_item->'product_id') not in ('number', 'null') then
+      raise exception 'Invalid product_id for "%"', v_item->>'fertilizer_name';
+    end if;
+
+    -- quantity_basis: when present and non-empty it must be a known basis.
+    if (v_item ? 'quantity_basis')
+       and coalesce(btrim(v_item->>'quantity_basis'), '') <> '' then
+      v_basis := btrim(v_item->>'quantity_basis');
+      if v_basis not in ('total', 'per_acre', 'per_liter_water') then
+        raise exception 'Invalid quantity_basis "%" for "%"', v_basis, v_item->>'fertilizer_name';
+      end if;
+    end if;
+  end loop;
+end;
+$$;
+
+-- ── 5. Extend the shared inserter ───────────────────────────────────────────
+
+create or replace function public.insert_fertilizer_plan_items(p_plan_id uuid, p_items jsonb)
+returns void
+language plpgsql
+as $$
+declare
+  v_item jsonb;
+  v_idx int := 0;
+  v_product_id bigint;
+begin
+  for v_item in select * from jsonb_array_elements(coalesce(p_items, '[]'::jsonb))
+  loop
+    -- Resolve product_id defensively: accept only a JSON number that names an
+    -- existing catalog product. A stale pick (product removed between select
+    -- and send) degrades to null — the plan still lands with the name as
+    -- fallback identity — instead of failing the consultant's whole send with
+    -- an FK error.
+    v_product_id := null;
+    if jsonb_typeof(v_item->'product_id') = 'number' then
+      select id into v_product_id
+      from public.chemical_products
+      where id = (v_item->>'product_id')::bigint;
+    end if;
+
+    insert into public.fertilizer_plan_items (
+      plan_id, application_date, fertilizer_name, quantity, unit,
+      application_method, application_frequency, notes, sort_order,
+      product_id, quantity_basis
+    )
+    values (
+      p_plan_id,
+      nullif(btrim(v_item->>'application_date'), '')::date,
+      btrim(v_item->>'fertilizer_name'),
+      (v_item->>'quantity')::numeric,
+      coalesce(nullif(btrim(v_item->>'unit'), ''), 'kg/acre'),
+      nullif(btrim(v_item->>'application_method'), ''),
+      coalesce(nullif(btrim(v_item->>'application_frequency'), '')::int, 1),
+      nullif(btrim(v_item->>'notes'), ''),
+      v_idx,
+      v_product_id,
+      nullif(btrim(v_item->>'quantity_basis'), '')
+    );
+    v_idx := v_idx + 1;
+  end loop;
+end;
+$$;


### PR DESCRIPTION
Web-side half of [vinesight-rn#199](https://github.com/ashish921998/vinesight-rn/issues/199) (units plan §6, Phase W). This repo owns the shared schema (ADR-0002), so the migration lands here.

## Schema (migration `202607060001`, **already applied to the live DB** and recorded in `schema_migrations`)

- `fertilizer_plan_items.product_id bigint` — nullable FK → `chemical_products(id)` ON DELETE SET NULL, partial index. Plan items gain real catalog identity; `fertilizer_name` remains the fallback for custom/legacy items.
- `fertilizer_plan_items.quantity_basis text` — CHECK in (`total`, `per_acre`, `per_liter_water`), null = legacy/web row (readers infer from the unit string exactly as today).
- Unit CHECK constraint — case-insensitive closed set covering both apps' pickers (`kg/acre, g/acre, L/acre, ml/acre, ppm` — web `PLAN_ITEM_UNIT_OPTIONS` and RN `MEASURE_TO_UNIT` are the identical five) plus bare/legacy/concentration spellings. All 7 existing rows pass (verified live).
- `validate_fertilizer_plan_items` + `insert_fertilizer_plan_items` extended in place: same signatures, so `send_fertilizer_plan` / `update_fertilizer_plan` and their grants are untouched. Non-number `product_id` and unknown `quantity_basis` are rejected at the validation boundary; a stale-but-numeric product id degrades to null at insert (name fallback) rather than failing the whole send with an FK error.
- **No basis derivation in SQL** — deliberate. The RN quantity kernel is the only sanctioned unit interpreter; a second parser in the database would reintroduce the drifting-parsers problem the units plan exists to kill.

## Verification

Applied as one transaction after a full dry run in a rolled-back transaction against the live DB: migration DDL + validator accept/reject probes + inserter probes (catalog pick lands with `per_liter_water`; stale product id nulls out, row still inserts) + a zero-rows-violate-unit-check scan.

## App code

Hand-maintained `Database` types (`src/types/database.ts`) and the `FertilizerPlanItem` service interface gain the two fields. Web reads use `select('*')` + interface casts, so new nullable columns are inert; web writes are unchanged (rows land with null basis/product and remain fully valid). `bun run typecheck` clean.

The RN-side adoption (authoring stamps `product_id` + basis via the RPC, reports key compliance on identity, `per_liter_water` round-trips) ships separately in vinesight-rn.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add catalog identity and first-class quantity basis to fertilizer plan items to improve accuracy and future reporting. Keeps legacy behavior and web flows unchanged.

- **Migration**
  - Added `product_id bigint` FK to `chemical_products(id)` (ON DELETE SET NULL) and `quantity_basis text` with allowed values (`total`, `per_acre`, `per_liter_water`); null keeps legacy unit-based inference.
  - Enforced a case-insensitive unit CHECK for a closed set (`kg/acre`, `g/acre`, `L/acre`, `ml/acre`, `ppm`) plus legacy/bare spellings.
  - Extended `validate_fertilizer_plan_items` and `insert_fertilizer_plan_items`: rejects non-number `product_id`; resolves numeric ids against catalog at insert (stale ids become null, plan still inserts); validates `quantity_basis` only—no SQL derivation.
  - Updated TypeScript types and `FertilizerPlanItem` interface with `product_id` and `quantity_basis`; no RPC signature changes; web reads/writes continue to work with nulls.

<sup>Written for commit 623aa426c82988645c952e5f93ddbfd19a9eace5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ashish921998/Vinesight/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

